### PR TITLE
849 validate benefit eligibility criteria acceptable value

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
@@ -5,6 +5,9 @@
  * Module contains functions related to usagov_benefit_finder_content.
  */
 
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\Entity\Node;
+
 /**
  * Implements hook_form_alter().
  */
@@ -25,5 +28,74 @@ function usagov_benefit_finder_content_form_alter(&$form, &$form_state, $form_id
       }
       $i++;
     } while ($i > 0);
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * @param array $form
+ *   Form array.
+ * @param FormStateInterface $form_state
+ *   Form state object.
+ */
+function usagov_benefit_finder_content_form_node_bears_benefit_form_alter(array &$form, FormStateInterface $form_state) {
+  $form['#validate'][] = 'usagov_benefit_finder_content_node_bears_benefit_edit_form_validate';
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * @param array $form
+ *   Form array.
+ * @param FormStateInterface $form_state
+ *   Form state object.
+ */
+function usagov_benefit_finder_content_form_node_bears_benefit_edit_form_alter(array &$form, FormStateInterface $form_state) {
+  $form['#validate'][] = 'usagov_benefit_finder_content_node_bears_benefit_edit_form_validate';
+}
+
+/**
+ * Validates benefit edit form benefit eligibility acceptable values.
+ *
+ * @param array $form
+ *   Form array.
+ * @param FormStateInterface $form_state
+ *   Form state object.
+ */
+function usagov_benefit_finder_content_node_bears_benefit_edit_form_validate(array $form, FormStateInterface $form_state) {
+  $errors = [];
+  $error_count = 0;
+
+  $eligibilities = $form_state->getValue('field_b_eligibility');
+  foreach ($eligibilities as $eligibility) {
+    $criteria_nid = $eligibility['subform']['field_b_criteria_key'][0]['target_id'];
+    if (empty($criteria_nid)) {
+      continue;
+    }
+    $acceptable_values = array_column($eligibility['subform']['field_b_acceptable_values'], 'value');
+
+    $criteria = Node::load($criteria_nid);
+    $criteria_title = $criteria->get('title')->value;
+    $criteria_type = $criteria->get('field_b_type')->getValue()[0]['value'];
+    $criteria_values = array_column($criteria->get('field_b_values')->getValue(), 'value');
+
+    if (!array_filter($acceptable_values)) {
+      $errors[] = t("Criteria \"$criteria_title\" acceptable values is empty.");
+    }
+
+    if (in_array($criteria_type, ['Boolean', 'Radio', 'Select'])) {
+      foreach ($acceptable_values as $value) {
+        if (!empty($value) && !in_array($value, $criteria_values)) {
+          $errors[] = t("Criteria \"$criteria_title\" acceptable value \"$value\" is not an option value.");
+        }
+      }
+    }
+  }
+
+  if (!empty($errors)) {
+    foreach ($errors as $error) {
+      $form_state->setErrorByName((string) ++$error_count, $error);
+    }
   }
 }


### PR DESCRIPTION
## PR Summary

This PR adds validation of benefit add and edit form. 
It validates the eligibility criteria acceptable values field

- validate the acceptable values field is not empty
- validate all the acceptable values are in the array of criteria option values

## Related Github Issue

- fixes #849 

## Detailed Testing steps

http://localhost/admin/content?combine=COVID&type=bears_benefit&status=All&langcode=en
Go to benefit "COVID-19 funeral assistance" edit page.

Test 1: Test acceptable values field empty
Make acceptable values field empty.
Click "Save".
<img width="600" alt="image" src="https://github.com/GSA/px-benefit-finder/assets/88853916/d6df78f1-2b16-4527-8cb0-c9f74329737b">
You get following error and cannot save.
<img width="400" alt="image" src="https://github.com/GSA/px-benefit-finder/assets/88853916/7b7bca00-7a33-4110-b27a-6ea8451ebcf6">

Test 2: Test acceptable value is not an option value of criteria
Input acceptable value "Unsure".
<img width="600" alt="image" src="https://github.com/GSA/px-benefit-finder/assets/88853916/ace05cdf-0b62-4ff0-9b70-b95fac88007e">
You get following error and cannot save.
<img width="400" alt="image" src="https://github.com/GSA/px-benefit-finder/assets/88853916/2248c120-2f35-4c04-8679-8b3b4aa6aef7">

