### PR TITLE
Resolve uncaught exception

### DIFF
--- a/benefit-finder/src/App/index.jsx
+++ b/benefit-finder/src/App/index.jsx
@@ -38,7 +38,7 @@ function App({ testAppContent, testQuery }) {
     if (process.env.NODE_ENV === 'production') {
       apiCalls.GET.LifeEvent().then(
         response =>
-          response.status === 200
+          response?.status === 200
             ? setContent(response.data)
             : setContent(testAppContent) // fallback for storybook
       )
@@ -48,7 +48,7 @@ function App({ testAppContent, testQuery }) {
       testAppContent === undefined
     ) {
       apiCalls.GET.LifeEvent().then(
-        response => response.status === 200 && setContent(response.data)
+        response => response?.status === 200 && setContent(response.data)
       )
     }
     // default to test state so we don't collide with component mounting


### PR DESCRIPTION
## PR Summary

The app was looking for an object key that doesn't exist on the request, so we Include optional chaining when checking `response.status`

## Related Github Issue

- fixes #671 

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [x] pull locally
- [x] `npm run build:storybook`
- [x] `npx http-server ./storybook-static `
- [x] `npm run cy:run:chrome`
- [x] ensure tests are able to run


