### PR TITLE
594 benefit accordion group component tests

### DIFF
--- a/benefit-finder/cypress/e2e/death-of-a-loved-one/selected-criteria-eligibility-benefits.cy.js
+++ b/benefit-finder/cypress/e2e/death-of-a-loved-one/selected-criteria-eligibility-benefits.cy.js
@@ -42,13 +42,16 @@ describe('Validate correct eligibility benefits display based on selected criter
     const dateOfDeath = utils.getDateByOffset(-30)
     cy.enterDateOfDeath(dateOfDeath.month, dateOfDeath.day, dateOfDeath.year)
 
-    // Date of funeral - 15 days ago
-    const dateOfFuneral = utils.getDateByOffset(-15)
-    cy.enterDateOfFuneral(
-      dateOfFuneral.month,
-      dateOfFuneral.day,
-      dateOfFuneral.year
-    )
+    pageObjects
+      .benefitSectionFieldset()
+      .contains(
+        EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[1]
+          .section.fieldsets[2].fieldset.inputs[0].inputCriteria.label
+      )
+      .parent()
+      .find('.usa-radio__label')
+      .contains('Yes')
+      .click()
 
     pageObjects
       .benefitSectionFieldset()
@@ -70,23 +73,23 @@ describe('Validate correct eligibility benefits display based on selected criter
       .filter(':visible')
       .should(
         'contain',
-        EN_DOLO_MOCK_DATA.data.benefits[19].benefit.eligibility[0].label
+        EN_DOLO_MOCK_DATA.data.benefits[22].benefit.eligibility[0].label
       )
       .and(
         'contain',
-        EN_DOLO_MOCK_DATA.data.benefits[19].benefit.eligibility[1].label
+        EN_DOLO_MOCK_DATA.data.benefits[22].benefit.eligibility[1].label
       )
       .and(
         'contain',
-        EN_DOLO_MOCK_DATA.data.benefits[19].benefit.eligibility[2].label
+        EN_DOLO_MOCK_DATA.data.benefits[22].benefit.eligibility[2].label
       )
       .and(
         'contain',
-        EN_DOLO_MOCK_DATA.data.benefits[19].benefit.eligibility[3].label
+        EN_DOLO_MOCK_DATA.data.benefits[22].benefit.eligibility[3].label
       )
       .and(
         'contain',
-        EN_DOLO_MOCK_DATA.data.benefits[19].benefit.eligibility[4].label
+        EN_DOLO_MOCK_DATA.data.benefits[22].benefit.eligibility[4].label
       )
   })
 })

--- a/benefit-finder/src/shared/api/mock-data/current.json
+++ b/benefit-finder/src/shared/api/mock-data/current.json
@@ -5,12 +5,12 @@
       "timeEstimate": "2-5 minutes",
       "titlePrefix": "",
       "title": "Benefit finder: death of a loved one",
