### PR TITLE
Missing keyboard focus on "more benefits" cards #732

### DIFF
--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.js.snap
@@ -5364,110 +5364,100 @@ exports[`loads window query scenario 1 1`] = `
                 More benefits
               </h3>
               <ul
-                class="add-list-reset"
+                class="usa-card-group"
               >
-                <div>
-                  <li
-                    class="relative-benefit-card usa-card add-list-reset"
+                <li
+                  class="relative-benefit-card tablet:grid-col-12 add-list-reset"
+                >
+                  <a
+                    class="usa-card__container"
+                    href="/benefit-finder/life_event/retirement"
                   >
-                    <a
-                      href="/benefit-finder/life_event/retirement"
+                    <div
+                      class="usa-card__header"
                     >
-                      <div
-                        class="usa-card__container"
+                      <h3
+                        class="usa-card__heading font-family-sans"
+                        id=""
                       >
-                        <div
-                          class="usa-card__header"
-                        >
-                          <h3
-                            class="usa-card__heading font-family-sans"
-                            id=""
-                          >
-                            Benefit finder: retirement
-                          </h3>
-                        </div>
-                        <div
-                          class="usa-card__body"
-                        >
-                          <p>
-                            Find out what financial, health care, and other benefits may be available as you enter this next phase of your life.
-                          </p>
-                        </div>
-                        <div
-                          class="usa-card__cta"
-                        >
-                          Call to action (retirement)
-                        </div>
-                        <svg
-                          class="carrot-two"
-                          fill="none"
-                          height="22"
-                          viewBox="0 0 13 22"
-                          width="13"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            clip-rule="evenodd"
-                            d="M3.18079 1.18074C2.79027 0.790216 2.1571 0.790215 1.76658 1.18074L0.706337 2.24098C0.316114 2.6312 0.315768 3.26377 0.705565 3.65442L7.33029 10.2936C7.71979 10.684 7.71979 11.3159 7.33029 11.7063L0.705566 18.3455C0.315768 18.7361 0.316113 19.3687 0.706336 19.7589L1.76658 20.8192C2.1571 21.2097 2.79027 21.2097 3.18079 20.8192L12.2929 11.7071C12.6834 11.3165 12.6834 10.6834 12.2929 10.2928L3.18079 1.18074Z"
-                            fill="#162E51"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </div>
-                    </a>
-                  </li>
-                </div>
-                <div>
-                  <li
-                    class="relative-benefit-card usa-card add-list-reset"
+                        Benefit finder: retirement
+                      </h3>
+                    </div>
+                    <div
+                      class="usa-card__body"
+                    >
+                      <p>
+                        Find out what financial, health care, and other benefits may be available as you enter this next phase of your life.
+                      </p>
+                    </div>
+                    <div
+                      class="usa-card__cta"
+                    >
+                      Call to action (retirement)
+                    </div>
+                    <svg
+                      class="carrot-two"
+                      fill="none"
+                      height="22"
+                      viewBox="0 0 13 22"
+                      width="13"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.18079 1.18074C2.79027 0.790216 2.1571 0.790215 1.76658 1.18074L0.706337 2.24098C0.316114 2.6312 0.315768 3.26377 0.705565 3.65442L7.33029 10.2936C7.71979 10.684 7.71979 11.3159 7.33029 11.7063L0.705566 18.3455C0.315768 18.7361 0.316113 19.3687 0.706336 19.7589L1.76658 20.8192C2.1571 21.2097 2.79027 21.2097 3.18079 20.8192L12.2929 11.7071C12.6834 11.3165 12.6834 10.6834 12.2929 10.2928L3.18079 1.18074Z"
+                        fill="#162E51"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </a>
+                </li>
+                <li
+                  class="relative-benefit-card tablet:grid-col-12 add-list-reset"
+                >
+                  <a
+                    class="usa-card__container"
+                    href="/benefit-finder/life_event/disability"
                   >
-                    <a
-                      href="/benefit-finder/life_event/disability"
+                    <div
+                      class="usa-card__header"
                     >
-                      <div
-                        class="usa-card__container"
+                      <h3
+                        class="usa-card__heading font-family-sans"
+                        id=""
                       >
-                        <div
-                          class="usa-card__header"
-                        >
-                          <h3
-                            class="usa-card__heading font-family-sans"
-                            id=""
-                          >
-                            Benefit finder: disability
-                          </h3>
-                        </div>
-                        <div
-                          class="usa-card__body"
-                        >
-                          <p>
-                            Whether you are newly disabled or have a lifelong challenge, assistance may be available, including financial help.
-                          </p>
-                        </div>
-                        <div
-                          class="usa-card__cta"
-                        >
-                          Call to action (disability)
-                        </div>
-                        <svg
-                          class="carrot-two"
-                          fill="none"
-                          height="22"
-                          viewBox="0 0 13 22"
-                          width="13"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            clip-rule="evenodd"
-                            d="M3.18079 1.18074C2.79027 0.790216 2.1571 0.790215 1.76658 1.18074L0.706337 2.24098C0.316114 2.6312 0.315768 3.26377 0.705565 3.65442L7.33029 10.2936C7.71979 10.684 7.71979 11.3159 7.33029 11.7063L0.705566 18.3455C0.315768 18.7361 0.316113 19.3687 0.706336 19.7589L1.76658 20.8192C2.1571 21.2097 2.79027 21.2097 3.18079 20.8192L12.2929 11.7071C12.6834 11.3165 12.6834 10.6834 12.2929 10.2928L3.18079 1.18074Z"
-                            fill="#162E51"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </div>
-                    </a>
-                  </li>
-                </div>
+                        Benefit finder: disability
+                      </h3>
+                    </div>
+                    <div
+                      class="usa-card__body"
+                    >
+                      <p>
+                        Whether you are newly disabled or have a lifelong challenge, assistance may be available, including financial help.
+                      </p>
+                    </div>
+                    <div
+                      class="usa-card__cta"
+                    >
+                      Call to action (disability)
+                    </div>
+                    <svg
+                      class="carrot-two"
+                      fill="none"
+                      height="22"
+                      viewBox="0 0 13 22"
+                      width="13"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.18079 1.18074C2.79027 0.790216 2.1571 0.790215 1.76658 1.18074L0.706337 2.24098C0.316114 2.6312 0.315768 3.26377 0.705565 3.65442L7.33029 10.2936C7.71979 10.684 7.71979 11.3159 7.33029 11.7063L0.705566 18.3455C0.315768 18.7361 0.316113 19.3687 0.706336 19.7589L1.76658 20.8192C2.1571 21.2097 2.79027 21.2097 3.18079 20.8192L12.2929 11.7071C12.6834 11.3165 12.6834 10.6834 12.2929 10.2928L3.18079 1.18074Z"
+                        fill="#162E51"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </a>
+                </li>
               </ul>
             </div>
             <div
@@ -10960,110 +10950,100 @@ exports[`loads window query scenario 2 1`] = `
                 More benefits
               </h3>
               <ul
