### PR TITLE
Add Dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/benefit-finder/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## PR Summary

This PR adds Dependabot configuration file to enable dependabot alerts and PRs.

## Related Github Issue

- fixes #[Implement Dependabot for V2 Repo#517](https://github.com/GSA/px-bears-drupal/issues/517)
