### PR TITLE
force focus on skip-to-nav, req by a11y

### DIFF
--- a/benefit-finder/.storybook/preview-body.html
+++ b/benefit-finder/.storybook/preview-body.html
@@ -1,2 +1,11 @@
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P2F6CBK&gtm_auth=OSvlSHtoCEGb9-yqEDaj5Q&gtm_preview=env-112&gtm_cookies_win=x"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<noscript
+  ><iframe
+    src="https://www.googletagmanager.com/ns.html?id=GTM-P2F6CBK&gtm_auth=OSvlSHtoCEGb9-yqEDaj5Q&gtm_preview=env-112&gtm_cookies_win=x"
+    height="0"
+    width="0"
+    style="display: none; visibility: hidden"
+  ></iframe
+></noscript>
+<a href="#skip-to-h1" class="usa-skipnav usa-sr-only focusable">
+  Skip to main content
+</a>

--- a/benefit-finder/public/index.html
+++ b/benefit-finder/public/index.html
@@ -31,6 +31,9 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+    <a href="#skip-to-h1" class="usa-skipnav usa-sr-only focusable">
+      Skip to main content
+    </a>
     <div
       id="benefit-finder"
       json-data-file-path="/s3/files/benefit-finder/api/life-event/death.json"

--- a/benefit-finder/src/App/index.jsx
+++ b/benefit-finder/src/App/index.jsx
@@ -1,4 +1,4 @@
-import { useState, createContext, useEffect } from 'react'
+import { useState, createContext, useEffect, useRef } from 'react'
 // import { useHandleUnload } from '../shared/hooks/useHandleUnload'
 import * as apiCalls from '../shared/api/apiCalls'
 import {
@@ -28,6 +28,8 @@ function App({ testAppContent, testQuery }) {
   const windowQuery = testQuery || window.location.search
   const hasQueryParams = windowQuery.includes(sharedToken)
   const isDraftMode = windowQuery.includes(draftToken)
+  const tabbableElements = document.getElementsByClassName('usa-skipnav')
+  const skipNav = useRef(tabbableElements[0])
 
   /**
    * lazy load our data state.
@@ -117,6 +119,7 @@ function App({ testAppContent, testQuery }) {
               handleStepBack={() => {
                 setVerifyStep(false)
                 setViewResults(false)
+                skipNav && skipNav.current.focus()
               }}
             />
           ) : verifyStep === false ? (
@@ -133,10 +136,12 @@ function App({ testAppContent, testQuery }) {
                   setVerifyStep={() => {
                     setVerifyStep(true)
                     setModalOpen(false)
+                    skipNav && skipNav.current.focus()
                   }}
                   setViewResults={() => {
                     setViewResults(true)
                     setModalOpen(false)
+                    skipNav && skipNav.current.focus()
                   }}
                   ui={t}
                   modalOpen={modalOpen}
@@ -149,9 +154,11 @@ function App({ testAppContent, testQuery }) {
               handleStepBack={() => {
                 setVerifyStep(false)
                 setViewResults(false)
+                skipNav && skipNav.current.focus()
               }}
               handleStepForward={() => {
                 setViewResults(true)
+                skipNav && skipNav.current.focus()
               }}
               ui={t}
               data={stepDataArray}

--- a/benefit-finder/src/App/index.jsx
+++ b/benefit-finder/src/App/index.jsx
@@ -1,5 +1,5 @@
-import { useState, createContext, useEffect, useRef } from 'react'
-// import { useHandleUnload } from '../shared/hooks/useHandleUnload'
+import { useState, createContext, useEffect } from 'react'
+import { useResetElement } from '../shared/hooks/useResetElement'
 import * as apiCalls from '../shared/api/apiCalls'
 import {
   Intro,
@@ -28,8 +28,8 @@ function App({ testAppContent, testQuery }) {
   const windowQuery = testQuery || window.location.search
   const hasQueryParams = windowQuery.includes(sharedToken)
   const isDraftMode = windowQuery.includes(draftToken)
-  const tabbableElements = document.getElementsByClassName('usa-skipnav')
-  const skipNav = useRef(tabbableElements[0])
+  // create our reset element
+  useResetElement()
 
   /**
    * lazy load our data state.
@@ -119,7 +119,6 @@ function App({ testAppContent, testQuery }) {
               handleStepBack={() => {
                 setVerifyStep(false)
                 setViewResults(false)
-                skipNav && skipNav.current.focus()
               }}
             />
           ) : verifyStep === false ? (
@@ -136,12 +135,10 @@ function App({ testAppContent, testQuery }) {
                   setVerifyStep={() => {
                     setVerifyStep(true)
                     setModalOpen(false)
-                    skipNav && skipNav.current.focus()
                   }}
                   setViewResults={() => {
                     setViewResults(true)
                     setModalOpen(false)
-                    skipNav && skipNav.current.focus()
                   }}
                   ui={t}
                   modalOpen={modalOpen}
@@ -154,11 +151,9 @@ function App({ testAppContent, testQuery }) {
               handleStepBack={() => {
                 setVerifyStep(false)
                 setViewResults(false)
-                skipNav && skipNav.current.focus()
               }}
               handleStepForward={() => {
                 setViewResults(true)
-                skipNav && skipNav.current.focus()
               }}
               ui={t}
               data={stepDataArray}

--- a/benefit-finder/src/App/index.jsx
+++ b/benefit-finder/src/App/index.jsx
@@ -1,5 +1,5 @@
 import { useState, createContext, useEffect } from 'react'
-import { useResetElement } from '../shared/hooks/useResetElement'
+import { useResetElement } from '../shared/hooks'
 import * as apiCalls from '../shared/api/apiCalls'
 import {
   Intro,

--- a/benefit-finder/src/shared/components/Intro/index.jsx
+++ b/benefit-finder/src/shared/components/Intro/index.jsx
@@ -1,4 +1,5 @@
-import { useRef } from 'react'
+// import { useRef } from 'react'
+import { useResetElement } from '../../hooks/useResetElement'
 import PropTypes from 'prop-types'
 import {
   Button,
@@ -23,12 +24,12 @@ import './_index.scss'
 const Intro = ({ data, ui, setStep, step }) => {
   const { timeEstimate, title, summary } = data
   const { heading, timeIndicator, steps, notices, button } = ui
-  const tabbableElements = document.getElementsByClassName('usa-skipnav')
-  const skipNav = useRef(tabbableElements[0])
+  // const resetElements = document.querySelectorAll('[tabindex="-1"]')
+  const resetElement = useResetElement()
 
   const handleStep = () => {
     setStep(step + 1)
-    skipNav && skipNav.current.focus()
+    resetElement.current.focus()
   }
 
   return (

--- a/benefit-finder/src/shared/components/Intro/index.jsx
+++ b/benefit-finder/src/shared/components/Intro/index.jsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import PropTypes from 'prop-types'
 import {
   Button,
@@ -22,8 +23,13 @@ import './_index.scss'
 const Intro = ({ data, ui, setStep, step }) => {
   const { timeEstimate, title, summary } = data
   const { heading, timeIndicator, steps, notices, button } = ui
+  const tabbableElements = document.getElementsByClassName('usa-skipnav')
+  const skipNav = useRef(tabbableElements[0])
 
-  const handleStep = () => setStep(step + 1) && document.activeElement.blur()
+  const handleStep = () => {
+    setStep(step + 1)
+    skipNav && skipNav.current.focus()
+  }
 
   return (
     data && (

--- a/benefit-finder/src/shared/components/Intro/index.jsx
+++ b/benefit-finder/src/shared/components/Intro/index.jsx
@@ -1,5 +1,4 @@
-// import { useRef } from 'react'
-import { useResetElement } from '../../hooks/useResetElement'
+import { useResetElement } from '../../hooks'
 import PropTypes from 'prop-types'
 import {
   Button,

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -50,6 +50,8 @@ const LifeEventSection = ({
   const classError = 'usa-input--error'
   const [hasData, setHasData] = useState(false)
   useHandleUnload(hasData) // alert the user if they try to go back in browser
+  const tabbableElements = document.getElementsByClassName('usa-skipnav')
+  const skipNav = useRef(tabbableElements[0])
 
   // desctructure data
   const {
@@ -165,7 +167,7 @@ const LifeEventSection = ({
       // set complete step usa-step-indicator__segment--complete
       setStep(step + updateIndex)
       setStepData(updateIndex)
-      document.activeElement.blur()
+      skipNav && skipNav.current.focus()
     }
   }
 
@@ -177,7 +179,7 @@ const LifeEventSection = ({
    */
   const handleBackUpdate = updateIndex => {
     setStep(step + updateIndex)
-    document.activeElement.blur()
+    skipNav && skipNav.current.focus()
   }
 
   /**

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import createMarkup from '../../utils/createMarkup'
 import { dateInputValidation } from '../../utils/inputValidation'
 import { useHandleUnload } from '../../hooks/useHandleUnload'
+import { useResetElement } from '../../hooks/useResetElement'
 import * as apiCalls from '../../api/apiCalls'
 import {
   Alert,
@@ -50,8 +51,11 @@ const LifeEventSection = ({
   const classError = 'usa-input--error'
   const [hasData, setHasData] = useState(false)
   useHandleUnload(hasData) // alert the user if they try to go back in browser
-  const tabbableElements = document.getElementsByClassName('usa-skipnav')
-  const skipNav = useRef(tabbableElements[0])
+  const resetElement = useResetElement()
+
+  useEffect(() => {
+    resetElement.current?.focus()
+  }, [resetElement])
 
   // desctructure data
   const {
@@ -167,7 +171,7 @@ const LifeEventSection = ({
       // set complete step usa-step-indicator__segment--complete
       setStep(step + updateIndex)
       setStepData(updateIndex)
-      skipNav && skipNav.current.focus()
+      resetElement && resetElement.current.focus()
     }
   }
 
@@ -179,7 +183,7 @@ const LifeEventSection = ({
    */
   const handleBackUpdate = updateIndex => {
     setStep(step + updateIndex)
-    skipNav && skipNav.current.focus()
+    resetElement.current.focus()
   }
 
   /**

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import createMarkup from '../../utils/createMarkup'
 import { dateInputValidation } from '../../utils/inputValidation'
 import { useHandleUnload } from '../../hooks/useHandleUnload'
-import { useResetElement } from '../../hooks/useResetElement'
+import { useResetElement } from '../../hooks'
 import * as apiCalls from '../../api/apiCalls'
 import {
   Alert,

--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -77,6 +77,7 @@ const Modal = ({
   /**
    * a function that triggers the modal to a closed state
    * @function
+   * @param {ref} triggerRef - passed to button for triggering modal
    */
   const handleCloseModal = triggerRef => {
     // focus the trigger if it is still in the DOM

--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -62,30 +62,13 @@ const Modal = ({
   navItemTwoLabel,
   navItemTwoFunction,
   handleCheckRequriedFields,
-  completed,
   modalOpen,
   setModalOpen,
 }) => {
   // state
   const triggerRef = useRef(null)
 
-  /**
-   * a function that checks for errors and then triggers the modal to open state
-   * @function
-   */
-  // const handleOpenModal = useCallback(() => {
-  //   completed === true
-  //     ? setModalOpen(true)
-  //     : handleCheckRequriedFields() === true && setModalOpen
-  //   if (completed === true) {
-  //     setModalOpen(true)
-  //   }
-  // }, [completed, handleCheckRequriedFields, setModalOpen])
-
   const handleOpenModal = () => {
-    // completed === true
-    //   ? setModalOpen(true)
-    //   : handleCheckRequriedFields() === true && setModalOpen
     if (handleCheckRequriedFields() === true) {
       setModalOpen(true)
     }

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useResetElement } from '../../hooks/useResetElement'
+import { useResetElement } from '../../hooks'
 import * as apiCalls from '../../api/apiCalls'
 import PropTypes from 'prop-types'
 import {

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -1,4 +1,5 @@
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState } from 'react'
+import { useResetElement } from '../../hooks/useResetElement'
 import * as apiCalls from '../../api/apiCalls'
 import PropTypes from 'prop-types'
 import {
@@ -41,13 +42,16 @@ const ResultsView = ({
   } = ui
 
   const [notQualifiedView, setNotQualifiedView] = useState(false)
-  const tabbableElements = document.getElementsByClassName('usa-skipnav')
-  const skipNav = useRef(tabbableElements[0])
+  const resetElement = useResetElement()
+
+  useEffect(() => {
+    resetElement.current?.focus()
+  }, [resetElement])
 
   const handleViewToggle = () => {
     setNotQualifiedView(!notQualifiedView)
     window.scrollTo(0, 0)
-    skipNav && skipNav.current.focus()
+    resetElement.current.focus()
   }
 
   useEffect(() => {
@@ -72,7 +76,10 @@ const ResultsView = ({
       <div className="grid-container">
         <div className="result-view-details">
           {notQualifiedView === false ? (
-            <StepBackLink setCurrent={handleStepBack}>
+            <StepBackLink
+              onClick={() => resetElement.current.focus()}
+              setCurrent={handleStepBack}
+            >
               {stepBackLink}
             </StepBackLink>
           ) : (

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import * as apiCalls from '../../api/apiCalls'
 import PropTypes from 'prop-types'
 import {
@@ -41,10 +41,13 @@ const ResultsView = ({
   } = ui
 
   const [notQualifiedView, setNotQualifiedView] = useState(false)
+  const tabbableElements = document.getElementsByClassName('usa-skipnav')
+  const skipNav = useRef(tabbableElements[0])
 
   const handleViewToggle = () => {
     setNotQualifiedView(!notQualifiedView)
     window.scrollTo(0, 0)
+    skipNav && skipNav.current.focus()
   }
 
   useEffect(() => {
@@ -75,7 +78,7 @@ const ResultsView = ({
           ) : (
             <Button
               className="step-back-link"
-              onClick={() => setNotQualifiedView(false)}
+              onClick={() => handleViewToggle()}
               unstyled
             >
               {stepBackLink}

--- a/benefit-finder/src/shared/components/StepBackLink/index.jsx
+++ b/benefit-finder/src/shared/components/StepBackLink/index.jsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useResetElement } from '../../hooks/useResetElement'
 import PropTypes from 'prop-types'
 import { Button } from '../index'
 import './_index.scss'
@@ -12,12 +12,11 @@ import './_index.scss'
  * @return {html} returns markup for a usa unstyled button
  */
 const StepBackLink = ({ children, setCurrent, currentIndex }) => {
-  const tabbableElements = document.getElementsByClassName('usa-skipnav')
-  const skipNav = useRef(tabbableElements[0])
+  const resetElement = useResetElement()
 
   const handleStep = () => {
     setCurrent(currentIndex)
-    skipNav && skipNav.current.focus()
+    resetElement.current.focus()
   }
 
   return (

--- a/benefit-finder/src/shared/components/StepBackLink/index.jsx
+++ b/benefit-finder/src/shared/components/StepBackLink/index.jsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import PropTypes from 'prop-types'
 import { Button } from '../index'
 import './_index.scss'
@@ -11,12 +12,16 @@ import './_index.scss'
  * @return {html} returns markup for a usa unstyled button
  */
 const StepBackLink = ({ children, setCurrent, currentIndex }) => {
+  const tabbableElements = document.getElementsByClassName('usa-skipnav')
+  const skipNav = useRef(tabbableElements[0])
+
+  const handleStep = () => {
+    setCurrent(currentIndex)
+    skipNav && skipNav.current.focus()
+  }
+
   return (
-    <Button
-      className="step-back-link"
-      unstyled
-      onClick={() => setCurrent(currentIndex)}
-    >
+    <Button className="step-back-link" unstyled onClick={() => handleStep()}>
       {children || 'Back'}
     </Button>
   )

--- a/benefit-finder/src/shared/components/StepBackLink/index.jsx
+++ b/benefit-finder/src/shared/components/StepBackLink/index.jsx
@@ -1,4 +1,4 @@
-import { useResetElement } from '../../hooks/useResetElement'
+import { useResetElement } from '../../hooks'
 import PropTypes from 'prop-types'
 import { Button } from '../index'
 import './_index.scss'

--- a/benefit-finder/src/shared/hooks/index.js
+++ b/benefit-finder/src/shared/hooks/index.js
@@ -1,0 +1,1 @@
+export { default as useResetElement } from './useResetElement'

--- a/benefit-finder/src/shared/hooks/useResetElement.js
+++ b/benefit-finder/src/shared/hooks/useResetElement.js
@@ -1,0 +1,22 @@
+import { useRef, useEffect } from 'react'
+
+export const useResetElement = () => {
+  /**
+   * a hook to set and get the reset element to focus
+   * @function
+   * @return {ref} returns ref element
+   */
+
+  // create a sr-only element to set focus on that is not in the default tab order
+  useEffect(() => {
+    if (document.getElementById('index-reset') === null) {
+      document.body.insertAdjacentHTML(
+        'beforebegin',
+        '<span tabIndex="-1" id="index-reset" class="a11y-sr-only"/>'
+      )
+    }
+  }, [])
+
+  const resetElement = useRef(document.getElementById('index-reset'))
+  return resetElement
+}

--- a/benefit-finder/src/shared/hooks/useResetElement/index.js
+++ b/benefit-finder/src/shared/hooks/useResetElement/index.js
@@ -1,18 +1,29 @@
 import { useRef, useEffect } from 'react'
 
-export const useResetElement = () => {
+const useResetElement = () => {
   /**
    * a hook to set and get the reset element to focus
    * @function
-   * @return {ref} returns ref element
+   * @return {React.ref} returns ref element
    */
+
+  // example useage
+  // assign hook to const
+
+  // const resetElement = useResetElement()
+
+  // foucus element as needed in an effect or synthetic event
+
+  // useEffect(() => {
+  //   resetElement.current?.focus()
+  // }, [resetElement])
 
   // create a sr-only element to set focus on that is not in the default tab order
   useEffect(() => {
     if (document.getElementById('index-reset') === null) {
       document.body.insertAdjacentHTML(
         'beforebegin',
-        '<span tabIndex="-1" id="index-reset" class="a11y-sr-only"/>'
+        '<span tabIndex="-1" id="index-reset" data-testid="index-reset" class="a11y-sr-only"/>'
       )
     }
   }, [])
@@ -20,3 +31,5 @@ export const useResetElement = () => {
   const resetElement = useRef(document.getElementById('index-reset'))
   return resetElement
 }
+
+export default useResetElement


### PR DESCRIPTION
## PR Summary

This works to force focus on the `skip to main content` link on each view change, with exception to modal.

## Related Github Issue

- fixes #757 

## Detailed Testing steps

- [ ] proxy data from main
- [ ] go through application using keyboard navigation
- [ ] ensure that each view change sets focus on the `skip to main content` link as demonstrated below


https://github.com/GSA/px-benefit-finder/assets/37077057/03ffcbfb-9bfd-49b8-ac3e-f0faf8f4485d


