### PR TITLE
destructure import to const

### DIFF
--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/index.stories.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/index.stories.jsx
@@ -6,6 +6,7 @@ const { data } = JSON.parse(content)
 const { benefits } = data
 const b = [benefits[0], benefits[1]]
 const entryKey = Object.keys(b[0])
+const { resultsView } = en
 
 export default {
   component: BenefitAccordionGroup,
@@ -13,7 +14,7 @@ export default {
   args: {
     data: b,
     entryKey: entryKey[0],
-    ui: en.resultsView,
+    ui: resultsView,
   },
 }
 

--- a/benefit-finder/src/shared/components/Intro/index.stories.jsx
+++ b/benefit-finder/src/shared/components/Intro/index.stories.jsx
@@ -4,6 +4,7 @@ import * as en from '../../locales/en/en.json'
 
 const { data } = JSON.parse(content)
 const { lifeEventForm } = data
+const { intro } = en
 
 export default {
   component: Intro,
@@ -13,7 +14,7 @@ export default {
   tags: ['autodocs'],
   args: {
     data: lifeEventForm,
-    ui: en.intro,
+    ui: intro,
   },
 }
 

--- a/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/index.stories.jsx
+++ b/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/index.stories.jsx
@@ -2,6 +2,8 @@ import KeyElegibilityCrieriaList from './index.jsx'
 import content from '../../api/mock-data/current.js'
 import * as en from '../../locales/en/en.json'
 
+const { resultsView } = en
+
 const { data } = JSON.parse(content)
 const { benefits } = data
 const b = benefits[0].benefit.eligibility
@@ -13,7 +15,7 @@ export default {
   args: {
     data: b,
     initialEligibilityLength,
-    ui: en.resultsView.benefitAccordion,
+    ui: resultsView.benefitAccordion,
   },
 }
 

--- a/benefit-finder/src/shared/components/NoticesList/index.stories.jsx
+++ b/benefit-finder/src/shared/components/NoticesList/index.stories.jsx
@@ -1,11 +1,13 @@
 import NoticesList from './index.jsx'
 import * as en from '../../locales/en/en.json'
 
+const { intro } = en
+
 export default {
   component: NoticesList,
   tags: ['autodocs'],
   args: {
-    data: en.intro.notices.list,
+    data: intro.notices.list,
   },
 }
 

--- a/benefit-finder/src/shared/components/ResultsView/index.stories.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.stories.jsx
@@ -1,11 +1,13 @@
 import ResultsView from './index.jsx'
 import * as en from '../../locales/en/en.json'
 
+const { resultsView } = en
+
 export default {
   component: ResultsView,
   tags: ['autodocs'],
   args: {
-    ui: en.resultsView,
+    ui: resultsView,
   },
 }
 

--- a/benefit-finder/src/shared/components/Select/index.stories.jsx
+++ b/benefit-finder/src/shared/components/Select/index.stories.jsx
@@ -1,6 +1,8 @@
 import Select from './index.jsx'
 import * as en from '../../locales/en/en.json'
 
+const { select } = en
+
 const selectOptions = [
   { value: 'value-1', label: 'Option 1' },
   { value: 'value-2', label: 'Option 2' },
@@ -11,7 +13,7 @@ export default {
   component: Select,
   tags: ['autodocs'],
   args: {
-    ui: en.select,
+    ui: select,
     options: selectOptions,
   },
 }

--- a/benefit-finder/src/shared/components/VerifySelectionsView/index.stories.jsx
+++ b/benefit-finder/src/shared/components/VerifySelectionsView/index.stories.jsx
@@ -1,11 +1,13 @@
 import VerifySelectionsView from './index.jsx'
 import * as en from '../../locales/en/en.json'
 
+const { verifySelectionsView } = en
+
 export default {
   component: VerifySelectionsView,
   tags: ['autodocs'],
   args: {
-    ui: en.verifySelectionsView,
+    ui: verifySelectionsView,
   },
 }
 


### PR DESCRIPTION
## PR Summary

cypress bundler didn't like the way we were importing locale json,

> ERROR in ./src/shared/components/BenefitAccordionGroup/index.stories.jsx 14:4-18
Should not import the named export 'resultsView' (imported as 'en') from default-exporting module (only default export is available soon)

This updates to de-structure the import and assign to a const before passing into the args

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [ ] pull local
- [ ] install nodes
- [ ]  navigate to benefit finder  and run 'npx cypress open' and then make a change a test e.g add a space in indexBenefitAccordionGroup.cy.jsx and save the changes, you should see that the wepack process completes without the reported error. 