### PR TITLE
include time offset in parsedate

### DIFF
--- a/benefit-finder/src/shared/utils/parseDate.js
+++ b/benefit-finder/src/shared/utils/parseDate.js
@@ -2,12 +2,15 @@
  * a parse our date object
  * @function
  * @param {object} value - { day, month, year }
- * @return {Date} returns a tandard format Date ie 1995-12-17T03:24:00
+ * @return {Date} returns a standard format Date ie 1995-12-17T03:24:00
  */
 const parseDate = value => {
   const d =
     value && new window.Date(Date.UTC(value.year, value.month, value.day))
-  return d
+  const adjustTimeOffset = new Date(
+    d.getTime() + Math.abs(d.getTimezoneOffset() * 60000)
+  )
+  return adjustTimeOffset
 }
 
 export default parseDate


### PR DESCRIPTION
## PR Summary

This updates our `parseDate` utility function to include the calculation for time offset due to the limited object values passed on new Date creation

## Related Github Issue

- fixes #645 

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [x] Navigate through form taking note of dates entered
- [x] Select review selections
- [x] Ensure that the dates selected match those rendered in the review listing
