### PR TITLE
Update bf tome static - Remove draft json from static site

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             sed -i "s#^    image: .*cms-latest*#    image: $DOCKERREPO:$IMAGE_TAG#" manifest.yml
             sed -i "s#^    - secauthsecrets##" manifest.yml
             sed -i "s#- name: cms#- name: benefit-finder-cms-${CIRCLE_BRANCH}#" manifest.yml
-            sed -i "s#^  memory: 1.5G#  memory: 512M#" manifest.yml
+            sed -i "s#^  memory: 1.5G#  memory: 1G#" manifest.yml
             sed -i "s#^    - database#    - benefit-finder-mysql-${CIRCLE_BRANCH}#" manifest.yml
             sed -i "s#^    - secrets#    - benefit-finder-secrets-${CIRCLE_BRANCH}#" manifest.yml
             sed -i "s#^    - storage#    - benefit-finder-storage-${CIRCLE_BRANCH}#" manifest.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,14 +436,14 @@ workflows:
           filters:
             branches:
               only: 
-                - 792-update-bf-tome-static
+                - dev
       - static-site-generation-dev:
           requires:
             - build_and_deploy_dev
           filters:
             branches:
               only: 
-                - 792-update-bf-tome-static
+                - dev
       - build_and_deploy_main:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,7 +396,7 @@ jobs:
           command: |
             export CIRCLE_BRANCH="dev"
             # cf run-task benefit-finder-cms-${CIRCLE_BRANCH} --command "pwd && ls -l && sh /var/www/scripts/static-generation.sh" --name "bf-static-${CIRCLE_BRANCH}"  -k "2G" -m ${TOME_MEMORY}
-            cf run-task benefit-finder-cms-${CIRCLE_BRANCH} --command "pwd && ls -l && sh /var/www/scripts/bf-tome-run.sh" --name "bf-static-${CIRCLE_BRANCH}"  -k "2G" -m ${TOME_MEMORY}
+            cf run-task benefit-finder-cms-${CIRCLE_BRANCH} --command "pwd && ls -l && sh /var/www/scripts/bf-tome-run.sh" --name "bf-static-${CIRCLE_BRANCH}"  -k "2G" -m "1G"
 
   static-site-generation-main:
     docker:
@@ -436,14 +436,14 @@ workflows:
           filters:
             branches:
               only: 
-                - dev
+                - 792-update-bf-tome-static
       - static-site-generation-dev:
           requires:
             - build_and_deploy_dev
           filters:
             branches:
               only: 
-                - dev
+                - 792-update-bf-tome-static
       - build_and_deploy_main:
           filters:
             branches:

--- a/bin/cloudgov/bf-tome-sync.sh
+++ b/bin/cloudgov/bf-tome-sync.sh
@@ -76,6 +76,7 @@ echo "Removing unwanted files ... "
 rm -rf $RENDER_DIR/jsonapi/ 2>&1 | tee -a $TOMELOG
 rm -rf $RENDER_DIR/node/ 2>&1 | tee -a $TOMELOG
 rm -rf $RENDER_DIR/es/node/ 2>&1 | tee -a $TOMELOG
+rm -rf $RENDER_DIR/benefit-finder/api/draft/life-event/ 2>&1 | tee -a $TOMELOG
 
 # # duplicate the logic used by the bootstrap script to find the static site hostname
 # WWW_HOST=$(echo $VCAP_APPLICATION | jq -r '.["application_uris"][]' | grep 'www\.usa\.gov' | head -n 1)


### PR DESCRIPTION
## PR Summary

This PR updates `bf-tome-sync` script to remove draft Json data files from the static site build. Also, it changes the Memory configuration for the `benefit-finder-dev` cms app and task to use as Russell has increased our Memory quota in the `benefit-finder-dev` space.

## Related Github Issue

- fixes #792 

## Detailed Testing steps

You may check the `benefit-finder-dev` static site on the below link:
https://bf-static-dev.bxdev.net/
