### PR TITLE
Updates Keyboard Tab Order on Error

### DIFF
--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.js.snap
@@ -5364,110 +5364,100 @@ exports[`loads window query scenario 1 1`] = `
                 More benefits
               </h3>
               <ul
-                class="add-list-reset"
+                class="usa-card-group"
               >
-                <div>
-                  <li
-                    class="relative-benefit-card usa-card add-list-reset"
+                <li
+                  class="relative-benefit-card tablet:grid-col-12 add-list-reset"
+                >
+                  <a
+                    class="usa-card__container"
+                    href="/benefit-finder/life_event/retirement"
                   >
-                    <a
-                      href="/benefit-finder/life_event/retirement"
+                    <div
+                      class="usa-card__header"
                     >
-                      <div
-                        class="usa-card__container"
+                      <h3
+                        class="usa-card__heading font-family-sans"
+                        id=""
                       >
-                        <div
-                          class="usa-card__header"
-                        >
-                          <h3
-                            class="usa-card__heading font-family-sans"
-                            id=""
-                          >
-                            Benefit finder: retirement
-                          </h3>
-                        </div>
-                        <div
-                          class="usa-card__body"
-                        >
-                          <p>
-                            Find out what financial, health care, and other benefits may be available as you enter this next phase of your life.
-                          </p>
-                        </div>
-                        <div
-                          class="usa-card__cta"
-                        >
-                          Call to action (retirement)
-                        </div>
-                        <svg
-                          class="carrot-two"
-                          fill="none"
-                          height="22"
-                          viewBox="0 0 13 22"
-                          width="13"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            clip-rule="evenodd"
-                            d="M3.18079 1.18074C2.79027 0.790216 2.1571 0.790215 1.76658 1.18074L0.706337 2.24098C0.316114 2.6312 0.315768 3.26377 0.705565 3.65442L7.33029 10.2936C7.71979 10.684 7.71979 11.3159 7.33029 11.7063L0.705566 18.3455C0.315768 18.7361 0.316113 19.3687 0.706336 19.7589L1.76658 20.8192C2.1571 21.2097 2.79027 21.2097 3.18079 20.8192L12.2929 11.7071C12.6834 11.3165 12.6834 10.6834 12.2929 10.2928L3.18079 1.18074Z"
-                            fill="#162E51"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </div>
-                    </a>
-                  </li>
-                </div>
-                <div>
-                  <li
-                    class="relative-benefit-card usa-card add-list-reset"
+                        Benefit finder: retirement
+                      </h3>
+                    </div>
+                    <div
+                      class="usa-card__body"
+                    >
+                      <p>
+                        Find out what financial, health care, and other benefits may be available as you enter this next phase of your life.
+                      </p>
+                    </div>
+                    <div
+                      class="usa-card__cta"
+                    >
+                      Call to action (retirement)
+                    </div>
+                    <svg
+                      class="carrot-two"
+                      fill="none"
+                      height="22"
+                      viewBox="0 0 13 22"
+                      width="13"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.18079 1.18074C2.79027 0.790216 2.1571 0.790215 1.76658 1.18074L0.706337 2.24098C0.316114 2.6312 0.315768 3.26377 0.705565 3.65442L7.33029 10.2936C7.71979 10.684 7.71979 11.3159 7.33029 11.7063L0.705566 18.3455C0.315768 18.7361 0.316113 19.3687 0.706336 19.7589L1.76658 20.8192C2.1571 21.2097 2.79027 21.2097 3.18079 20.8192L12.2929 11.7071C12.6834 11.3165 12.6834 10.6834 12.2929 10.2928L3.18079 1.18074Z"
+                        fill="#162E51"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </a>
+                </li>
+                <li
+                  class="relative-benefit-card tablet:grid-col-12 add-list-reset"
+                >
+                  <a
+                    class="usa-card__container"
+                    href="/benefit-finder/life_event/disability"
                   >
-                    <a
-                      href="/benefit-finder/life_event/disability"
+                    <div
+                      class="usa-card__header"
                     >
-                      <div
-                        class="usa-card__container"
+                      <h3
+                        class="usa-card__heading font-family-sans"
+                        id=""
                       >
-                        <div
-                          class="usa-card__header"
-                        >
-                          <h3
-                            class="usa-card__heading font-family-sans"
-                            id=""
-                          >
-                            Benefit finder: disability
-                          </h3>
-                        </div>
-                        <div
-                          class="usa-card__body"
-                        >
-                          <p>
-                            Whether you are newly disabled or have a lifelong challenge, assistance may be available, including financial help.
-                          </p>
-                        </div>
-                        <div
-                          class="usa-card__cta"
-                        >
-                          Call to action (disability)
-                        </div>
-                        <svg
-                          class="carrot-two"
-                          fill="none"
-                          height="22"
-                          viewBox="0 0 13 22"
-                          width="13"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            clip-rule="evenodd"
-                            d="M3.18079 1.18074C2.79027 0.790216 2.1571 0.790215 1.76658 1.18074L0.706337 2.24098C0.316114 2.6312 0.315768 3.26377 0.705565 3.65442L7.33029 10.2936C7.71979 10.684 7.71979 11.3159 7.33029 11.7063L0.705566 18.3455C0.315768 18.7361 0.316113 19.3687 0.706336 19.7589L1.76658 20.8192C2.1571 21.2097 2.79027 21.2097 3.18079 20.8192L12.2929 11.7071C12.6834 11.3165 12.6834 10.6834 12.2929 10.2928L3.18079 1.18074Z"
-                            fill="#162E51"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </div>
-                    </a>
-                  </li>
-                </div>
+                        Benefit finder: disability
+                      </h3>
+                    </div>
+                    <div
+                      class="usa-card__body"
+                    >
+                      <p>
+                        Whether you are newly disabled or have a lifelong challenge, assistance may be available, including financial help.
+                      </p>
+                    </div>
+                    <div
+                      class="usa-card__cta"
+                    >
+                      Call to action (disability)
+                    </div>
+                    <svg
+                      class="carrot-two"
+                      fill="none"
+                      height="22"
+                      viewBox="0 0 13 22"
+                      width="13"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.18079 1.18074C2.79027 0.790216 2.1571 0.790215 1.76658 1.18074L0.706337 2.24098C0.316114 2.6312 0.315768 3.26377 0.705565 3.65442L7.33029 10.2936C7.71979 10.684 7.71979 11.3159 7.33029 11.7063L0.705566 18.3455C0.315768 18.7361 0.316113 19.3687 0.706336 19.7589L1.76658 20.8192C2.1571 21.2097 2.79027 21.2097 3.18079 20.8192L12.2929 11.7071C12.6834 11.3165 12.6834 10.6834 12.2929 10.2928L3.18079 1.18074Z"
+                        fill="#162E51"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </a>
+                </li>
               </ul>
             </div>
             <div
@@ -10960,110 +10950,100 @@ exports[`loads window query scenario 2 1`] = `
                 More benefits
               </h3>
               <ul
