### PR TITLE
update json data file path passing

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
@@ -117,13 +117,13 @@ class LifeEventController {
     if ($life_event) {
       $field_name = '';
       if ($this->mode == "published") {
-        $field_name = 'field_json_data_file';
+        $field_name = 'field_json_data_file_path';
       }
       else if ($this->mode == "draft") {
-        $field_name = 'field_draft_json_data_file';
+        $field_name = 'field_draft_json_data_file_path';
       }
       $life_event->set($field_name, [
-        'target_id' => $file->id(),
+        'value' =>  $fileUrlString,
       ]);
       $life_event->save();
     }

--- a/usagov_benefit_finder/modules/usagov_benefit_finder_app/usagov_benefit_finder_page/usagov_benefit_finder_page.module
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_app/usagov_benefit_finder_page/usagov_benefit_finder_page.module
@@ -55,12 +55,8 @@ function usagov_benefit_finder_page_preprocess_page(&$variables) {
   $node = \Drupal::routeMatch()->getParameter('node');
   if ($node && $node->bundle() == "bears_life_event") {
     if (\Drupal::routeMatch()->getRouteName() == 'entity.node.canonical') {
-      $field_json_data_file = $node->get('field_json_data_file')->referencedEntities();
-      $uri = $field_json_data_file[0]->getFileUri();
-      $variables['json_data_file_path'] = \Drupal::service('file_url_generator')->generate($uri)->toString();
-      $field_draft_json_data_file = $node->get('field_draft_json_data_file')->referencedEntities();
-      $uri = $field_draft_json_data_file[0]->getFileUri();
-      $variables['draft_json_data_file_path'] = \Drupal::service('file_url_generator')->generate($uri)->toString();
+      $variables['json_data_file_path'] = $node->get('field_json_data_file_path')->value;
+      $variables['draft_json_data_file_path'] = $node->get('field_draft_json_data_file')->value;
     }
   }
 }


### PR DESCRIPTION
## PR Summary

This work updates json data file path passing method.
It uses text field to pass the json data file path.
For example, 
JSON data file path: /s3/files/benefit-finder/api/life-event/death.json
Draft JSON data file path: /s3/files/benefit-finder/api/draft/life-event/death.json