### PR TITLE
A11y fixes

### DIFF
--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.js.snap
@@ -123,6 +123,7 @@ exports[`loads intro 1`] = `
                     class="notice"
                   >
                     <div
+                      aria-live="polite"
                       class="usa-alert usa-alert--info no-background"
                       role="alert"
                       tabindex="-1"
@@ -152,6 +153,7 @@ exports[`loads intro 1`] = `
                     class="notice"
                   >
                     <div
+                      aria-live="polite"
                       class="usa-alert usa-alert--info no-background"
                       role="alert"
                       tabindex="-1"
@@ -175,6 +177,7 @@ exports[`loads intro 1`] = `
                     class="notice"
                   >
                     <div
+                      aria-live="polite"
                       class="usa-alert usa-alert--info no-background"
                       role="alert"
                       tabindex="-1"
@@ -424,6 +427,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -585,6 +589,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -741,6 +746,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -902,6 +908,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -1059,6 +1066,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -1230,6 +1238,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -1396,6 +1405,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -1568,6 +1578,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -1735,6 +1746,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -1901,6 +1913,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -2067,6 +2080,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -2218,6 +2232,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -2385,6 +2400,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -2541,6 +2557,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -2702,6 +2719,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -2863,6 +2881,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -3015,6 +3034,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -3166,6 +3186,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -3327,6 +3348,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -3493,6 +3515,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -3669,6 +3692,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -3830,6 +3854,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -3992,6 +4017,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -4158,6 +4184,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -4334,6 +4361,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -4500,6 +4528,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -4671,6 +4700,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -4837,6 +4867,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -5009,6 +5040,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -5170,6 +5202,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -5331,6 +5364,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -5755,6 +5789,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -5931,6 +5966,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -6102,6 +6138,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -6278,6 +6315,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -6448,6 +6486,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -6632,6 +6671,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -6790,6 +6830,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -6975,6 +7016,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -7155,6 +7197,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -7337,6 +7380,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -7518,6 +7562,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -7682,6 +7727,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -7865,6 +7911,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -8036,6 +8083,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -8188,6 +8236,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -8364,6 +8413,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -8518,6 +8568,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -8671,6 +8722,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -8847,6 +8899,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -9016,6 +9069,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -9208,6 +9262,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -9360,6 +9415,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -9526,6 +9582,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -9684,6 +9741,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -9866,6 +9924,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -10045,6 +10104,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -10231,6 +10291,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -10413,6 +10474,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -10602,6 +10664,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -10778,6 +10841,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"
@@ -10954,6 +11018,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-live="polite"
                         class="benefit-alert usa-alert usa-alert--info "
                         role="alert"
                         tabindex="0"

--- a/benefit-finder/src/shared/components/Alert/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Alert/__tests__/__snapshots__/index.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Alert renders a match to the previous snapshot 1`] = `
 <div
+  aria-live="polite"
   className=""
   role="alert"
   tabIndex={0}

--- a/benefit-finder/src/shared/components/Alert/index.jsx
+++ b/benefit-finder/src/shared/components/Alert/index.jsx
@@ -34,6 +34,8 @@ const Alert = ({
       role="alert"
       ref={alertFieldRef}
       tabIndex={tabIndex || 0}
+      aria-live="polite"
+      aria-hidden={error}
     >
       {children ? (
         <div className="usa-alert__body">

--- a/benefit-finder/src/shared/components/Date/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Date/__tests__/__snapshots__/index.spec.js.snap
@@ -22,6 +22,7 @@ exports[`Date renders a match to the previous snapshot 1`] = `
     </div>
     <select
       aria-describedby="month-description-undefined"
+      aria-invalid={false}
       className="usa-select "
       id="date_of_birth_month-undefined"
       name="date_of_birth_month-undefined"
@@ -113,6 +114,7 @@ exports[`Date renders a match to the previous snapshot 1`] = `
     </div>
     <input
       aria-describedby="day-description-undefined"
+      aria-invalid={false}
       className="usa-input "
       id="date_of_birth_day-undefined"
       inputMode="numeric"
@@ -138,6 +140,7 @@ exports[`Date renders a match to the previous snapshot 1`] = `
     </div>
     <input
       aria-describedby="year-description-undefined"
+      aria-invalid={false}
       className="usa-input "
       id="date_of_birth_year-undefined"
       inputMode="numeric"

--- a/benefit-finder/src/shared/components/Date/index.jsx
+++ b/benefit-finder/src/shared/components/Date/index.jsx
@@ -10,7 +10,7 @@ import './_index.scss'
  * @param {object} value - inherited state values
  * @return {Date} returns a tandard format Date ie 1995-12-17T03:24:00
  */