-                class="add-list-reset"
+                class="usa-card-group"
               >
-                <div>
-                  <li
-                    class="relative-benefit-card usa-card add-list-reset"
+                <li
+                  class="relative-benefit-card tablet:grid-col-12 add-list-reset"
+                >
+                  <a
+                    class="usa-card__container"
+                    href="/benefit-finder/life_event/retirement"
                   >
-                    <a
-                      href="/benefit-finder/life_event/retirement"
+                    <div
+                      class="usa-card__header"
                     >
-                      <div
-                        class="usa-card__container"
+                      <h3
+                        class="usa-card__heading font-family-sans"
+                        id=""
                       >
-                        <div
-                          class="usa-card__header"
-                        >
-                          <h3
-                            class="usa-card__heading font-family-sans"
-                            id=""
-                          >
-                            Benefit finder: retirement
-                          </h3>
-                        </div>
-                        <div
-                          class="usa-card__body"
-                        >
-                          <p>
-                            Find out what financial, health care, and other benefits may be available as you enter this next phase of your life.
-                          </p>
-                        </div>
-                        <div
-                          class="usa-card__cta"
-                        >
-                          Call to action (retirement)
-                        </div>
-                        <svg
-                          class="carrot-two"
-                          fill="none"
-                          height="22"
-                          viewBox="0 0 13 22"
-                          width="13"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            clip-rule="evenodd"
-                            d="M3.18079 1.18074C2.79027 0.790216 2.1571 0.790215 1.76658 1.18074L0.706337 2.24098C0.316114 2.6312 0.315768 3.26377 0.705565 3.65442L7.33029 10.2936C7.71979 10.684 7.71979 11.3159 7.33029 11.7063L0.705566 18.3455C0.315768 18.7361 0.316113 19.3687 0.706336 19.7589L1.76658 20.8192C2.1571 21.2097 2.79027 21.2097 3.18079 20.8192L12.2929 11.7071C12.6834 11.3165 12.6834 10.6834 12.2929 10.2928L3.18079 1.18074Z"
-                            fill="#162E51"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </div>
-                    </a>
-                  </li>
-                </div>
-                <div>
-                  <li
-                    class="relative-benefit-card usa-card add-list-reset"
+                        Benefit finder: retirement
+                      </h3>
+                    </div>
+                    <div
+                      class="usa-card__body"
+                    >
+                      <p>
+                        Find out what financial, health care, and other benefits may be available as you enter this next phase of your life.
+                      </p>
+                    </div>
+                    <div
+                      class="usa-card__cta"
+                    >
+                      Call to action (retirement)
+                    </div>
+                    <svg
+                      class="carrot-two"
+                      fill="none"
+                      height="22"
+                      viewBox="0 0 13 22"
+                      width="13"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.18079 1.18074C2.79027 0.790216 2.1571 0.790215 1.76658 1.18074L0.706337 2.24098C0.316114 2.6312 0.315768 3.26377 0.705565 3.65442L7.33029 10.2936C7.71979 10.684 7.71979 11.3159 7.33029 11.7063L0.705566 18.3455C0.315768 18.7361 0.316113 19.3687 0.706336 19.7589L1.76658 20.8192C2.1571 21.2097 2.79027 21.2097 3.18079 20.8192L12.2929 11.7071C12.6834 11.3165 12.6834 10.6834 12.2929 10.2928L3.18079 1.18074Z"
+                        fill="#162E51"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </a>
+                </li>
+                <li
+                  class="relative-benefit-card tablet:grid-col-12 add-list-reset"
+                >
+                  <a
+                    class="usa-card__container"
+                    href="/benefit-finder/life_event/disability"
                   >