-                class="add-list-reset"
+                class="usa-card-group"
               >
-                <div>
-                  <li
-                    class="relative-benefit-card usa-card add-list-reset"
+                <li
+                  class="relative-benefit-card tablet:grid-col-12 add-list-reset"
+                >
+                  <a
+                    class="usa-card__container"
+                    href="/benefit-finder/life_event/retirement"
                   >
-                    <a
-                      href="/benefit-finder/life_event/retirement"
+                    <div
+                      class="usa-card__header"
                     >
-                      <div
-                        class="usa-card__container"
+                      <h3
+                        class="usa-card__heading font-family-sans"
+                        id=""
                       >
-                        <div
-                          class="usa-card__header"
-                        >
-                          <h3
-                            class="usa-card__heading font-family-sans"
-                            id=""
-                          >
-                            Benefit finder: retirement
-                          </h3>
-                        </div>
-                        <div
-                          class="usa-card__body"
-                        >
-                          <p>
-                            Find out what financial, health care, and other benefits may be available as you enter this next phase of your life.
-                          </p>
-                        </div>
-                        <div
-                          class="usa-card__cta"
-                        >
-                          Call to action (retirement)
-                        </div>
-                        <svg
-                          class="carrot-two"
-                          fill="none"
-                          height="22"
-                          viewBox="0 0 13 22"
-                          width="13"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            clip-rule="evenodd"
-                            d="M3.18079 1.18074C2.79027 0.790216 2.1571 0.790215 1.76658 1.18074L0.706337 2.24098C0.316114 2.6312 0.315768 3.26377 0.705565 3.65442L7.33029 10.2936C7.71979 10.684 7.71979 11.3159 7.33029 11.7063L0.705566 18.3455C0.315768 18.7361 0.316113 19.3687 0.706336 19.7589L1.76658 20.8192C2.1571 21.2097 2.79027 21.2097 3.18079 20.8192L12.2929 11.7071C12.6834 11.3165 12.6834 10.6834 12.2929 10.2928L3.18079 1.18074Z"
-                            fill="#162E51"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </div>
-                    </a>
-                  </li>
-                </div>
-                <div>
-                  <li
-                    class="relative-benefit-card usa-card add-list-reset"
+                        Benefit finder: retirement
+                      </h3>
+                    </div>
+                    <div
+                      class="usa-card__body"
+                    >
+                      <p>
+                        Find out what financial, health care, and other benefits may be available as you enter this next phase of your life.
+                      </p>
+                    </div>
+                    <div
+                      class="usa-card__cta"
+                    >
+                      Call to action (retirement)
+                    </div>
+                    <svg
+                      class="carrot-two"
+                      fill="none"
+                      height="22"
+                      viewBox="0 0 13 22"
+                      width="13"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.18079 1.18074C2.79027 0.790216 2.1571 0.790215 1.76658 1.18074L0.706337 2.24098C0.316114 2.6312 0.315768 3.26377 0.705565 3.65442L7.33029 10.2936C7.71979 10.684 7.71979 11.3159 7.33029 11.7063L0.705566 18.3455C0.315768 18.7361 0.316113 19.3687 0.706336 19.7589L1.76658 20.8192C2.1571 21.2097 2.79027 21.2097 3.18079 20.8192L12.2929 11.7071C12.6834 11.3165 12.6834 10.6834 12.2929 10.2928L3.18079 1.18074Z"
+                        fill="#162E51"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </a>
+                </li>
+                <li
+                  class="relative-benefit-card tablet:grid-col-12 add-list-reset"
+                >
+                  <a
+                    class="usa-card__container"
+                    href="/benefit-finder/life_event/disability"
                   >
