### PR TITLE
806 add canonical url link

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_app/usagov_benefit_finder_page/usagov_benefit_finder_page.module
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_app/usagov_benefit_finder_page/usagov_benefit_finder_page.module
@@ -42,11 +42,11 @@ function usagov_benefit_finder_page_page_attachments_alter(array &$page) {
   if ($node && $node->bundle() == "bears_life_event") {
     if (\Drupal::routeMatch()->getRouteName() == 'entity.node.canonical') {
       $page['#attached']['library'][] = 'usagov_benefit_finder_page/benefit_finder_app';
-      $url=$node->toUrl('canonical')->setAbsolute(TRUE);
-      $page['#attached']['html_head_link'][]=[
+      $url = $node->toUrl('canonical')->setAbsolute(TRUE);
+      $page['#attached']['html_head_link'][] = [
         [
-          'rel'=>'canonical',
-          'href'=>$url->toString(),
+          'rel' => 'canonical',
+          'href' => $url->toString(),
         ],
       ];
     }

--- a/usagov_benefit_finder/modules/usagov_benefit_finder_app/usagov_benefit_finder_page/usagov_benefit_finder_page.module
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_app/usagov_benefit_finder_page/usagov_benefit_finder_page.module
@@ -42,6 +42,13 @@ function usagov_benefit_finder_page_page_attachments_alter(array &$page) {
   if ($node && $node->bundle() == "bears_life_event") {
     if (\Drupal::routeMatch()->getRouteName() == 'entity.node.canonical') {
       $page['#attached']['library'][] = 'usagov_benefit_finder_page/benefit_finder_app';
+      $url=$node->toUrl('canonical')->setAbsolute(TRUE);
+      $page['#attached']['html_head_link'][]=[
+        [
+          'rel'=>'canonical',
+          'href'=>$url->toString(),
+        ],
+      ];
     }
   }
 }


### PR DESCRIPTION
## PR Summary

This work add canonical URL link in life event page.

## Related Github Issue

- fixes #806 

## Detailed Testing steps

Navigate to life event page
Inspect HTML head.
It includes canonical URL link. 
For example, in local life event death, the HTML head following canonical URL link.
`<link rel="canonical" href="http://localhost/benefit-finder/death">`