-                    <a
-                      href="/benefit-finder/life_event/disability"
+                    <div
+                      class="usa-card__header"
                     >
-                      <div
-                        class="usa-card__container"
+                      <h3
+                        class="usa-card__heading font-family-sans"
+                        id=""
                       >
-                        <div
-                          class="usa-card__header"
-                        >
-                          <h3
-                            class="usa-card__heading font-family-sans"
-                            id=""
-                          >
-                            Benefit finder: disability
-                          </h3>
-                        </div>
-                        <div
-                          class="usa-card__body"
-                        >
-                          <p>
-                            Whether you are newly disabled or have a lifelong challenge, assistance may be available, including financial help.
-                          </p>
-                        </div>
-                        <div
-                          class="usa-card__cta"
-                        >
-                          Call to action (disability)
-                        </div>
-                        <svg
-                          class="carrot-two"
-                          fill="none"
-                          height="22"
-                          viewBox="0 0 13 22"
-                          width="13"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            clip-rule="evenodd"
-                            d="M3.18079 1.18074C2.79027 0.790216 2.1571 0.790215 1.76658 1.18074L0.706337 2.24098C0.316114 2.6312 0.315768 3.26377 0.705565 3.65442L7.33029 10.2936C7.71979 10.684 7.71979 11.3159 7.33029 11.7063L0.705566 18.3455C0.315768 18.7361 0.316113 19.3687 0.706336 19.7589L1.76658 20.8192C2.1571 21.2097 2.79027 21.2097 3.18079 20.8192L12.2929 11.7071C12.6834 11.3165 12.6834 10.6834 12.2929 10.2928L3.18079 1.18074Z"
-                            fill="#162E51"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </div>
-                    </a>
-                  </li>
-                </div>
+                        Benefit finder: disability
+                      </h3>
+                    </div>
+                    <div
+                      class="usa-card__body"
+                    >
+                      <p>
+                        Whether you are newly disabled or have a lifelong challenge, assistance may be available, including financial help.
+                      </p>
+                    </div>
+                    <div
+                      class="usa-card__cta"
+                    >
+                      Call to action (disability)
+                    </div>
+                    <svg
+                      class="carrot-two"
+                      fill="none"
+                      height="22"
+                      viewBox="0 0 13 22"
+                      width="13"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.18079 1.18074C2.79027 0.790216 2.1571 0.790215 1.76658 1.18074L0.706337 2.24098C0.316114 2.6312 0.315768 3.26377 0.705565 3.65442L7.33029 10.2936C7.71979 10.684 7.71979 11.3159 7.33029 11.7063L0.705566 18.3455C0.315768 18.7361 0.316113 19.3687 0.706336 19.7589L1.76658 20.8192C2.1571 21.2097 2.79027 21.2097 3.18079 20.8192L12.2929 11.7071C12.6834 11.3165 12.6834 10.6834 12.2929 10.2928L3.18079 1.18074Z"
+                        fill="#162E51"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </a>
+                </li>
               </ul>
             </div>
             <div