-                    <a
-                      href="/benefit-finder/life_event/disability"
+                    <div
+                      class="usa-card__header"
                     >
-                      <div
-                        class="usa-card__container"
+                      <h3
+                        class="usa-card__heading font-family-sans"
+                        id=""
                       >
-                        <div
-                          class="usa-card__header"
-                        >
-                          <h3
-                            class="usa-card__heading font-family-sans"
-                            id=""
-                          >
-                            Benefit finder: disability
-                          </h3>
-                        </div>
-                        <div
-                          class="usa-card__body"
-                        >
-                          <p>
-                            Whether you are newly disabled or have a lifelong challenge, assistance may be available, including financial help.
-                          </p>
-                        </div>
-                        <div
-                          class="usa-card__cta"
-                        >
-                          Call to action (disability)
-                        </div>
-                        <svg
-                          class="carrot-two"
-                          fill="none"
-                          height="22"
-                          viewBox="0 0 13 22"
-                          width="13"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            clip-rule="evenodd"
-                            d="M3.18079 1.18074C2.79027 0.790216 2.1571 0.790215 1.76658 1.18074L0.706337 2.24098C0.316114 2.6312 0.315768 3.26377 0.705565 3.65442L7.33029 10.2936C7.71979 10.684 7.71979 11.3159 7.33029 11.7063L0.705566 18.3455C0.315768 18.7361 0.316113 19.3687 0.706336 19.7589L1.76658 20.8192C2.1571 21.2097 2.79027 21.2097 3.18079 20.8192L12.2929 11.7071C12.6834 11.3165 12.6834 10.6834 12.2929 10.2928L3.18079 1.18074Z"
-                            fill="#162E51"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </div>
-                    </a>
-                  </li>
-                </div>
+                        Benefit finder: disability
+                      </h3>
+                    </div>
+                    <div
+                      class="usa-card__body"
+                    >
+                      <p>
+                        Whether you are newly disabled or have a lifelong challenge, assistance may be available, including financial help.
+                      </p>
+                    </div>
+                    <div
+                      class="usa-card__cta"
+                    >
+                      Call to action (disability)
+                    </div>
+                    <svg
+                      class="carrot-two"
+                      fill="none"
+                      height="22"
+                      viewBox="0 0 13 22"
+                      width="13"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.18079 1.18074C2.79027 0.790216 2.1571 0.790215 1.76658 1.18074L0.706337 2.24098C0.316114 2.6312 0.315768 3.26377 0.705565 3.65442L7.33029 10.2936C7.71979 10.684 7.71979 11.3159 7.33029 11.7063L0.705566 18.3455C0.315768 18.7361 0.316113 19.3687 0.706336 19.7589L1.76658 20.8192C2.1571 21.2097 2.79027 21.2097 3.18079 20.8192L12.2929 11.7071C12.6834 11.3165 12.6834 10.6834 12.2929 10.2928L3.18079 1.18074Z"
+                        fill="#162E51"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </a>
+                </li>
               </ul>
             </div>
             <div