-      "summary": "<p><strong>Losing a loved one is hard.</strong> Finding help shouldn’t be.</p><p>Screen the federal benefits you may be eligible for.</p>",
+      "summary": "<p><strong>We are sorry for your loss. </strong>Losing a loved one is hard. Finding help shouldn’t be.&nbsp;</p>\r\n\r\n<p><strong>Answer a few questions </strong>and&nbsp;get a personal list of&nbsp;potential benefits.</p>\r\n",
       "relevantBenefits": [
         {
           "lifeEvent": {
             "title": "Benefit finder: retirement",
-            "body": "<p>Find out what financial, health care, and other benefits may be available as you enter this next phase of your life.</p>",
+            "body": "<p>Find out what financial, health care, and other benefits may be available during this time.</p>\r\n",
             "link": "/bears/life_event/retirement",
             "cta": "Call to action (retirement)"
           }
@@ -18,7 +18,7 @@
         {
           "lifeEvent": {
             "title": "Benefit finder: disability",
-            "body": "<p>Whether you are newly disabled or have a lifelong challenge, assistance may be available, including financial help.</p>",
+            "body": "<p>Whether you are newly disabled or have a lifelong challenge, assistance may be available, including financial help.</p>\r\n",
             "link": "/bears/life_event/disability",
             "cta": "Call to action (disability)"
           }
@@ -28,7 +28,7 @@
         {
           "section": {
             "heading": "About the applicant",
-            "description": "<p>About the person looking for benefits</p>",
+            "description": "<p>About the person looking for benefits</p>\r\n",
             "fieldsets": [
               {
                 "fieldset": {
@@ -238,7 +238,7 @@
         {
           "section": {
             "heading": "About the deceased",
-            "description": "<p>About the person who died</p>",
+            "description": "<p>About the person who died</p>\r\n",
             "fieldsets": [
               {
                 "fieldset": {
@@ -618,13 +618,63 @@
     "benefits": [
       {
         "benefit": {
+          "title": "Survivors pension for spouse",
+          "summary": "<p>Monthly payments to surviving spouses of wartime veterans with certain income and net worth limits.</p>\r\n",
+          "SourceLink": "https://www.va.gov/pension/survivors-pension/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: discharged under conditions other than dishonorable",
+              "acceptableValues": [
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is unmarried or widowed",
+              "acceptableValues": [
+                "Unmarried",
+                "Widowed"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse",
+              "acceptableValues": [
+                "Spouse"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
           "title": "Burial benefits",
-          "summary": "<p>Burial and transport assistance for the deceased, and travel support for the spouse, children, and immediate family members of the service member.</p>",
+          "summary": "<p>Burial and transport assistance for the deceased, and travel support for the spouse, children, and immediate family members of the service member.</p>\r\n",
           "SourceLink": "https://www.militaryonesource.mil/benefits/funeral-and-burial-benefits-for-service-members/",
           "SourceIsEnglish": "TRUE",
           "agency": {
             "title": "Department of Defense (DOD)",
-            "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
+            "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>\r\n",
             "lede": ""
           },
           "tags": [
@@ -670,13 +720,1005 @@
       },
       {
         "benefit": {
+          "title": "Presidential Memorial Certificate",
+          "summary": "<p>An engraved Presidential Memorial Certificate (PMC) signed by the current president honoring the military service of a veteran or reservist.</p>\r\n",
+          "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/presidential-memorial-certificates/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/traveling to VA care",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors benefits for spouse with disabilities",
+          "summary": "<p>Benefits for surviving spouses and certain divorced spouses with disabilities. Eligible survivors must have a disability that prevents them from working for more than a year. You only need one application to apply for all SSA benefits.</p>\r\n",
+          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h2",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": "Social Security Administration (SSA)",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_paid_into_SS",
+              "label": "The deceased worked and paid Social Security taxes",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are over 50 years",
+              "acceptableValues": [
+                ">=50years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is widowed or divorced",
+              "acceptableValues": [
+                "Widowed",
+                "Divorced"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a US citizen or eligible non-citizen",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse",
+              "acceptableValues": [
+                "Spouse"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Veterans burial allowance",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Assistance with burial, funeral, and transportation costs of a deceased veteran.</p>\r\n",
+          "SourceLink": "https://www.va.gov/burials-memorials/veterans-burial-allowance/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_date_of_death",
+              "label": "The deceased died within the last two years",
+              "acceptableValues": [
+                "<2years"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: discharged under conditions other than dishonorable",
+              "acceptableValues": [
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation",
+              "acceptableValues": [
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/traveling to VA care",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_paid_funeral_expenses",
+              "label": "You paid for funeral or burial expenses",
+              "acceptableValues": [
+                "Yes"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "COVID-19 funeral assistance",
+          "summary": "<p>Financial assistance for burial and funeral costs for someone who died of COVID-19. To be eligible, you have not been reimbursed from an organization or agency.</p>\r\n",
+          "SourceLink": "https://www.fema.gov/disasters/coronavirus/economic/funeral-assistance",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": " Federal Emergency Management Agency (FEMA)",
+            "summary": "<p>Federal Emergency Management Agency (FEMA) offers support to people during natural disasters and national emergencies, including housing and funeral assistance.</p>\r\n",
+            "lede": "<p>Federal Emergency Management Agency (FEMA) offers support to people during natural disasters and national emergencies, including housing and funeral assistance.</p>\r\n"
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_died_of_COVID",
+              "label": "The deceased's death was COVID-19 related",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_death_location_is_US",
+              "label": "The deceased died in the U.S.",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_date_of_death",
+              "label": "The deceased died after May 20th, 2020",
+              "acceptableValues": [
+                ">01-20-2020"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a U.S. citizen or eligible non-citizen",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_paid_funeral_expenses",
+              "label": "You paid for funeral or burial expenses and were not reimbursed",
+              "acceptableValues": [
+                "Yes"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Veterans headstone and grave marker",
+          "summary": "<p>A headstone, grave or niche marker, or medallion to honor a veteran, service member, or eligible family member.</p>\r\n",
+          "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/headstones-markers-medallions/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_grave_headstone",
+              "label": "The person is buried in a grave with a privately purchased headstone or an unmarked grave",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Dependency and Indemnity Compensation (DIC)",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Tax-free financial assistance to eligible dependents, spouses, or parents of service members and veterans.</p>\r\n",
+          "SourceLink": "https://www.va.gov/disability/dependency-indemnity-compensation/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member or discharged under conditions other than dishonorable",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, or died while receiving/eligible for VA compensation",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: child, parent, or spouse",
+              "acceptableValues": [
+                "Child",
+                "Parent",
+                "Spouse"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors pension for child",
+          "summary": "<p>Monthly payments to qualified unmarried dependent children of deceased wartime veterans.</p>\r\n",
+          "SourceLink": "https://www.va.gov/pension/survivors-pension/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "You served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "Your service status is: discharged under conditions other than dishonorable",
+              "acceptableValues": [
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are under 18 years",
+              "acceptableValues": [
+                "<18years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is unmarried",
+              "acceptableValues": [
+                "Unmarried"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: child",
+              "acceptableValues": [
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Annuity for certain military surviving spouses",
+          "summary": "<p>Financial support for surviving spouses of members of the uniformed services.</p>\r\n",
+          "SourceLink": "https://militarypay.defense.gov/Benefits/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Defense (DOD)",
+            "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_date_of_death",
+              "label": "Deceased died before 1978",
+              "acceptableValues": [
+                "<01-01-1978"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "You served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: retired from the service",
+              "acceptableValues": [
+                "Retired from the service"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse",
+              "acceptableValues": [
+                "Spouse"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Education benefits (GI Bill) for survivors",
+          "summary": "<p>VA education benefits or job training for dependents and survivors of a veteran. You must have a high school or GED diploma to be eligible.</p>\r\n",
+          "SourceLink": "https://www.va.gov/education/survivor-dependent-benefits/",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: Active-duty service member or discharged under conditions other than dishonorable",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty or died as a result of a service-related disability/illness",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse or child",
+              "acceptableValues": [
+                "Spouse",
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors pension for child with disabilities",
+          "summary": "<p>Monthly payments to qualified unmarried dependent children with disabilities of wartime veterans with certain income and net worth limits.</p>\r\n",
+          "SourceLink": "https://www.va.gov/pension/survivors-pension/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: discharged under conditions other than dishonorable",
+              "acceptableValues": [
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are under 18 years",
+              "acceptableValues": [
+                ">18years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is unmarried",
+              "acceptableValues": [
+                "Unmarried"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: child",
+              "acceptableValues": [
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Burial in VA national cemetery",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Burial in VA national cemeteries for eligible veterans, service members, and some family members.</p>\r\n",
+          "SourceLink": "https://www.va.gov/burials-memorials/eligibility/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/traveling to VA care",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivor benefit plan",
+          "summary": "<p>Offers up to 55% of a service member's retired pay for survivors of active duty service members and some retired and reserve members.</p>\r\n",
+          "SourceLink": "https://bja.ojp.gov/program/psob/benefits",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Defense (DOD)",
+            "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, retired from the service, or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Retired from the service",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty or died while on inactive-duty service training",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died while on inactive-duty service training"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse or child",
+              "acceptableValues": [
+                "Spouse",
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Public safety officers' Educational Assistance Program",
+          "summary": "<p>Financial assistance for higher education to spouses and children of police, fire, and emergency public safety officers killed in the line of duty.</p>\r\n",
+          "SourceLink": "https://psob.bja.ojp.gov/PSOB_Education2018.pdf",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Justice (DOJ)",
+            "summary": "<p>Offers financial and educational support to help families of fallen public safety officers.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_public_safety_officer",
+              "label": "The deceased was a public safety officer who died in the line of duty",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse or child",
+              "acceptableValues": [
+                "Spouse",
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors benefits for mothers/fathers with a child",
+          "summary": "<p>Social Security survivors benefits to the person providing care for the child of a deceased worker.</p>\r\n",
+          "SourceLink": "https://www.ssa.gov/forms/ssa-5.html",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Social Security Administration (SSA)",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_paid_into_SS",
+              "label": "The deceased worked and paid Social Security taxes",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is unmarried or widowed",
+              "acceptableValues": [
+                "Unmarried",
+                "Widowed"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a US citizen or eligible non-citizen",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_care_for_child",
+              "label": "You are caring for a child of someone who is retired, has a disability, or has died, and the child is disabled or under the age of 16",
+              "acceptableValues": [
+                "Yes"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Veterans medallions",
+          "summary": "<p>A headstone medallion, grave marker, and Presidential Memorial Certificate for eligible veterans buried in a private cemetery.</p>\r\n",
+          "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/headstones-markers-medallions/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or a member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_grave_headstone",
+              "label": "The person is buried in a grave with a privately purchased headstone or an unmarked grave",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Burial flag",
+          "summary": "<p>A United States flag for the coffin or urn in honor of the military service member.</p>\r\n",
+          "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/burial-flags/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Lump-sum death benefit",
+          "summary": "<p>Financial assistance of $255 to surviving spouses of a deceased person who qualified for Social Security benefits.</p>\r\n",
+          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h7",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": "Social Security Administration (SSA)",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_paid_into_SS",
+              "label": "The deceased worked and paid Social Security taxes",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_date_of_death",
+              "label": "The deceased died within the last two years",
+              "acceptableValues": [
+                "<2years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a U.S. citizen or eligible non-citizen",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse or child",
+              "acceptableValues": [
+                "Spouse",
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Life insurance for survivors of veterans",
+          "summary": "<p>Payment from a veteran's or service member's life insurance policy.</p>\r\n",
+          "SourceLink": "https://www.benefits.va.gov/INSURANCE/sglivgli.asp",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, retired from the service, or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Retired from the service",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Civilian Health and Medical Program of the VA (CHAMPVA)",
+          "summary": "<p>Health insurance for dependents and surviving spouses covering some health care services and supplies.</p>\r\n",
+          "SourceLink": "https://www.va.gov/health-care/family-caregiver-benefits/champva/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>\r\n",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member or discharged under conditions other than dishonorable",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty or died as a result of a service-related disability/illness",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is: unmarried or widowed",
+              "acceptableValues": [
+                "Unmarried",
+                "Widowed"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: child or spouse",
+              "acceptableValues": [
+                "Child",
+                "Spouse"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
           "title": "Death gratuity",
-          "summary": "<p>Tax free payment of $100,000 to eligible survivors of members of the Armed Forces who died while on active duty or while serving in certain reserve statuses.</p>",
+          "summary": "<p>Tax free payment of $100,000 to eligible survivors of members of the Armed Forces who died while on active duty or while serving in certain reserve statuses.</p>\r\n",
           "SourceLink": "https://militarypay.defense.gov/Benefits/Death-Gratuity/",
           "SourceIsEnglish": "TRUE",
           "agency": {
             "title": "Department of Defense (DOD)",
-            "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
+            "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>\r\n",
             "lede": ""
           },
           "tags": [
@@ -721,13 +1763,13 @@
       },
       {
         "benefit": {
-          "title": "Burial flag",
-          "summary": "<p>A United States flag for the coffin or urn in honor of the military service member.</p>",
-          "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/burial-flags/",
-          "SourceIsEnglish": "TRUE",
+          "title": "Survivors benefits for child",
+          "summary": "<p>Offers Social Security survivors benefits to a child, stepchild, grandchild, or adopted child of eligible workers.</p>\r\n",
+          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h4",
+          "SourceIsEnglish": "FALSE",
           "agency": {
-            "title": "Veterans Affairs Department (VA)",
-            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "title": "Social Security Administration (SSA)",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>\r\n",
             "lede": ""
           },
           "tags": [
@@ -735,163 +1777,10 @@
           ],
           "eligibility": [
             {
-              "criteriaKey": "deceased_served_in_active_military",
-              "label": "The deceased served in the active military",
+              "criteriaKey": "deceased_paid_into_SS",
+              "label": "The deceased worked and paid Social Security taxes",
               "acceptableValues": [
                 "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_service_status",
-              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves",
-              "acceptableValues": [
-                "Active-duty service member",
-                "Discharged under conditions other than dishonorable",
-                "Member of the National Guard/Reserves"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
-              "acceptableValues": [
-                "Spouse",
-                "Child",
-                "Parent",
-                "Other family member"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Annuity for certain military surviving spouses",
-          "summary": "<p>Financial support for surviving spouses of members of the uniformed services.</p>",
-          "SourceLink": "https://militarypay.defense.gov/Benefits/",
-          "SourceIsEnglish": "TRUE",
-          "agency": {
-            "title": "Department of Defense (DOD)",
-            "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "lifeEvents": [
-            "Death"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_date_of_death",
-              "label": "Deceased died before 1978",
-              "acceptableValues": [
-                "<01-01-1978"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_served_in_active_military",
-              "label": "You served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_service_status",
-              "label": "The service status of the deceased is: retired from the service",
-              "acceptableValues": [
-                "Retired from the service"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: spouse",
-              "acceptableValues": [
-                "Spouse"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Burial in VA national cemetery",
-          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Burial in VA national cemeteries for eligible veterans, service members, and some family members.</p>",
-          "SourceLink": "https://www.va.gov/burials-memorials/eligibility/",
-          "SourceIsEnglish": "TRUE",
-          "agency": {
-            "title": "Veterans Affairs Department (VA)",
-            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_served_in_active_military",
-              "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_service_status",
-              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves",
-              "acceptableValues": [
-                "Active-duty service member",
-                "Discharged under conditions other than dishonorable",
-                "Member of the National Guard/Reserves"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_military_death_circumstance",
-              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation",
-              "acceptableValues": [
-                "Died while on active duty",
-                "Died as a result of a service-related disability/illness",
-                "Died while receiving/traveling to VA care",
-                "Died while receiving/eligible for VA compensation"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Civilian Health and Medical Program of the VA (CHAMPVA) for child",
-          "summary": "<p>Health insurance for dependents and surviving spouses covering some health care services and supplies.</p>",
-          "SourceLink": "https://www.va.gov/health-care/family-caregiver-benefits/champva/",
-          "SourceIsEnglish": "TRUE",
-          "agency": {
-            "title": "Veterans Affairs Department (VA)",
-            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_served_in_active_military",
-              "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_service_status",
-              "label": "The service status of the deceased is: active-duty service member or discharged under conditions other than dishonorable",
-              "acceptableValues": [
-                "Active-duty service member",
-                "Discharged under conditions other than dishonorable"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_military_death_circumstance",
-              "label": "One of the following applies to the deceased: died while on active duty or died as a result of a service-related disability/illness",
-              "acceptableValues": [
-                "Died while on active duty",
-                "Died as a result of a service-related disability/illness"
               ]
             },
             {
@@ -903,58 +1792,9 @@
             },
             {
               "criteriaKey": "applicant_marital_status",
-              "label": "Your marital status is: unmarried ",
+              "label": "Your marital status is unmarried",
               "acceptableValues": [
                 "Unmarried"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: child",
-              "acceptableValues": [
-                "Child"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "COVID-19 funeral assistance",
-          "summary": "<p>Financial assistance for burial and funeral costs for someone who died of COVID-19. To be eligible, you were not reimbursed from an organization or agency.</p>",
-          "SourceLink": "https://www.fema.gov/disasters/coronavirus/economic/funeral-assistance",
-          "SourceIsEnglish": "FALSE",
-          "agency": {
-            "title": " Federal Emergency Management Agency (FEMA)",
-            "summary": "<p>Federal Emergency Management Agency (FEMA) offers support to people during natural disasters and national emergencies, including housing and funeral assistance.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "lifeEvents": [
-            "Death"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_died_of_COVID",
-              "label": "The deceased died due to COVID-19",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_death_location_is_US",
-              "label": "The deceased died in the U.S.",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_date_of_death",
-              "label": "The deceased died after May 20th, 2020",
-              "acceptableValues": [
-                ">01-20-2020"
               ]
             },
             {
@@ -965,244 +1805,9 @@
               ]
             },
             {
-              "criteriaKey": "applicant_paid_funeral_expenses",
-              "label": "You paid for funeral or burial expenses and were not reimbursed",
-              "acceptableValues": [
-                "Yes"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Dependency and Indemnity Compensation (DIC) for child",
-          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Tax-free financial assistance to surviving children or family members of service members and veterans.</p>",
-          "SourceLink": "https://www.va.gov/disability/dependency-indemnity-compensation/",
-          "SourceIsEnglish": "TRUE",
-          "agency": {
-            "title": "Veterans Affairs Department (VA)",
-            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_served_in_active_military",
-              "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_service_status",
-              "label": "The service status of the deceased is: active-duty service member or discharged under conditions other than dishonorable",
-              "acceptableValues": [
-                "Active-duty service member",
-                "Discharged under conditions other than dishonorable"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_military_death_circumstance",
-              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, or died while receiving/eligible for VA compensation",
-              "acceptableValues": [
-                "Died while on active duty",
-                "Died as a result of a service-related disability/illness",
-                "Died while receiving/eligible for VA compensation"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_date_of_birth",
-              "label": "You are under 18 years",
-              "acceptableValues": [
-                "<18years"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_marital_status",
-              "label": "Your marital status is: unmarried",
-              "acceptableValues": [
-                "Unmarried"
-              ]
-            },
-            {
               "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: child",
+              "label": "Applicant's relationship to the deceased is: child",
               "acceptableValues": [
-                "Child"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Dependency and Indemnity Compensation (DIC) for parent",
-          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Tax-free financial assistance to surviving parents or family members of service members and veterans.</p>",
-          "SourceLink": "https://www.va.gov/disability/dependency-indemnity-compensation/",
-          "SourceIsEnglish": "TRUE",
-          "agency": {
-            "title": "Veterans Affairs Department (VA)",
-            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_served_in_active_military",
-              "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_service_status",
-              "label": "The service status of the deceased is: active-duty service member or discharged under conditions other than dishonorable",
-              "acceptableValues": [
-                "Active-duty service member",
-                "Discharged under conditions other than dishonorable"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_military_death_circumstance",
-              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, or died while receiving/eligible for VA compensation",
-              "acceptableValues": [
-                "Died while on active duty",
-                "Died as a result of a service-related disability/illness",
-                "Died while receiving/eligible for VA compensation"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_income",
-              "label": "You have limited income and resources",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: parent",
-              "acceptableValues": [
-                "Parent"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Dependency and Indemnity Compensation (DIC) for spouse",
-          "summary": "<p>Tax-free financial assistance to surviving spouses or family members of service members or veterans.</p>",
-          "SourceLink": "https://www.va.gov/disability/dependency-indemnity-compensation/",
-          "SourceIsEnglish": "TRUE",
-          "agency": {
-            "title": "Veterans Affairs Department (VA)",
-            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "lifeEvents": [
-            "Death"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_served_in_active_military",
-              "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_service_status",
-              "label": "The service status of the deceased is: active-duty service member or discharged under conditions other than dishonorable",
-              "acceptableValues": [
-                "Active-duty service member",
-                "Discharged under conditions other than dishonorable"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_military_death_circumstance",
-              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, or died while receiving/eligible for VA compensation",
-              "acceptableValues": [
-                "Died while on active duty",
-                "Died as a result of a service-related disability/illness",
-                "Died while receiving/eligible for VA compensation"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_marital_status",
-              "label": "Marital status: unmarried or widowed",
-              "acceptableValues": [
-                "Unmarried",
-                "Widowed"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Applicant's relationship to the deceased: spouse",
-              "acceptableValues": [
-                "Spouse"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Education benefits (GI Bill) for survivors",
-          "summary": "<p>VA education benefits or job training for dependents and survivors of a veteran.</p>",
-          "SourceLink": "https://www.va.gov/education/survivor-dependent-benefits/",
-          "SourceIsEnglish": "FALSE",
-          "agency": {
-            "title": "Veterans Affairs Department (VA)",
-            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_served_in_active_military",
-              "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_service_status",
-              "label": "The service status of the deceased is: Active-duty service member or discharged under conditions other than dishonorable",
-              "acceptableValues": [
-                "Active-duty service member",
-                "Discharged under conditions other than dishonorable"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_military_death_circumstance",
-              "label": "One of the following applies to the deceased: died while on active duty or died as a result of a service-related disability/illness",
-              "acceptableValues": [
-                "Died while on active duty",
-                "Died as a result of a service-related disability/illness"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_high-school_diploma",
-              "label": "You have a high school diploma or GED certificate",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: spouse or child",
-              "acceptableValues": [
-                "Spouse",
                 "Child"
               ]
             }
@@ -1212,13 +1817,13 @@
       {
         "benefit": {
           "title": "Financial Assistance and Social Services (FASS) for deceased",
-          "summary": "<p>Assistance with burial expenses of deceased indigent Indians who do not have resources for funeral expenses.</p>",
+          "summary": "<p>Assistance with burial expenses of deceased American Indians who do not have resources for funeral expenses or with certain income and net worth limits.</p>\r\n",
           "SourceLink": "https://www.bia.gov/bia/ois/dhs/financial-assistance",
           "SourceIsEnglish": "FALSE",
           "agency": {
             "title": "Department of Interior (DOI) - Indian Affairs",
-            "summary": "<p>The Bureau of Indian Affairs enhances the quality of life and protects and improves the trust assets of American Indians, Indian tribes, and Alaska Natives.</p>",
-            "lede": "<p>The Bureau of Indian Affairs enhances the quality of life and protects and improves the trust assets of American Indians, Indian tribes, and Alaska Natives.</p>"
+            "summary": "<p>The Bureau of Indian Affairs enhances the quality of life and protects and improves the trust assets of American Indians, Indian tribes, and Alaska Natives.</p>\r\n",
+            "lede": "<p>The Bureau of Indian Affairs enhances the quality of life and protects and improves the trust assets of American Indians, Indian tribes, and Alaska Natives.</p>\r\n"
           },
           "tags": [
             "Death of a loved one"
@@ -1233,12 +1838,40 @@
               "acceptableValues": [
                 "Yes"
               ]
-            },
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Coal mine workers' compensation (black lung benefits) for surviving spouse",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Compensation to surviving spouses of coal minerstotally disabled by or whose deaths are attributable to pneumoconiosis.</p>\r\n",
+          "SourceLink": "https://www.dol.gov/agencies/owcp/dcmwc/filing_guide_survivor",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Labor (DOL)",
+            "summary": "<p>Promotes and improves the welfare, working conditions, opportunities, benefits and rights of wage earners, job seekers, and retirees of the United States.</p>\r\n",
+            "lede": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Promotes and improves the welfare, working conditions, opportunities, benefits and rights of wage earners, job seekers, and retirees of the United States.</p>\r\n"
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
+          ],
+          "eligibility": [
             {
-              "criteriaKey": "applicant_income",
-              "label": "You have limited income and resources",
+              "criteriaKey": "deceased_miner",
+              "label": "The deceased worked in the coal mines and their death was due to black lung disease (pneumoconiosis)",
               "acceptableValues": [
                 "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse",
+              "acceptableValues": [
+                "Spouse"
               ]
             }
           ]
@@ -1247,12 +1880,12 @@
       {
         "benefit": {
           "title": "Home loan program for survivors",
-          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->A VA-backed home loan to surviving spouses of veterans.</p>",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->A VA-backed home loan to surviving spouses of veterans.</p>\r\n",
           "SourceLink": "https://www.va.gov/housing-assistance/home-loans/surviving-spouse/",
           "SourceIsEnglish": "TRUE",
           "agency": {
             "title": "Veterans Affairs Department (VA)",
-            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>\r\n",
             "lede": ""
           },
           "tags": [
@@ -1306,499 +1939,13 @@
       },
       {
         "benefit": {
-          "title": "Life insurance for survivors of veterans",
-          "summary": "<p>Payment from a veteran's or service member's life insurance policy.</p>",
-          "SourceLink": "https://www.benefits.va.gov/INSURANCE/sglivgli.asp",
-          "SourceIsEnglish": "TRUE",
-          "agency": {
-            "title": "Veterans Affairs Department (VA)",
-            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_served_in_active_military",
-              "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_service_status",
-              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, retired from the service, or member of the National Guard/Reserves",
-              "acceptableValues": [
-                "Active-duty service member",
-                "Discharged under conditions other than dishonorable",
-                "Retired from the service",
-                "Member of the National Guard/Reserves"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
-              "acceptableValues": [
-                "Spouse",
-                "Child",
-                "Parent",
-                "Other family member"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Lump-sum death benefit",
-          "summary": "<p>Financial assistance of $255 to surviving spouses of a deceased person who qualified for Social Security benefits.</p>",
-          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h7",
-          "SourceIsEnglish": "FALSE",
-          "agency": {
-            "title": "Social Security Administration (SSA)",
-            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "lifeEvents": [
-            "Death"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_paid_into_SS",
-              "label": "The deceased worked and paid Social Security taxes",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_date_of_death",
-              "label": "The deceased died within the last two years",
-              "acceptableValues": [
-                "<2years"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_citizen_status",
-              "label": "You are a U.S. citizen or eligible non-citizen",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: spouse or child",
-              "acceptableValues": [
-                "Spouse",
-                "Child"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Presidential Memorial Certificate",
-          "summary": "<p>An engraved Presidential Memorial Certificate (PMC) signed by the current president honoring the military service of a veteran or reservist.</p>",
-          "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/presidential-memorial-certificates/",
-          "SourceIsEnglish": "TRUE",
-          "agency": {
-            "title": "Veterans Affairs Department (VA)",
-            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_served_in_active_military",
-              "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_service_status",
-              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves",
-              "acceptableValues": [
-                "Active-duty service member",
-                "Discharged under conditions other than dishonorable",
-                "Member of the National Guard/Reserves"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_military_death_circumstance",
-              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation",
-              "acceptableValues": [
-                "Died while on active duty",
-                "Died as a result of a service-related disability/illness",
-                "Died while receiving/traveling to VA care",
-                "Died while receiving/eligible for VA compensation"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
-              "acceptableValues": [
-                "Spouse",
-                "Child",
-                "Parent",
-                "Other family member"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Public safety officers' death benefits",
-          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->A one-time benefit for survivors of law enforcement officers, firefighters, and other first responders whose deaths were related to an injury sustained during the line of duty.</p>",
-          "SourceLink": "https://bja.ojp.gov/program/psob/benefits",
-          "SourceIsEnglish": "TRUE",
-          "agency": {
-            "title": "Department of Justice (DOJ)",
-            "summary": "<p>Offers financial and educational support to help families of fallen public safety officers.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "lifeEvents": [
-            "Death"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_public_safety_officer",
-              "label": "The deceased was a public safety officer who died in the line of duty",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
-              "acceptableValues": [
-                "Spouse",
-                "Child",
-                "Parent",
-                "Other family member"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Public safety officers' Educational Assistance Program",
-          "summary": "<p>Financial assistance for higher education to spouses and children of police, fire, and emergency public safety officers killed in the line of duty.</p>",
-          "SourceLink": "https://psob.bja.ojp.gov/PSOB_Education2018.pdf",
-          "SourceIsEnglish": "TRUE",
-          "agency": {
-            "title": "Department of Justice (DOJ)",
-            "summary": "<p>Offers financial and educational support to help families of fallen public safety officers.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "lifeEvents": [
-            "Death"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_public_safety_officer",
-              "label": "The deceased was a public safety officer who died in the line of duty",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: spouse or child",
-              "acceptableValues": [
-                "Spouse",
-                "Child"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Survivor benefit plan",
-          "summary": "<p>Offers up to 55% of a service member's retired pay for survivors of active duty service members and some retired and reserve members.</p>",
-          "SourceLink": "https://bja.ojp.gov/program/psob/benefits",
-          "SourceIsEnglish": "TRUE",
-          "agency": {
-            "title": "Department of Defense (DOD)",
-            "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_served_in_active_military",
-              "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_service_status",
-              "label": "The service status of the deceased is: active-duty service member, retired from the service, or member of the National Guard/Reserves",
-              "acceptableValues": [
-                "Active-duty service member",
-                "Retired from the service",
-                "Member of the National Guard/Reserves"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_military_death_circumstance",
-              "label": "One of the following applies to the deceased: died while on active duty or died while on inactive-duty service training",
-              "acceptableValues": [
-                "Died while on active duty",
-                "Died while on inactive-duty service training"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: spouse or child",
-              "acceptableValues": [
-                "Spouse",
-                "Child"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Survivors benefits for child",
-          "summary": "<p>Offers Social Security survivors benefits to a child, stepchild, grandchild, or adopted child of eligible workers.</p>",
-          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h4",
-          "SourceIsEnglish": "FALSE",
-          "agency": {
-            "title": "Social Security Administration (SSA)",
-            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_paid_into_SS",
-              "label": "The deceased worked and paid Social Security taxes",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_date_of_birth",
-              "label": "You are under 18 years",
-              "acceptableValues": [
-                "<18years"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_marital_status",
-              "label": "Your marital status is unmarried",
-              "acceptableValues": [
-                "Unmarried"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_citizen_status",
-              "label": "You are a U.S. citizen or eligible non-citizen",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Applicant's relationship to the deceased is: child",
-              "acceptableValues": [
-                "Child"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Survivors benefits for child with disabilities",
-          "summary": "<p>Social Security survivors benefits to a child, stepchild, grandchild, or adopted child with disabilities of eligible workers.</p>",
-          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h4",
-          "SourceIsEnglish": "FALSE",
-          "agency": {
-            "title": "Social Security Administration (SSA)",
-            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_paid_into_SS",
-              "label": "The deceased worked and paid Social Security taxes",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_date_of_birth",
-              "label": "You are under 18 years",
-              "acceptableValues": [
-                "<18years"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_marital_status",
-              "label": "Your marital status is unmarried",
-              "acceptableValues": [
-                "Unmarried"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_citizen_status",
-              "label": "You are a U.S. citizen or eligible non-citizen",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_disability",
-              "label": "You have a disability or impairment",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_ability_to_work",
-              "label": "You are unable to work for a year or more because of a disability or your disability is expected to result in death",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: child",
-              "acceptableValues": [
-                "Child"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Survivors benefits for mothers/fathers",
-          "summary": "<p>Social Security survivors benefits to the person providing care for the child of a deceased worker.</p>",
-          "SourceLink": "https://www.ssa.gov/forms/ssa-5.html",
-          "SourceIsEnglish": "TRUE",
-          "agency": {
-            "title": "Social Security Administration (SSA)",
-            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_paid_into_SS",
-              "label": "The deceased worked and paid Social Security taxes",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_marital_status",
-              "label": "Your marital status is unmarried or widowed",
-              "acceptableValues": [
-                "Unmarried",
-                "Widowed"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_citizen_status",
-              "label": "You are a US citizen or eligible non-citizen",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_care_for_child",
-              "label": "You are caring for a child of someone who is retired, has a disability, or has died, and the child is disabled or under the age of 16",
-              "acceptableValues": [
-                "Yes"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Survivors benefits for parents",
-          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Social Security survivors benefits to parents of eligible workers.</p>",
-          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h5",
-          "SourceIsEnglish": "FALSE",
-          "agency": {
-            "title": "Social Security Administration (SSA)",
-            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_paid_into_SS",
-              "label": "The deceased worked and paid Social Security taxes",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_date_of_birth",
-              "label": "You are over 62 years",
-              "acceptableValues": [
-                ">=62years"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_citizen_status",
-              "label": "You are a US citizen or eligible non-citizen",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: parent",
-              "acceptableValues": [
-                "Parent"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
           "title": "Survivors benefits for spouse",
-          "summary": "<p>Social Security survivors benefits to surviving spouses and certain divorced spouses of eligible workers.</p>",
+          "summary": "<p>Social Security survivors benefits to surviving spouses and certain divorced spouses of eligible workers.</p>\r\n",
           "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h2",
           "SourceIsEnglish": "FALSE",
           "agency": {
             "title": "Social Security Administration (SSA)",
-            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>\r\n",
             "lede": ""
           },
           "tags": [
@@ -1846,17 +1993,20 @@
       },
       {
         "benefit": {
-          "title": "Survivors benefits for spouse with disabilities",
-          "summary": "<p>Social Security survivors benefits to surviving spouses and certain divorced spouses with disabilities of eligible workers.</p>",
-          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h2",
+          "title": "Survivors benefits for child with disabilities",
+          "summary": "<p>Social Security survivors benefits to a child, stepchild, grandchild, or adopted child with disabilities of eligible workers. You only need one application to apply for all SSA benefits.</p>\r\n",
+          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h4",
           "SourceIsEnglish": "FALSE",
           "agency": {
             "title": "Social Security Administration (SSA)",
-            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>\r\n",
             "lede": ""
           },
           "tags": [
             "Death of a loved one"
+          ],
+          "lifeEvents": [
+            "Death"
           ],
           "eligibility": [
             {
@@ -1864,81 +2014,6 @@
               "label": "The deceased worked and paid Social Security taxes",
               "acceptableValues": [
                 "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_date_of_birth",
-              "label": "You are over 50 years",
-              "acceptableValues": [
-                ">=50years"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_marital_status",
-              "label": "Your marital status is widowed or divorced",
-              "acceptableValues": [
-                "Widowed",
-                "Divorced"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_citizen_status",
-              "label": "You are a US citizen or eligible non-citizen",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_disability",
-              "label": "You have a disability or impairment",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_ability_to_work",
-              "label": "You are unable to work for a year or more because of a disability or your disability is expected to result in death",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: spouse",
-              "acceptableValues": [
-                "Spouse"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Survivors pension for child",
-          "summary": "<p>Monthly payments to qualified unmarried dependent children of deceased wartime veterans.</p>",
-          "SourceLink": "https://www.va.gov/pension/survivors-pension/",
-          "SourceIsEnglish": "TRUE",
-          "agency": {
-            "title": "Veterans Affairs Department (VA)",
-            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_served_in_active_military",
-              "label": "You served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_service_status",
-              "label": "Your service status is: discharged for conditions other than dishonorable",
-              "acceptableValues": [
-                "Discharged for conditions other than dishonorable"
               ]
             },
             {
@@ -1956,6 +2031,13 @@
               ]
             },
             {
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a U.S. citizen or eligible non-citizen",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Your relationship to the deceased is: child",
               "acceptableValues": [
@@ -1967,62 +2049,45 @@
       },
       {
         "benefit": {
-          "title": "Survivors pension for child with disabilities",
-          "summary": "<p>Monthly payments to qualified unmarried dependent children with disabilities of wartime veterans with certain income and net worth limits.</p>",
-          "SourceLink": "https://www.va.gov/pension/survivors-pension/",
-          "SourceIsEnglish": "TRUE",
+          "title": "Survivors benefits for parents",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Social Security survivors benefits to parents of eligible workers.</p>\r\n",
+          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h5",
+          "SourceIsEnglish": "FALSE",
           "agency": {
-            "title": "Veterans Affairs Department (VA)",
-            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "title": "Social Security Administration (SSA)",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>\r\n",
             "lede": ""
           },
           "tags": [
             "Death of a loved one"
           ],
-          "lifeEvents": [
-            "Death"
-          ],
           "eligibility": [
             {
-              "criteriaKey": "deceased_served_in_active_military",
-              "label": "The deceased served in the active military",
+              "criteriaKey": "deceased_paid_into_SS",
+              "label": "The deceased worked and paid Social Security taxes",
               "acceptableValues": [
                 "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_service_status",
-              "label": "The service status of the deceased is: discharged for conditions other than dishonorable",
-              "acceptableValues": [
-                "Discharged for conditions other than dishonorable"
               ]
             },
             {
               "criteriaKey": "applicant_date_of_birth",
-              "label": "You are under 18 years",
+              "label": "You are over 62 years",
               "acceptableValues": [
-                ">18years"
+                ">=62years"
               ]
             },
             {
-              "criteriaKey": "applicant_marital_status",
-              "label": "Your marital status is unmarried",
-              "acceptableValues": [
-                "Unmarried"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_disability",
-              "label": "You have a disability or impairment",
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a US citizen or eligible non-citizen",
               "acceptableValues": [
                 "Yes"
               ]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: child",
+              "label": "Your relationship to the deceased is: parent",
               "acceptableValues": [
-                "Child"
+                "Parent"
               ]
             }
           ]
@@ -2030,67 +2095,13 @@
       },
       {
         "benefit": {
-          "title": "Survivors pension for spouse",
-          "summary": "<p>Monthly payments to surviving spouses of wartime veterans with certain income and net worth limits.</p>",
-          "SourceLink": "https://www.va.gov/pension/survivors-pension/",
+          "title": "Public safety officers' death benefits",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->A one-time benefit for survivors of law enforcement officers, firefighters, and other first responders whose deaths were related to an injury sustained during the line of duty.</p>\r\n",
+          "SourceLink": "https://bja.ojp.gov/program/psob/benefits",
           "SourceIsEnglish": "TRUE",
           "agency": {
-            "title": "Veterans Affairs Department (VA)",
-            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_served_in_active_military",
-              "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_service_status",
-              "label": "The service status of the deceased is: discharged for conditions other than dishonorable",
-              "acceptableValues": [
-                "Discharged for conditions other than dishonorable"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_marital_status",
-              "label": "Your marital status is unmarried or widowed",
-              "acceptableValues": [
-                "Unmarried",
-                "Widowed"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_income",
-              "label": "You have limited income and resources",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: spouse",
-              "acceptableValues": [
-                "Spouse"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Veterans burial allowance",
-          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Assistance with burial, funeral, and transportation costs of a deceased veteran.</p>",
-          "SourceLink": "https://www.va.gov/burials-memorials/veterans-burial-allowance/",
-          "SourceIsEnglish": "TRUE",
-          "agency": {
-            "title": "Veterans Affairs Department (VA)",
-            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "title": "Department of Justice (DOJ)",
+            "summary": "<p>Offers financial and educational support to help families of fallen public safety officers.</p>\r\n",
             "lede": ""
           },
           "tags": [
@@ -2101,140 +2112,8 @@
           ],
           "eligibility": [
             {
-              "criteriaKey": "deceased_date_of_death",
-              "label": "The deceased died within the last two years",
-              "acceptableValues": [
-                "<2years"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_served_in_active_military",
-              "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_service_status",
-              "label": "The service status of the deceased is: discharged for conditions other than dishonorable",
-              "acceptableValues": [
-                "Discharged for conditions other than dishonorable"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_military_death_circumstance",
-              "label": "One of the following applies to the deceased: died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation",
-              "acceptableValues": [
-                "Died as a result of a service-related disability/illness",
-                "Died while receiving/traveling to VA care",
-                "Died while receiving/eligible for VA compensation"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
-              "acceptableValues": [
-                "Spouse",
-                "Child",
-                "Parent",
-                "Other family member"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_paid_funeral_expenses",
-              "label": "You paid for funeral or burial expenses",
-              "acceptableValues": [
-                "Yes"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Veterans headstone and grave marker",
-          "summary": "<p>A headstone, grave or niche marker, or medallion to honor a veteran, service member, or eligible family member.</p>",
-          "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/headstones-markers-medallions/",
-          "SourceIsEnglish": "TRUE",
-          "agency": {
-            "title": "Veterans Affairs Department (VA)",
-            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_served_in_active_military",
-              "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_service_status",
-              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves",
-              "acceptableValues": [
-                "Active-duty service member",
-                "Discharged under conditions other than dishonorable",
-                "Member of the National Guard/Reserves"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_grave_headstone",
-              "label": "The person is buried in a grave with a privately purchased headstone or an unmarked grave",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "applicant_relationship_to_the_deceased",
-              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
-              "acceptableValues": [
-                "Spouse",
-                "Child",
-                "Parent",
-                "Other family member"
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "benefit": {
-          "title": "Veterans medallion",
-          "summary": "<p>A headstone medallion, grave marker, and Presidential Memorial Certificate for eligible veterans buried in a private cemetery.</p>",
-          "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/headstones-markers-medallions/",
-          "SourceIsEnglish": "TRUE",
-          "agency": {
-            "title": "Veterans Affairs Department (VA)",
-            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
-            "lede": ""
-          },
-          "tags": [
-            "Death of a loved one"
-          ],
-          "eligibility": [
-            {
-              "criteriaKey": "deceased_served_in_active_military",
-              "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_service_status",
-              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or a member of the National Guard/Reserves",
-              "acceptableValues": [
-                "Active-duty service member",
-                "Discharged under conditions other than dishonorable",
-                "Member of the National Guard/Reserves"
-              ]
-            },
-            {
-              "criteriaKey": "deceased_grave_headstone",
-              "label": "The person is buried in a grave with a privately purchased headstone or an unmarked grave",
+              "criteriaKey": "deceased_public_safety_officer",
+              "label": "The deceased was a public safety officer who died in the line of duty",
               "acceptableValues": [
                 "Yes"
               ]

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/indexBenefitAccordionGroup.cy.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/indexBenefitAccordionGroup.cy.jsx
@@ -1,0 +1,41 @@
+import { composeStories } from '@storybook/react'
+import * as stories from '../index.stories'
+const { Primary, ExpandAll } = composeStories(stories)
+
+describe('BenefitAccordionGroup component tests', () => {
+  it('Validate opening individual accordion only expands the clicked accordion and clicking it again closes it', () => {
+    cy.mount(<Primary />)
+    cy.get('.usa-accordion__button').contains('Burial benefits').click()
+    cy.get('.usa-accordion__button')
+      .contains('Burial benefits')
+      .parent()
+      .should('have.attr', 'aria-expanded', 'true')
+    cy.get('.usa-accordion__button')
+      .contains('Death gratuity')
+      .parent()
+      .should('have.attr', 'aria-expanded', 'false')
+    cy.get('.usa-accordion__button').contains('Burial benefits').click()
+    cy.get('.usa-accordion__button').each(accordion => {
+      cy.wrap(accordion).should('have.attr', 'aria-expanded', 'false')
+    })
+  })
+
+  it('Validate clicking Expand all opens all accordions', () => {
+    cy.mount(<ExpandAll />)
+    cy.get('.expand-all').click()
+    cy.get('.expand-all').should('contain.text', 'Collapse all')
+    cy.get('.usa-accordion__button').each(accordion => {
+      cy.wrap(accordion).should('have.attr', 'aria-expanded', 'true')
+    })
+  })
+
+  it('Validate clicking Collapse all closes all accordions', () => {
+    cy.mount(<ExpandAll />)
+    cy.get('.expand-all').click()
+    cy.get('.expand-all').click()
+    cy.get('.expand-all').should('contain.text', 'Expand all')
+    cy.get('.usa-accordion__button').each(accordion => {
+      cy.wrap(accordion).should('have.attr', 'aria-expanded', 'false')
+    })
+  })
+})

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/indexBenefitAccordionGroup.cy.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/indexBenefitAccordionGroup.cy.jsx
@@ -23,7 +23,7 @@ describe('BenefitAccordionGroup component tests', () => {
   it('Validate clicking Expand all opens all accordions', () => {
     cy.mount(<ExpandAll />)
     cy.get('.expand-all').click()
-    cy.get('.expand-all').should('contain.text', 'Collapse all')
+    cy.get('.expand-all').should('contain.text', 'Close all')
     cy.get('.usa-accordion__button').each(accordion => {
       cy.wrap(accordion).should('have.attr', 'aria-expanded', 'true')
     })
@@ -33,7 +33,7 @@ describe('BenefitAccordionGroup component tests', () => {
     cy.mount(<ExpandAll />)
     cy.get('.expand-all').click()
     cy.get('.expand-all').click()
-    cy.get('.expand-all').should('contain.text', 'Expand all')
+    cy.get('.expand-all').should('contain.text', 'Open all')
     cy.get('.usa-accordion__button').each(accordion => {
       cy.wrap(accordion).should('have.attr', 'aria-expanded', 'false')
     })

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/index.stories.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/index.stories.jsx
@@ -1,5 +1,6 @@
 import BenefitAccordionGroup from './index.jsx'
 import content from '../../api/mock-data/current.js'
+import * as en from '../../locales/en/en.json'
 
 const { data } = JSON.parse(content)
 const { benefits } = data
@@ -12,6 +13,7 @@ export default {
   args: {
     data: b,
     entryKey: entryKey[0],
+    ui: en.resultsView,
   },
 }
 

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/index.stories.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/index.stories.jsx
@@ -6,6 +6,7 @@ const { data } = JSON.parse(content)
 const { benefits } = data
 const b = [benefits[0], benefits[1]]
 const entryKey = Object.keys(b[0])
+const { resultsView } = en
 
 export default {
   component: BenefitAccordionGroup,
@@ -13,7 +14,7 @@ export default {
   args: {
     data: b,
     entryKey: entryKey[0],
-    ui: en.resultsView,
+    ui: resultsView,
   },
 }
 

--- a/benefit-finder/src/shared/components/Intro/index.stories.jsx
+++ b/benefit-finder/src/shared/components/Intro/index.stories.jsx
@@ -4,6 +4,7 @@ import * as en from '../../locales/en/en.json'
 
 const { data } = JSON.parse(content)
 const { lifeEventForm } = data
+const { intro } = en
 
 export default {
   component: Intro,
@@ -13,7 +14,7 @@ export default {
   tags: ['autodocs'],
   args: {
     data: lifeEventForm,
-    ui: en.intro,
+    ui: intro,
   },
 }
 

--- a/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/index.stories.jsx
+++ b/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/index.stories.jsx
@@ -2,6 +2,8 @@ import KeyElegibilityCrieriaList from './index.jsx'
 import content from '../../api/mock-data/current.js'
 import * as en from '../../locales/en/en.json'
 
+const { resultsView } = en
+
 const { data } = JSON.parse(content)
 const { benefits } = data
 const b = benefits[0].benefit.eligibility
@@ -13,7 +15,7 @@ export default {
   args: {
     data: b,
     initialEligibilityLength,
-    ui: en.resultsView.benefitAccordion,
+    ui: resultsView.benefitAccordion,
   },
 }
 

--- a/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/index.stories.jsx
+++ b/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/index.stories.jsx
@@ -1,5 +1,6 @@
 import KeyElegibilityCrieriaList from './index.jsx'
 import content from '../../api/mock-data/current.js'
+import * as en from '../../locales/en/en.json'
 
 const { data } = JSON.parse(content)
 const { benefits } = data
@@ -12,6 +13,7 @@ export default {
   args: {
     data: b,
     initialEligibilityLength,
+    ui: en.resultsView.benefitAccordion,
   },
 }
 

--- a/benefit-finder/src/shared/components/NoticesList/index.stories.jsx
+++ b/benefit-finder/src/shared/components/NoticesList/index.stories.jsx
@@ -1,11 +1,13 @@
 import NoticesList from './index.jsx'
 import * as en from '../../locales/en/en.json'
 
+const { intro } = en
+
 export default {
   component: NoticesList,
   tags: ['autodocs'],
   args: {
-    data: en.intro.notices.list,
+    data: intro.notices.list,
   },
 }
 

--- a/benefit-finder/src/shared/components/ResultsView/index.stories.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.stories.jsx
@@ -1,11 +1,13 @@
 import ResultsView from './index.jsx'
 import * as en from '../../locales/en/en.json'
 
+const { resultsView } = en
+
 export default {
   component: ResultsView,
   tags: ['autodocs'],
   args: {
-    ui: en.resultsView,
+    ui: resultsView,
   },
 }
 

--- a/benefit-finder/src/shared/components/Select/index.stories.jsx
+++ b/benefit-finder/src/shared/components/Select/index.stories.jsx
@@ -1,6 +1,8 @@
 import Select from './index.jsx'
 import * as en from '../../locales/en/en.json'
 
+const { select } = en
+
 const selectOptions = [
   { value: 'value-1', label: 'Option 1' },
   { value: 'value-2', label: 'Option 2' },
@@ -11,7 +13,7 @@ export default {
   component: Select,
   tags: ['autodocs'],
   args: {
-    ui: en.select,
+    ui: select,
     options: selectOptions,
   },
 }

--- a/benefit-finder/src/shared/components/VerifySelectionsView/index.stories.jsx
+++ b/benefit-finder/src/shared/components/VerifySelectionsView/index.stories.jsx
@@ -1,11 +1,13 @@
 import VerifySelectionsView from './index.jsx'
 import * as en from '../../locales/en/en.json'
 
+const { verifySelectionsView } = en
+
 export default {
   component: VerifySelectionsView,
   tags: ['autodocs'],
   args: {
-    ui: en.verifySelectionsView,
+    ui: verifySelectionsView,
   },
 }
 

--- a/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
@@ -253,7 +253,9 @@ class LifeEventController {
 
     // Build benefits.
     foreach ($benefit_nodes as $benefit_node) {
-      $benefits[]["benefit"] = $this->buildBenefit($benefit_node);
+      if (!empty($benefit_node)) {
+        $benefits[]["benefit"] = $this->buildBenefit($benefit_node);
+      }
     }
 
     // Encode JSON data.


### PR DESCRIPTION
## PR Summary

Cypress bundler doesn’t like importing “as” for the locale json. When we launch cypress with ‘npx cypress open’, webpack throughs errors on the console when you save changes you are making on cypress tests.
This PR includes updates to de-structure the import and assign to a constant before passing into the args and thus fixes the webpack process completes without errors.
Mock data has also been updated to reflect current change in VDI

## Related Github Issue
fixes issue(#594 [fix failing storybook components and add component tests ] )

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [ ] pull local
- [ ] install nodes
- [ ] navigate to benefit finder and run 'npx cypress open' and then make a change a test e.g add a space in indexBenefitAccordionGroup.cy.jsx and save the changes, you should see that the webpack process completes without the reported error
- [ ] run `npm run cy:run:chrome` and verify all tests are passing