--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.js.snap
@@ -119,6 +119,7 @@ exports[`loads intro 1`] = `
                     <div
                       class="usa-alert usa-alert--info no-background"
                       role="alert"
+                      tabindex="-1"
                     >
                       <div
                         class="usa-alert__body"
@@ -147,6 +148,7 @@ exports[`loads intro 1`] = `
                     <div
                       class="usa-alert usa-alert--info no-background"
                       role="alert"
+                      tabindex="-1"
                     >
                       <div
                         class="usa-alert__body"
@@ -169,6 +171,7 @@ exports[`loads intro 1`] = `
                     <div
                       class="usa-alert usa-alert--info no-background"
                       role="alert"
+                      tabindex="-1"
                     >
                       <div
                         class="usa-alert__body"
@@ -411,6 +414,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -571,6 +575,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -726,6 +731,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -886,6 +892,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -1042,6 +1049,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -1212,6 +1220,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -1377,6 +1386,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -1548,6 +1558,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -1714,6 +1725,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -1879,6 +1891,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -2044,6 +2057,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -2194,6 +2208,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -2360,6 +2375,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -2515,6 +2531,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -2675,6 +2692,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -2835,6 +2853,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -2986,6 +3005,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -3136,6 +3156,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -3296,6 +3317,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -3461,6 +3483,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -3636,6 +3659,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -3796,6 +3820,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -3957,6 +3982,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -4122,6 +4148,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -4297,6 +4324,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -4462,6 +4490,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -4632,6 +4661,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -4797,6 +4827,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -4968,6 +4999,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -5128,6 +5160,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -5288,6 +5321,7 @@ exports[`loads window query scenario 1 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -5705,6 +5739,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -5880,6 +5915,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -6050,6 +6086,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -6225,6 +6262,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -6394,6 +6432,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -6577,6 +6616,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -6734,6 +6774,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -6918,6 +6959,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -7097,6 +7139,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -7278,6 +7321,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -7458,6 +7502,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -7621,6 +7666,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -7803,6 +7849,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -7973,6 +8020,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -8124,6 +8172,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -8299,6 +8348,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -8452,6 +8502,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -8604,6 +8655,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -8779,6 +8831,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -8947,6 +9000,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -9138,6 +9192,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -9289,6 +9344,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -9454,6 +9510,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -9611,6 +9668,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -9792,6 +9850,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -9970,6 +10029,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -10155,6 +10215,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -10336,6 +10397,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -10524,6 +10586,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -10699,6 +10762,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"
@@ -10874,6 +10938,7 @@ exports[`loads window query scenario 2 1`] = `
                       <div
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
+                        tabindex="0"
                       >
                         <div
                           class="usa-alert__body"

--- a/benefit-finder/src/App/index.jsx
+++ b/benefit-finder/src/App/index.jsx
@@ -1,5 +1,5 @@
 import { useState, createContext, useEffect } from 'react'
-import { useHandleUnload } from '../shared/hooks/useHandleUnload'
+// import { useHandleUnload } from '../shared/hooks/useHandleUnload'
 import * as apiCalls from '../shared/api/apiCalls'
 import {
   Intro,
@@ -28,9 +28,6 @@ function App({ testAppContent, testQuery }) {
   const windowQuery = testQuery || window.location.search
   const hasQueryParams = windowQuery.includes(sharedToken)
   const isDraftMode = windowQuery.includes(draftToken)
-
-  const [hasData, setHasData] = useState(false)
-  useHandleUnload(hasData) // alert the user if they try to go back in browser
 
   /**
    * lazy load our data state.
@@ -144,7 +141,6 @@ function App({ testAppContent, testQuery }) {
                   ui={t}
                   modalOpen={modalOpen}
                   setModalOpen={setModalOpen}
-                  setHasData={setHasData}
                 />
               </Form>
             </div>

--- a/benefit-finder/src/shared/components/Alert/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Alert/__tests__/__snapshots__/index.spec.js.snap
@@ -4,6 +4,7 @@ exports[`Alert renders a match to the previous snapshot 1`] = `
 <div
   className=""
   role="alert"