-const Date = ({ onChange, value, required, ui, id, valid }) => {
+const Date = ({ onChange, value, required, ui, id, invalid }) => {
   const { date, select } = ui
   const { labelDay, labelMonth, labelYear, monthOptions, alert } = date
   const { dateDefaultValue } = select
@@ -19,7 +19,7 @@ const Date = ({ onChange, value, required, ui, id, valid }) => {
 
   return (
     <div id={`usa-memorable-date-${id}`} className="usa-memorable-date">
-      {valid === true && (
+      {invalid === true && (
         <Alert
           className="date-alert"
           heading={ui.alertBanner.heading}
@@ -45,6 +45,7 @@ const Date = ({ onChange, value, required, ui, id, valid }) => {
           required={required === 'TRUE'}
           value={(value && value.month) || ''}
           onChange={onChange}
+          aria-invalid={invalid === true}
         >
           <option value="" key="default" disabled>
             {dateDefaultValue}
@@ -72,6 +73,7 @@ const Date = ({ onChange, value, required, ui, id, valid }) => {
           value={(value && value.day) || ''}
           onChange={onChange}
           required={required === 'TRUE'}
+          aria-invalid={invalid === true}
         />
       </div>
       <div className="usa-form-group usa-form-group--year">
@@ -90,6 +92,7 @@ const Date = ({ onChange, value, required, ui, id, valid }) => {
           value={(value && value.year) || ''}
           onChange={onChange}
           required={required === 'TRUE'}
+          aria-invalid={invalid === true}
         />
       </div>
     </div>

--- a/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.js.snap
@@ -106,6 +106,7 @@ exports[`Intro renders a match to the previous snapshot 1`] = `
               className="notice"
             >
               <div
+                aria-live="polite"
                 className=""
                 role="alert"
                 tabIndex={-1}
@@ -132,6 +133,7 @@ exports[`Intro renders a match to the previous snapshot 1`] = `
               className="notice"
             >
               <div
+                aria-live="polite"
                 className=""
                 role="alert"
                 tabIndex={-1}
@@ -158,6 +160,7 @@ exports[`Intro renders a match to the previous snapshot 1`] = `
               className="notice"
             >
               <div
+                aria-live="polite"
                 className=""
                 role="alert"
                 tabIndex={-1}

--- a/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
@@ -64,6 +64,8 @@ Array [
         id="benefit-section"
       >
         <div
+          aria-hidden={true}
+          aria-live="polite"
           className=""
           role="alert"
           tabIndex={0}
@@ -132,6 +134,7 @@ Array [
                 </div>
                 <select
                   aria-describedby="month-description-applicant_date_of_birth_0"
+                  aria-invalid={false}
                   className="usa-select required-field"
                   id="date_of_birth_month-applicant_date_of_birth_0"
                   name="date_of_birth_month-applicant_date_of_birth_0"
@@ -224,6 +227,7 @@ Array [
                 </div>
                 <input
                   aria-describedby="day-description-applicant_date_of_birth_0"
+                  aria-invalid={false}
                   className="usa-input required-field"
                   id="date_of_birth_day-applicant_date_of_birth_0"
                   inputMode="numeric"
@@ -250,6 +254,7 @@ Array [
                 </div>
                 <input
                   aria-describedby="year-description-applicant_date_of_birth_0"
+                  aria-invalid={false}
                   className="usa-input required-field"
                   id="date_of_birth_year-applicant_date_of_birth_0"
                   inputMode="numeric"
@@ -284,6 +289,7 @@ Array [
               Select
             </label>
             <select
+              aria-invalid={false}
               className=""
               id="applicant_relationship_to_the_deceased_0"
               name="applicant_relationship_to_the_deceased_0"
@@ -347,6 +353,7 @@ Array [
               Select
             </label>
             <select
+              aria-invalid={false}
               className=""
               id="applicant_marital_status_0"
               name="applicant_marital_status_0"
@@ -392,6 +399,7 @@ Array [
             Are you a U.S. citizen or eligible non-citizen?
           </legend>
           <div
+            aria-invalid={0}
             className="radio-group"
           >
             <div
@@ -443,6 +451,7 @@ Array [
             Are you caring for a child of the deceased who is disabled or under the age of 16?
           </legend>
           <div
+            aria-invalid={0}
             className="radio-group"
           >
             <div
@@ -494,6 +503,7 @@ Array [
             Did you pay for funeral or burial expenses?
           </legend>
           <div
+            aria-invalid={0}
             className="radio-group"
           >
             <div

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -75,7 +75,7 @@ const LifeEventSection = ({
   }
 
   const handleFieldAlerts = () => {
-    setHasError(document.querySelectorAll(`.${classError}`))
+    setHasError(Array.from(document.querySelectorAll(`.${classError}`)))
   }
 
   /**
@@ -152,6 +152,24 @@ const LifeEventSection = ({
       ? handleSuccess()
       : handleAlert()
   }
+
+  /**
+   * a function that updates our step count and set our data index
+   * @function
+   * @param {array} hasError - collection of error elements
+   * @param {event} event - passed in change handler
+   */
+  const updateAlertArray = (hasError, event) => {
+    hasError.forEach((element, index) => {
+      if (element.id.includes(event.target.id)) {
+        hasError.splice(index, 1)
+      }
+    })
+
+    if (hasError.length === 0) {
+      alertFieldRef.current.classList.add('display-none')
+    }
+  }
   /**
    *
    * end alert
@@ -199,7 +217,9 @@ const LifeEventSection = ({
       setCurrentData,
       event.target.value
     )
+    updateAlertArray(hasError, event)
   }
+  // console.log(hasError)
 
   /**
    * a function that handles the current selected value of our radio
@@ -210,7 +230,7 @@ const LifeEventSection = ({
   const handleDateChanged = (event, criteriaKey) => {
     event.target.value.length > 0 && setHasData(true)
     window.history.replaceState({}, '', window.location.pathname)
-    dateInputValidation(event) === true &&
+    if (dateInputValidation(event) === true) {
       apiCalls.PUT.DataDate(
         criteriaKey,
         currentData,
@@ -218,6 +238,8 @@ const LifeEventSection = ({
         event.target.value,
         event.target.id
       )
+      updateAlertArray(hasError, event)
+    }
   }
 
   const handleDateRequired = (values, item) => {
@@ -321,7 +343,7 @@ const LifeEventSection = ({
                                   }
                                   invalid={
                                     hasError.length &&
-                                    Array.from(hasError)
+                                    hasError
                                       .map(item => item.id.includes(fieldSetId))
                                       .includes(true)
                                   }
@@ -364,7 +386,7 @@ const LifeEventSection = ({
                                 key={fieldSetId}
                                 aria-invalid={
                                   hasError.length &&
-                                  Array.from(hasError)
+                                  hasError
                                     .map(item => item.id.includes(fieldSetId))
                                     .includes(true)
                                 }
@@ -422,6 +444,7 @@ const LifeEventSection = ({
                         >
                           {item.fieldset.inputs.map((input, index) => {
                             const fieldSetId = `${item.fieldset.criteriaKey}_${index}`
+
                             return (
                               <div key={fieldSetId}>
                                 <Date
@@ -440,7 +463,7 @@ const LifeEventSection = ({
                                   id={fieldSetId}
                                   invalid={
                                     hasError.length &&
-                                    Array.from(hasError)
+                                    hasError
                                       .map(item => item.id.includes(fieldSetId))
                                       .includes(true)
                                   }

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -319,6 +319,12 @@ const LifeEventSection = ({
                                       item.fieldset.criteriaKey
                                     )
                                   }
+                                  invalid={
+                                    hasError.length &&
+                                    Array.from(hasError)
+                                      .map(item => item.id.includes(fieldSetId))
+                                      .includes(true)
+                                  }
                                 />
                               </div>
                             )
@@ -353,7 +359,16 @@ const LifeEventSection = ({
                             )
 
                             return (
-                              <div className="radio-group" key={fieldSetId}>
+                              <div
+                                className="radio-group"
+                                key={fieldSetId}
+                                aria-invalid={
+                                  hasError.length &&
+                                  Array.from(hasError)
+                                    .map(item => item.id.includes(fieldSetId))
+                                    .includes(true)
+                                }
+                              >
                                 {/* map the options */}
                                 {input.inputCriteria.values.map(
                                   (option, index) => {
@@ -423,7 +438,7 @@ const LifeEventSection = ({
                                   }
                                   ui={ui}
                                   id={fieldSetId}
-                                  valid={
+                                  invalid={
                                     hasError.length &&
                                     Array.from(hasError)
                                       .map(item => item.id.includes(fieldSetId))

--- a/benefit-finder/src/shared/components/Modal/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Modal/__tests__/__snapshots__/index.spec.js.snap
@@ -9,6 +9,7 @@ exports[`Modal renders a match to the previous snapshot 1`] = `
     className=""
     onClick={[Function]}
     onKeyDown={[Function]}
+    role="button"
     tabIndex="0"
   />
 </div>

--- a/benefit-finder/src/shared/components/Modal/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Modal/__tests__/__snapshots__/index.spec.js.snap
@@ -5,6 +5,7 @@ exports[`Modal renders a match to the previous snapshot 1`] = `
   className="benefit-modal-group"
 >
   <a
+    aria-label="Continue button"
     className=""
     onClick={[Function]}
     onKeyDown={[Function]}

--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -111,6 +111,7 @@ const Modal = ({
         tabIndex="0"
         triggerRef={triggerRef}
         aria-label="Continue button"
+        role="button"
       >
         {triggerLabel}
       </ObfuscatedLink>

--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -176,6 +176,7 @@ const Modal = ({
       >
         <button
           type="button"
+          aria-label="Close button"
           className="modal-button"
           onClick={() => handleCloseModal(triggerRef)}
         >

--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -110,6 +110,7 @@ const Modal = ({
         noCarrot
         tabIndex="0"
         triggerRef={triggerRef}
+        aria-label="Continue button"
       >
         {triggerLabel}
       </ObfuscatedLink>

--- a/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.js.snap
@@ -11,6 +11,7 @@ exports[`NoticesList renders a match to the previous snapshot 1`] = `
       className="notice"
     >
       <div
+        aria-live="polite"
         className=""
         role="alert"
         tabIndex={-1}
@@ -37,6 +38,7 @@ exports[`NoticesList renders a match to the previous snapshot 1`] = `
       className="notice"
     >
       <div
+        aria-live="polite"
         className=""
         role="alert"
         tabIndex={-1}
@@ -63,6 +65,7 @@ exports[`NoticesList renders a match to the previous snapshot 1`] = `
       className="notice"
     >
       <div
+        aria-live="polite"
         className=""
         role="alert"
         tabIndex={-1}

--- a/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.js.snap
@@ -345,6 +345,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -521,6 +522,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -692,6 +694,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -868,6 +871,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -1038,6 +1042,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -1222,6 +1227,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -1380,6 +1386,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -1565,6 +1572,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -1745,6 +1753,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -1927,6 +1936,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -2108,6 +2118,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -2272,6 +2283,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -2455,6 +2467,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -2626,6 +2639,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -2778,6 +2792,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -2954,6 +2969,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -3108,6 +3124,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -3261,6 +3278,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -3437,6 +3455,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -3606,6 +3625,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -3798,6 +3818,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -3950,6 +3971,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -4116,6 +4138,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -4274,6 +4297,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -4456,6 +4480,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -4635,6 +4660,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -4821,6 +4847,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -5003,6 +5030,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -5192,6 +5220,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -5368,6 +5397,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"
@@ -5544,6 +5574,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-live="polite"
                       class="benefit-alert usa-alert usa-alert--info "
                       role="alert"
                       tabindex="0"

--- a/benefit-finder/src/shared/components/Select/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Select/__tests__/__snapshots__/index.spec.js.snap
@@ -8,6 +8,7 @@ Array [
     Dropdown Label
   </label>,
   <select
+    aria-invalid={false}
     className=""
     required={false}
     value=""

--- a/benefit-finder/src/shared/components/Select/index.jsx
+++ b/benefit-finder/src/shared/components/Select/index.jsx
@@ -13,6 +13,7 @@ import './_index.scss'
  * @param {function} onChange - The inherited onChange handler
  * @param {object} ui - The inherited object for ui translations
  * @param {string} className - inherited class string
+ * @param {boolean} invalid - state of validity passed from handler
  * @return {html} returns a semantic html select element with options
  */
 function Select({
@@ -24,6 +25,7 @@ function Select({
   required,
   ui,
   className,
+  invalid,
 }) {
   const { labelSelect, defaultValue } = ui
   const handleRequired = required === 'TRUE' ? ['required-field'] : ''
@@ -59,6 +61,7 @@ function Select({
         onChange={onChange}
         value={selected || ''}
         required={required === 'TRUE'}
+        aria-invalid={invalid === true}
       >
         <option value="" key="default" disabled>
           {defaultValue}


### PR DESCRIPTION
## PR Summary

This works to update and improve a11y for alerts and clarify aria announcements for certain elements in the stepped form

## Related Github Issue

- fixes #817 
- fixes #810
- fixes #818 

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [x] activate voiceover

- fixes #817 
- [x] navigate to modal step
- [x] tab to close button, should announce `Close button`


https://github.com/GSA/px-benefit-finder/assets/37077057/7289a39c-ccce-4d59-a271-8dc434e06399



- fixes #810

- [ ] tab through the form, for  the "Continue" button that triggers the modal, it should announce "Continue button"

https://github.com/GSA/px-benefit-finder/assets/37077057/255f58d2-a02e-41eb-ae8f-fefb3b0910d7



- fixes #818 

- [x] tab navigate to inital step of form
- [x] confirm it does not announce error status
- [x] tab navigate to initial DOB question, confirm it does not announce "invalid"
- [x] tab navigate to continue button, enter to trigger error status state
- [x] tab navigate to initial DOB question, confirm it now _does_ announce "invalid"
- [x] include values for each of the three inputs, confirm the inputs no longer have error indication, error message, and no longer announce "invalid"

activity should follow behavior similar to recording

https://github.com/GSA/px-benefit-finder/assets/37077057/7f511113-407e-42cc-a474-452a9c27f226