--- a/benefit-finder/src/shared/components/Card/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Card/__tests__/__snapshots__/index.spec.js.snap
@@ -4,46 +4,44 @@ exports[`Card renders a match to the previous snapshot 1`] = `
 <li
   className=""
 >
-  <a>
+  <a
+    className="usa-card__container"
+  >
     <div
-      className="usa-card__container"
+      className="usa-card__header"
     >
-      <div
-        className="usa-card__header"
-      >
-        <h3
-          className=""
-          id=""
-        />
-      </div>
-      <div
-        className="usa-card__body"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": undefined,
-          }
-        }
+      <h3
+        className=""
+        id=""
       />
-      <div
-        className="usa-card__cta"
-      />
-      <svg
-        className="carrot"
-        fill="#162E51"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M0 0h24v24H0z"
-          fill="none"
-        />
-        <path
-          d="M7 10l5 5 5-5z"
-        />
-      </svg>
     </div>
+    <div
+      className="usa-card__body"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": undefined,
+        }
+      }
+    />
+    <div
+      className="usa-card__cta"
+    />
+    <svg
+      className="carrot"
+      fill="#162E51"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M0 0h24v24H0z"
+        fill="none"
+      />
+      <path
+        d="M7 10l5 5 5-5z"
+      />
+    </svg>
   </a>
 </li>
 `;

--- a/benefit-finder/src/shared/components/Card/_index.scss
+++ b/benefit-finder/src/shared/components/Card/_index.scss
@@ -20,11 +20,11 @@
       text-decoration: none;
     }
 
-    a:hover .usa-card__container {
+    a:hover.usa-card__container {
       background-color: color.$dark-sky;
     }
 
-    a:active .usa-card__container {
+    a:active.usa-card__container {
       border: 2px solid color.$pop-blue;
     }
 

--- a/benefit-finder/src/shared/components/Card/index.jsx
+++ b/benefit-finder/src/shared/components/Card/index.jsx
@@ -16,7 +16,7 @@ import './_index.scss'
  * @return {html} returns a semantic html list element
  */
 const Card = ({ className, title, body, cta, href, noCarrot, carrotType }) => {
-  const defaultClasses = ['usa-card add-list-reset']
+  const defaultClasses = ['add-list-reset']
   const handleCarrot =
     noCarrot === true ? null : <Carrot color="#162E51" type={carrotType} />
 
@@ -28,20 +28,18 @@ const Card = ({ className, title, body, cta, href, noCarrot, carrotType }) => {
       })}
       key={`${title}`}
     >
-      <a href={href}>
-        <div className="usa-card__container">
-          <div className="usa-card__header">
-            <Heading className="usa-card__heading" headingLevel={3}>
-              {title}
-            </Heading>
-          </div>
-          <div
-            className="usa-card__body"
-            dangerouslySetInnerHTML={createMarkup(body)}
-          />
-          <div className="usa-card__cta">{cta}</div>
-          {handleCarrot}
+      <a className="usa-card__container" href={href}>
+        <div className="usa-card__header">
+          <Heading className="usa-card__heading" headingLevel={3}>
+            {title}
+          </Heading>
         </div>
+        <div
+          className="usa-card__body"
+          dangerouslySetInnerHTML={createMarkup(body)}
+        />
+        <div className="usa-card__cta">{cta}</div>
+        {handleCarrot}
       </a>
     </li>
   )

--- a/benefit-finder/src/shared/components/RelativeBenefitList/index.jsx
+++ b/benefit-finder/src/shared/components/RelativeBenefitList/index.jsx
@@ -5,6 +5,7 @@ import { Card } from '../index'
  * a functional component that renders a list of usa-card component(s)
  * @component
  * @param {array} data - passed benefits data