+  tabIndex={0}
 >
   <div
     className="usa-alert__body"

--- a/benefit-finder/src/shared/components/Alert/index.jsx
+++ b/benefit-finder/src/shared/components/Alert/index.jsx
@@ -22,6 +22,7 @@ const Alert = ({
   description,
   error,
   noBackground,
+  tabIndex,
 }) => {
   const defaultClasses = error
     ? ['usa-alert', 'usa-alert--error', 'display-none']
@@ -32,6 +33,7 @@ const Alert = ({
       className={useHandleClassName({ className, defaultClasses })}
       role="alert"
       ref={alertFieldRef}
+      tabIndex={tabIndex || 0}
     >
       {children ? (
         <div className="usa-alert__body">

--- a/benefit-finder/src/shared/components/Card/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Card/__tests__/__snapshots__/index.spec.js.snap
@@ -4,46 +4,44 @@ exports[`Card renders a match to the previous snapshot 1`] = `
 <li
   className=""
 >
-  <a>
+  <a
+    className="usa-card__container"
+  >
     <div
-      className="usa-card__container"
+      className="usa-card__header"
     >
-      <div
-        className="usa-card__header"
-      >
-        <h3
-          className=""
-          id=""
-        />
-      </div>
-      <div
-        className="usa-card__body"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": undefined,
-          }
-        }
+      <h3
+        className=""
+        id=""
       />
-      <div
-        className="usa-card__cta"
-      />
-      <svg
-        className="carrot"
-        fill="#162E51"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M0 0h24v24H0z"
-          fill="none"
-        />
-        <path
-          d="M7 10l5 5 5-5z"
-        />
-      </svg>
     </div>
+    <div
+      className="usa-card__body"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": undefined,
+        }
+      }
+    />
+    <div
+      className="usa-card__cta"
+    />
+    <svg
+      className="carrot"
+      fill="#162E51"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M0 0h24v24H0z"
+        fill="none"
+      />
+      <path
+        d="M7 10l5 5 5-5z"
+      />
+    </svg>
   </a>
 </li>
 `;

--- a/benefit-finder/src/shared/components/Card/_index.scss
+++ b/benefit-finder/src/shared/components/Card/_index.scss
@@ -20,11 +20,11 @@
       text-decoration: none;
     }
 
-    a:hover .usa-card__container {
+    a:hover.usa-card__container {
       background-color: color.$dark-sky;
     }
 
-    a:active .usa-card__container {
+    a:active.usa-card__container {
       border: 2px solid color.$pop-blue;
     }
 

--- a/benefit-finder/src/shared/components/Card/index.jsx
+++ b/benefit-finder/src/shared/components/Card/index.jsx
@@ -16,7 +16,7 @@ import './_index.scss'
  * @return {html} returns a semantic html list element
  */
 const Card = ({ className, title, body, cta, href, noCarrot, carrotType }) => {
-  const defaultClasses = ['usa-card add-list-reset']
+  const defaultClasses = ['add-list-reset']
   const handleCarrot =
     noCarrot === true ? null : <Carrot color="#162E51" type={carrotType} />
 
@@ -28,20 +28,18 @@ const Card = ({ className, title, body, cta, href, noCarrot, carrotType }) => {
       })}
       key={`${title}`}
     >
-      <a href={href}>
-        <div className="usa-card__container">
-          <div className="usa-card__header">
-            <Heading className="usa-card__heading" headingLevel={3}>
-              {title}
-            </Heading>
-          </div>
-          <div
-            className="usa-card__body"
-            dangerouslySetInnerHTML={createMarkup(body)}
-          />
-          <div className="usa-card__cta">{cta}</div>
-          {handleCarrot}
+      <a className="usa-card__container" href={href}>
+        <div className="usa-card__header">
+          <Heading className="usa-card__heading" headingLevel={3}>
+            {title}
+          </Heading>
         </div>
+        <div
+          className="usa-card__body"
+          dangerouslySetInnerHTML={createMarkup(body)}
+        />
+        <div className="usa-card__cta">{cta}</div>
+        {handleCarrot}
       </a>
     </li>
   )

--- a/benefit-finder/src/shared/components/Date/_index.scss
+++ b/benefit-finder/src/shared/components/Date/_index.scss
@@ -23,8 +23,10 @@
     @include p;
 
     &.usa-input--error {
-      outline: 4px solid color.$alert-red !important;
-      border: none;
+      padding: 9.75px;
+      height: initial;
+      border-radius: 3px;
+      border-color: color.$alert-red !important;
     }
   }
 

--- a/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.js.snap
@@ -108,6 +108,7 @@ exports[`Intro renders a match to the previous snapshot 1`] = `
               <div
                 className=""
                 role="alert"
+                tabIndex={-1}
               >
                 <div
                   className="usa-alert__body"
@@ -133,6 +134,7 @@ exports[`Intro renders a match to the previous snapshot 1`] = `
               <div
                 className=""
                 role="alert"
+                tabIndex={-1}
               >
                 <div
                   className="usa-alert__body"
@@ -158,6 +160,7 @@ exports[`Intro renders a match to the previous snapshot 1`] = `
               <div
                 className=""
                 role="alert"
+                tabIndex={-1}
               >
                 <div
                   className="usa-alert__body"

--- a/benefit-finder/src/shared/components/Intro/index.jsx
+++ b/benefit-finder/src/shared/components/Intro/index.jsx
@@ -23,6 +23,8 @@ const Intro = ({ data, ui, setStep, step }) => {
   const { timeEstimate, title, summary } = data
   const { heading, timeIndicator, steps, notices, button } = ui
 
+  const handleStep = () => setStep(step + 1) && document.activeElement.blur()
+
   return (
     data && (
       <div className="intro">
@@ -57,7 +59,7 @@ const Intro = ({ data, ui, setStep, step }) => {
             <div className="line-sperator" />
           </div>
           <div className="cta-wrapper">
-            <Button onClick={() => setStep(step + 1)}>{button}</Button>
+            <Button onClick={() => handleStep()}>{button}</Button>
           </div>
         </div>
       </div>

--- a/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
@@ -66,6 +66,7 @@ Array [
         <div
           className=""
           role="alert"
+          tabIndex={0}
         >
           <div
             className="usa-alert__body"

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import createMarkup from '../../utils/createMarkup'
 import { dateInputValidation } from '../../utils/inputValidation'
+import { useHandleUnload } from '../../hooks/useHandleUnload'
 import * as apiCalls from '../../api/apiCalls'
 import {
   Alert,
@@ -39,7 +40,6 @@ const LifeEventSection = ({
   ui,
   modalOpen,
   setModalOpen,
-  setHasData,
 }) => {
   // const currentStep = step - 1
   // state
@@ -48,6 +48,8 @@ const LifeEventSection = ({
   const [values, setValues] = useState([])
   const [hasError, setHasError] = useState([])
   const classError = 'usa-input--error'
+  const [hasData, setHasData] = useState(false)
+  useHandleUnload(hasData) // alert the user if they try to go back in browser
 
   // desctructure data
   const {
@@ -88,6 +90,7 @@ const LifeEventSection = ({
   const handleAlert = () => {
     // remove the display class from the alert
     alertFieldRef.current.classList.remove('display-none')
+    alertFieldRef.current.focus()
     // add to all the collected error fields an error class
     values.forEach(field => {
       field.classList.contains('required-field') &&
@@ -162,6 +165,7 @@ const LifeEventSection = ({
       // set complete step usa-step-indicator__segment--complete
       setStep(step + updateIndex)
       setStepData(updateIndex)
+      document.activeElement.blur()
     }
   }
 
@@ -173,6 +177,7 @@ const LifeEventSection = ({
    */
   const handleBackUpdate = updateIndex => {
     setStep(step + updateIndex)
+    document.activeElement.blur()
   }
 
   /**

--- a/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.js.snap
@@ -13,6 +13,7 @@ exports[`NoticesList renders a match to the previous snapshot 1`] = `
       <div
         className=""
         role="alert"
+        tabIndex={-1}
       >
         <div
           className="usa-alert__body"
@@ -38,6 +39,7 @@ exports[`NoticesList renders a match to the previous snapshot 1`] = `
       <div
         className=""
         role="alert"
+        tabIndex={-1}
       >
         <div
           className="usa-alert__body"
@@ -63,6 +65,7 @@ exports[`NoticesList renders a match to the previous snapshot 1`] = `
       <div
         className=""
         role="alert"
+        tabIndex={-1}
       >
         <div
           className="usa-alert__body"

--- a/benefit-finder/src/shared/components/NoticesList/index.jsx
+++ b/benefit-finder/src/shared/components/NoticesList/index.jsx
@@ -23,7 +23,7 @@ const NoticesList = ({ data }) => {
       data.data.map((item, i) => {
         return (
           <li className="notice" key={`notice-${i}`}>
-            <Alert noBackground>
+            <Alert noBackground tabIndex={-1}>
               <div
                 className="notice-item"
                 dangerouslySetInnerHTML={createMarkup(item.notice)}

--- a/benefit-finder/src/shared/components/RelativeBenefitList/index.jsx
+++ b/benefit-finder/src/shared/components/RelativeBenefitList/index.jsx
@@ -5,6 +5,7 @@ import { Card } from '../index'
  * a functional component that renders a list of usa-card component(s)
  * @component
  * @param {array} data - passed benefits data
+ * @param {number} carrotType - determines display type
  * @return {html} returns a semantic html unorderd list element
  */
 const RelativeBenefitList = ({ data, carrotType }) => {
@@ -32,7 +33,7 @@ const RelativeBenefitList = ({ data, carrotType }) => {
 
 RelativeBenefitList.propTypes = {
   data: PropTypes.array,
-  dataKey: PropTypes.string,
+  carrotType: PropTypes.number,
 }
 
 export default RelativeBenefitList

--- a/benefit-finder/src/shared/components/RelativeBenefitList/index.jsx
+++ b/benefit-finder/src/shared/components/RelativeBenefitList/index.jsx
@@ -5,23 +5,24 @@ import { Card } from '../index'
  * a functional component that renders a list of usa-card component(s)
  * @component
  * @param {array} data - passed benefits data
- * @param {string} dataKey - key to reference
  * @return {html} returns a semantic html unorderd list element
  */
-const RelativeBenefitList = ({ data }) => {
+const RelativeBenefitList = ({ data, carrotType }) => {
   return (
     <ul className="usa-card-group">
       {data &&
         data.map((item, i) => {
-          const { title, link, cta } = item
+          const { title, link, cta, body } = item.lifeEvent
 
           return (
             <Card
-              className="relative-benefit-card tablet:grid-col-6"
+              className="relative-benefit-card tablet:grid-col-12"
               title={title}
               cta={cta}
               href={link}
+              body={body}
               key={`${title}-${i}`}
+              carrotType={carrotType}
             />
           )
         })}

--- a/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.js.snap
@@ -335,6 +335,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -510,6 +511,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -680,6 +682,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -855,6 +858,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -1024,6 +1028,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -1207,6 +1212,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -1364,6 +1370,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -1548,6 +1555,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -1727,6 +1735,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -1908,6 +1917,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -2088,6 +2098,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -2251,6 +2262,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -2433,6 +2445,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -2603,6 +2616,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -2754,6 +2768,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -2929,6 +2944,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -3082,6 +3098,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -3234,6 +3251,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -3409,6 +3427,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -3577,6 +3596,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -3768,6 +3788,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -3919,6 +3940,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -4084,6 +4106,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -4241,6 +4264,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -4422,6 +4446,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -4600,6 +4625,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -4785,6 +4811,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -4966,6 +4993,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -5154,6 +5182,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -5329,6 +5358,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"
@@ -5504,6 +5534,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     <div
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
+                      tabindex="0"
                     >
                       <div
                         class="usa-alert__body"

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -7,9 +7,9 @@ import {
   EmailButton,
   Heading,
   StepBackLink,
-  Card,
   Chevron,
   ShareButton,
+  RelativeBenefitList,
 } from '../index'
 import createMarkup from '../../utils/createMarkup'
 import './_index.scss'
@@ -132,32 +132,10 @@ const ResultsView = ({
                 {resultsRelativeBenefits?.heading}
               </Heading>
               {relevantBenefits && (
-                <ul className="add-list-reset">
-                  {relevantBenefits[0] && (
-                    <div key="benefit-card-one">
-                      <Card
-                        className="relative-benefit-card"
-                        title={`${relevantBenefits[0].lifeEvent.title}`}
-                        body={`${relevantBenefits[0].lifeEvent.body}`}
-                        cta={`${relevantBenefits[0].lifeEvent.cta}`}
-                        href={`${relevantBenefits[0].lifeEvent.link}`}
-                        carrotType={2}
-                      ></Card>
-                    </div>
-                  )}
-                  {relevantBenefits[1] && (
-                    <div key="benefit-card-two">
-                      <Card
-                        className="relative-benefit-card"
-                        title={`${relevantBenefits[1].lifeEvent.title}`}
-                        body={`${relevantBenefits[1].lifeEvent.body}`}
-                        cta={`${relevantBenefits[1].lifeEvent.cta}`}
-                        href={`${relevantBenefits[1].lifeEvent.link}`}
-                        carrotType={2}
-                      ></Card>
-                    </div>
-                  )}
-                </ul>
+                <RelativeBenefitList
+                  data={relevantBenefits}
+                  carrotType={2}
+                ></RelativeBenefitList>
               )}
             </div>
           )}

--- a/benefit-finder/src/shared/components/Select/_index.scss
+++ b/benefit-finder/src/shared/components/Select/_index.scss
@@ -10,8 +10,10 @@
     }
 
     &.usa-input--error {
-      outline: 4px solid color.$alert-red !important;
-      border: none;
+      padding: 8px 32px 8px 8px;
+      height: initial;
+      border-radius: 3px;
+      border-color: color.$alert-red !important;
     }
   }
 }


### PR DESCRIPTION
## PR Summary

This focuses the alert element on error when present.

## Related Github Issue

- fixes #758

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [ ] proxy data from main sandbox env
- [ ] tab through without entering values to the fields until you get to "continue", select
- [ ] confirm first alert is focused
- [ ] tab through errors and correct them using the keyboard
- [ ] tab through and select 'continue'
- [ ] confirm you are on the second step


https://github.com/GSA/px-benefit-finder/assets/37077057/4dd4ad3b-f6c5-4a19-982f-58b2aed7fc0b


