### PR TITLE
include fragment keys so that they are unique in a list

### DIFF
--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import createMarkup from '../../utils/createMarkup'
 import { dateInputValidation } from '../../utils/inputValidation'
@@ -285,7 +285,9 @@ const LifeEventSection = ({
                       // case select
                       //
                       //
-                      <>
+                      <Fragment
+                        key={`select-${item.fieldset.criteriaKey}+${index}`}
+                      >
                         <Fieldset
                           key={`select-${item.fieldset.criteriaKey}-${index}`}
                           legend={item.fieldset.legend}
@@ -325,7 +327,7 @@ const LifeEventSection = ({
                           })}
                         </Fieldset>
                         {children || null}
-                      </>
+                      </Fragment>
                     ) : item.fieldset.inputs[0].inputCriteria.type ===
                       'Radio' ? (
                       //
@@ -333,7 +335,9 @@ const LifeEventSection = ({
                       // case radio
                       //
                       //
-                      <>
+                      <Fragment
+                        key={`radio-${item.fieldset.criteriaKey}+${index}`}
+                      >
                         <Fieldset
                           key={`radio-${item.fieldset.criteriaKey}-${index}`}
                           legend={item.fieldset.legend}
@@ -384,7 +388,7 @@ const LifeEventSection = ({
                           })}
                         </Fieldset>
                         {children || null}
-                      </>
+                      </Fragment>
                     ) : item.fieldset.inputs[0].inputCriteria.type ===
                       'Date' ? (
                       //
@@ -392,7 +396,9 @@ const LifeEventSection = ({
                       // case date
                       //
                       //
-                      <>
+                      <Fragment
+                        key={`date-${item.fieldset.criteriaKey}+${index}`}
+                      >
                         <Fieldset
                           key={`date-${item.fieldset.criteriaKey}-${index}`}
                           legend={item.fieldset.legend}
@@ -431,7 +437,7 @@ const LifeEventSection = ({
                           })}
                         </Fieldset>
                         {children || null}
-                      </>
+                      </Fragment>
                     ) : null
 
                   const parentElement = ({ item, i }) =>


### PR DESCRIPTION
## PR Summary

A missing `<Fragment />` key was causing a console log warning on unique keys in lists.

```sh
  ● Console

    console.error
      Warning: Each child in a list should have a unique "key" prop.
      
      Check the render method of `LifeEventSection`. See https://reactjs.org/link/warning-keys for more information.
          at LifeEventSection (/Users/geoffreyqueen/Projects/px-benefit-finder/benefit-finder/src/shared/components/LifeEventSection/index.jsx:34:3)

      262 |             />
      263 |             {currentData && (
    > 264 |               <div id="benefit-section">
          |               ^
      265 |                 <Alert
      266 |                   alertFieldRef={alertFieldRef}
      267 |                   heading={ui.alertBanner.heading}

```
This addresses issues in https://github.com/orgs/GSA/projects/48/views/16?filterQuery=sprint%3A%40current+assignee%3A%22scottqueen-bixal%22&pane=issue&itemId=49580387

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [x] pull changes locally
- [x] `cd benefit-finder`
- [x]  `npm install`
- [x]  `CI=true npm run test`
- [x]  ensure test console warning does not appear