+ * @param {number} carrotType - determines display type
  * @return {html} returns a semantic html unorderd list element
  */
 const RelativeBenefitList = ({ data, carrotType }) => {
@@ -32,7 +33,7 @@ const RelativeBenefitList = ({ data, carrotType }) => {
 
 RelativeBenefitList.propTypes = {
   data: PropTypes.array,
-  dataKey: PropTypes.string,
+  carrotType: PropTypes.number,
 }
 
 export default RelativeBenefitList

--- a/benefit-finder/src/shared/components/RelativeBenefitList/index.jsx
+++ b/benefit-finder/src/shared/components/RelativeBenefitList/index.jsx
@@ -5,23 +5,24 @@ import { Card } from '../index'
  * a functional component that renders a list of usa-card component(s)
  * @component
  * @param {array} data - passed benefits data
- * @param {string} dataKey - key to reference
  * @return {html} returns a semantic html unorderd list element
  */
-const RelativeBenefitList = ({ data }) => {
+const RelativeBenefitList = ({ data, carrotType }) => {
   return (
     <ul className="usa-card-group">
       {data &&
         data.map((item, i) => {
-          const { title, link, cta } = item
+          const { title, link, cta, body } = item.lifeEvent
 
           return (
             <Card
-              className="relative-benefit-card tablet:grid-col-6"
+              className="relative-benefit-card tablet:grid-col-12"
               title={title}
               cta={cta}
               href={link}
+              body={body}
               key={`${title}-${i}`}
+              carrotType={carrotType}
             />
           )
         })}

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -7,9 +7,9 @@ import {
   EmailButton,
   Heading,
   StepBackLink,
-  Card,
   Chevron,
   ShareButton,
+  RelativeBenefitList,
 } from '../index'
 import createMarkup from '../../utils/createMarkup'
 import './_index.scss'
@@ -132,32 +132,10 @@ const ResultsView = ({
                 {resultsRelativeBenefits?.heading}
               </Heading>
               {relevantBenefits && (
-                <ul className="add-list-reset">
-                  {relevantBenefits[0] && (
-                    <div key="benefit-card-one">
-                      <Card
-                        className="relative-benefit-card"
-                        title={`${relevantBenefits[0].lifeEvent.title}`}
-                        body={`${relevantBenefits[0].lifeEvent.body}`}
-                        cta={`${relevantBenefits[0].lifeEvent.cta}`}
-                        href={`${relevantBenefits[0].lifeEvent.link}`}
-                        carrotType={2}
-                      ></Card>
-                    </div>
-                  )}
-                  {relevantBenefits[1] && (
-                    <div key="benefit-card-two">
-                      <Card
-                        className="relative-benefit-card"
-                        title={`${relevantBenefits[1].lifeEvent.title}`}
-                        body={`${relevantBenefits[1].lifeEvent.body}`}
-                        cta={`${relevantBenefits[1].lifeEvent.cta}`}
-                        href={`${relevantBenefits[1].lifeEvent.link}`}
-                        carrotType={2}
-                      ></Card>
-                    </div>
-                  )}
-                </ul>
+                <RelativeBenefitList
+                  data={relevantBenefits}
+                  carrotType={2}
+                ></RelativeBenefitList>
               )}
             </div>
           )}


### PR DESCRIPTION
## PR Summary

refactors results view to leverage the `RelativeBenefits` component.  This includes the structure needed to get `[href]:focus` with uswds styles working again.

## Related Github Issue

- fixes #732

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [x] proxy data from main sandbox
- [x] navigate to http://localhost:3000/death?applicant_date_of_birth=%7B%22month%22%3A%220%22%2C%22day%22%3A%2222%22%2C%22year%22%3A%222022%22%7D&applicant_relationship_to_the_deceased=Spouse&applicant_marital_status=Married&deceased_date_of_death=%7B%22month%22%3A%220%22%2C%22day%22%3A%228%22%2C%22year%22%3A%221977%22%7D&deceased_death_location_is_US=Yes&shared=true%27
- [x] tab to relative benefits cards
- [x] ensure outline appears when focused

<img width="555" alt="Screenshot 2024-01-08 at 1 00 17 PM" src="https://github.com/GSA/px-benefit-finder/assets/37077057/fece3e8d-f738-4497-aa35-a58ca67ab5ff">

