### PR TITLE
includes green check for key eligible criteria list

### DIFF
--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
@@ -5743,6 +5743,23 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Applicant's relationship to the deceased is: spouse, child, parent, or other family member
                           </li>
                         </ul>
@@ -5920,6 +5937,23 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your relationship to the deceased is: spouse, child, parent, or other family member
                           </li>
                         </ul>
@@ -6097,6 +6131,23 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your relationship to the deceased is: spouse, child, parent, or other family member
                           </li>
                         </ul>
@@ -6269,6 +6320,23 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your relationship to the deceased is: spouse
                           </li>
                         </ul>
@@ -6801,30 +6869,115 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_died_of_COVID"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             The deceased died due to COVID-19
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_death_location_is_US"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             The deceased died in the U.S.
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_date_of_death"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             The deceased died after May 20th, 2020
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_citizen_status"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             You are a U.S. citizen or eligible non-citizen
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_paid_funeral_expenses"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             You paid for funeral or burial expenses and were not reimbursed
                           </li>
                         </ul>
@@ -7328,12 +7481,46 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_marital_status"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Marital status: unmarried or widowed
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Applicant's relationship to the deceased: spouse
                           </li>
                         </ul>
@@ -7511,6 +7698,23 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your relationship to the deceased is: spouse or child
                           </li>
                         </ul>
@@ -7859,12 +8063,46 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_marital_status"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your marital status is widowed
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your relationship to the deceased is: spouse
                           </li>
                         </ul>
@@ -8042,6 +8280,23 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your relationship to the deceased is: spouse, child, parent, or other family member
                           </li>
                         </ul>
@@ -8214,18 +8469,69 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_paid_into_SS"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             The deceased worked and paid Social Security taxes
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_citizen_status"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             You are a U.S. citizen or eligible non-citizen
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your relationship to the deceased is: spouse or child
                           </li>
                         </ul>
@@ -8380,6 +8686,23 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your relationship to the deceased is: spouse, child, parent, or other family member
                           </li>
                         </ul>
@@ -8558,6 +8881,23 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your relationship to the deceased is: spouse, child, parent, or other family member
                           </li>
                         </ul>
@@ -8712,6 +9052,23 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your relationship to the deceased is: spouse or child
                           </li>
                         </ul>
@@ -8866,6 +9223,23 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your relationship to the deceased is: spouse or child
                           </li>
                         </ul>
@@ -9043,12 +9417,46 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_paid_into_SS"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             The deceased worked and paid Social Security taxes
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_citizen_status"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             You are a U.S. citizen or eligible non-citizen
                           </li>
                         </ul>
@@ -9213,12 +9621,46 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_paid_into_SS"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             The deceased worked and paid Social Security taxes
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_citizen_status"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             You are a U.S. citizen or eligible non-citizen
                           </li>
                         </ul>
@@ -9405,24 +9847,92 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_paid_into_SS"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             The deceased worked and paid Social Security taxes
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_marital_status"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your marital status is unmarried or widowed
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_citizen_status"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             You are a US citizen or eligible non-citizen
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_care_for_child"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             You are caring for a child of someone who is retired, has a disability, or has died, and the child is disabled or under the age of 16
                           </li>
                         </ul>
@@ -9560,18 +10070,69 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_paid_into_SS"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             The deceased worked and paid Social Security taxes
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_date_of_birth"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             You are over 62 years
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_citizen_status"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             You are a US citizen or eligible non-citizen
                           </li>
                         </ul>
@@ -9725,30 +10286,115 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_paid_into_SS"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             The deceased worked and paid Social Security taxes
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_date_of_birth"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             You are over 60 years
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_marital_status"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your marital status is widowed or divorced
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_citizen_status"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             You are a US citizen or eligible non-citizen
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your relationship to the deceased is: spouse
                           </li>
                         </ul>
@@ -9885,30 +10531,115 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_paid_into_SS"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             The deceased worked and paid Social Security taxes
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_date_of_birth"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             You are over 50 years
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_marital_status"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your marital status is widowed or divorced
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_citizen_status"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             You are a US citizen or eligible non-citizen
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your relationship to the deceased is: spouse
                           </li>
                         </ul>
@@ -10248,6 +10979,23 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_date_of_birth"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             You are under 18 years
                           </li>
                         </ul>
@@ -10435,12 +11183,46 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_marital_status"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your marital status is unmarried or widowed
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your relationship to the deceased is: spouse
                           </li>
                         </ul>
@@ -10619,12 +11401,46 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your relationship to the deceased is: spouse, child, parent, or other family member
                           </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_paid_funeral_expenses"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             You paid for funeral or burial expenses
                           </li>
                         </ul>
@@ -10807,6 +11623,23 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your relationship to the deceased is: spouse, child, parent, or other family member
                           </li>
                         </ul>
@@ -10984,6 +11817,23 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
+                            <div>
+                              <svg
+                                class="bf-checkmark--green"
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 24 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                  fill="#009831"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                             Your relationship to the deceased is: spouse, child, parent, or other family member
                           </li>
                         </ul>

--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
@@ -5743,7 +5743,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -5937,7 +5939,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -6131,7 +6135,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -6320,7 +6326,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -6869,7 +6877,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_died_of_COVID"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -6892,7 +6902,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_death_location_is_US"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -6915,7 +6927,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_date_of_death"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -6938,7 +6952,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_citizen_status"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -6961,7 +6977,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_paid_funeral_expenses"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -7481,7 +7499,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_marital_status"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -7504,7 +7524,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -7698,7 +7720,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -8063,7 +8087,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_marital_status"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -8086,7 +8112,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -8280,7 +8308,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -8469,7 +8499,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_paid_into_SS"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -8492,7 +8524,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_citizen_status"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -8515,7 +8549,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -8686,7 +8722,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -8881,7 +8919,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -9052,7 +9092,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -9223,7 +9265,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -9417,7 +9461,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_paid_into_SS"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -9440,7 +9486,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_citizen_status"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -9621,7 +9669,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_paid_into_SS"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -9644,7 +9694,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_citizen_status"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -9847,7 +9899,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_paid_into_SS"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -9870,7 +9924,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_marital_status"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -9893,7 +9949,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_citizen_status"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -9916,7 +9974,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_care_for_child"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -10070,7 +10130,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_paid_into_SS"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -10093,7 +10155,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_date_of_birth"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -10116,7 +10180,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_citizen_status"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -10286,7 +10352,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_paid_into_SS"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -10309,7 +10377,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_date_of_birth"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -10332,7 +10402,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_marital_status"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -10355,7 +10427,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_citizen_status"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -10378,7 +10452,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -10531,7 +10607,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="deceased_paid_into_SS"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -10554,7 +10632,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_date_of_birth"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -10577,7 +10657,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_marital_status"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -10600,7 +10682,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_citizen_status"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -10623,7 +10707,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -10979,7 +11065,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_date_of_birth"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -11183,7 +11271,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_marital_status"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -11206,7 +11296,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -11401,7 +11493,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -11424,7 +11518,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_paid_funeral_expenses"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -11623,7 +11719,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"
@@ -11817,7 +11915,9 @@ exports[`loads window query scenario 2 1`] = `
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                             data-testid="applicant_relationship_to_the_deceased"
                           >
-                            <div>
+                            <div
+                              aria-hidden="true"
+                            >
                               <svg
                                 class="bf-checkmark--green"
                                 fill="none"

--- a/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/_index.scss
+++ b/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/_index.scss
@@ -28,6 +28,13 @@
         padding: space.$space-md space.$space-lg;
         border: 0.5px solid color.$pop-blue;
         background-color: color.$sky;
+        display: flex;
+        flex-wrap: nowrap;
+
+        .bf-checkmark--green {
+          height: 100%;
+          margin-right: space.$space-lg;
+        }
       }
 
       li.usa-list {

--- a/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/index.jsx
+++ b/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/index.jsx
@@ -60,7 +60,7 @@ const KeyElegibilityCrieriaList = ({
                   className="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                   data-testid={`${criteriaKey}`}
                 >
-                  <div>
+                  <div aria-hidden="true">
                     <GreenCheck />
                   </div>
                   {label}

--- a/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/index.jsx
+++ b/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/index.jsx
@@ -20,6 +20,24 @@ const KeyElegibilityCrieriaList = ({
   const { benefitSummary, benefitSummaryPrefix, benefitSummaryConjunction } = ui
   const defaultClasses = ['key-eligibility-criteria-group']
 
+  const GreenCheck = () => (
+    <svg
+      width="24"
+      height="20"
+      viewBox="0 0 24 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className="bf-checkmark--green"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+        fill="#009831"
+      />
+    </svg>
+  )
+
   return (
     <div className={useHandleClassName({ className, defaultClasses })}>
       {data && (
@@ -42,6 +60,9 @@ const KeyElegibilityCrieriaList = ({
                   className="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                   data-testid={`${criteriaKey}`}
                 >
+                  <div>
+                    <GreenCheck />
+                  </div>
                   {label}
                 </li>
               )

--- a/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
@@ -299,7 +299,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -493,7 +495,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -687,7 +691,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -876,7 +882,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -1425,7 +1433,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_died_of_COVID"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -1448,7 +1458,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_death_location_is_US"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -1471,7 +1483,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_date_of_death"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -1494,7 +1508,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_citizen_status"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -1517,7 +1533,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_paid_funeral_expenses"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -2037,7 +2055,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_marital_status"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -2060,7 +2080,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -2254,7 +2276,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -2619,7 +2643,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_marital_status"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -2642,7 +2668,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -2836,7 +2864,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -3024,7 +3054,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_paid_into_SS"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -3047,7 +3079,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_date_of_death"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -3070,7 +3104,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_citizen_status"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -3093,7 +3129,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -3246,7 +3284,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -3441,7 +3481,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -3612,7 +3654,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -3783,7 +3827,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -3977,7 +4023,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_paid_into_SS"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -4000,7 +4048,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_citizen_status"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -4181,7 +4231,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_paid_into_SS"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -4204,7 +4256,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_citizen_status"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -4407,7 +4461,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_paid_into_SS"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -4430,7 +4486,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_marital_status"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -4453,7 +4511,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_citizen_status"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -4476,7 +4536,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_care_for_child"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -4630,7 +4692,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_paid_into_SS"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -4653,7 +4717,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_date_of_birth"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -4676,7 +4742,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_citizen_status"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -4846,7 +4914,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_paid_into_SS"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -4869,7 +4939,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_date_of_birth"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -4892,7 +4964,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_marital_status"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -4915,7 +4989,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_citizen_status"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -4938,7 +5014,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -5091,7 +5169,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_paid_into_SS"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -5114,7 +5194,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_date_of_birth"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -5137,7 +5219,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_marital_status"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -5160,7 +5244,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_citizen_status"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -5183,7 +5269,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -5539,7 +5627,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_date_of_birth"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -5743,7 +5833,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_marital_status"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -5766,7 +5858,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -5961,7 +6055,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_date_of_death"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -5984,7 +6080,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -6007,7 +6105,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_paid_funeral_expenses"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -6201,7 +6301,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"
@@ -6395,7 +6497,9 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
-                          <div>
+                          <div
+                            aria-hidden="true"
+                          >
                             <svg
                               class="bf-checkmark--green"
                               fill="none"

--- a/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
@@ -299,6 +299,23 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Applicant's relationship to the deceased is: spouse, child, parent, or other family member
                         </li>
                       </ul>
@@ -476,6 +493,23 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your relationship to the deceased is: spouse, child, parent, or other family member
                         </li>
                       </ul>
@@ -653,6 +687,23 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your relationship to the deceased is: spouse, child, parent, or other family member
                         </li>
                       </ul>
@@ -825,6 +876,23 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your relationship to the deceased is: spouse
                         </li>
                       </ul>
@@ -1357,30 +1425,115 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_died_of_COVID"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           The deceased died due to COVID-19
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_death_location_is_US"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           The deceased died in the U.S.
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_date_of_death"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           The deceased died after May 20th, 2020
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_citizen_status"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           You are a U.S. citizen or eligible non-citizen
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_paid_funeral_expenses"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           You paid for funeral or burial expenses and were not reimbursed
                         </li>
                       </ul>
@@ -1884,12 +2037,46 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_marital_status"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Marital status: unmarried or widowed
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Applicant's relationship to the deceased: spouse
                         </li>
                       </ul>
@@ -2067,6 +2254,23 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your relationship to the deceased is: spouse or child
                         </li>
                       </ul>
@@ -2415,12 +2619,46 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_marital_status"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your marital status is widowed
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your relationship to the deceased is: spouse
                         </li>
                       </ul>
@@ -2598,6 +2836,23 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your relationship to the deceased is: spouse, child, parent, or other family member
                         </li>
                       </ul>
@@ -2769,24 +3024,92 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_paid_into_SS"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           The deceased worked and paid Social Security taxes
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_date_of_death"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           The deceased died within the last two years
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_citizen_status"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           You are a U.S. citizen or eligible non-citizen
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your relationship to the deceased is: spouse or child
                         </li>
                       </ul>
@@ -2923,6 +3246,23 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your relationship to the deceased is: spouse, child, parent, or other family member
                         </li>
                       </ul>
@@ -3101,6 +3441,23 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your relationship to the deceased is: spouse, child, parent, or other family member
                         </li>
                       </ul>
@@ -3255,6 +3612,23 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your relationship to the deceased is: spouse or child
                         </li>
                       </ul>
@@ -3409,6 +3783,23 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your relationship to the deceased is: spouse or child
                         </li>
                       </ul>
@@ -3586,12 +3977,46 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_paid_into_SS"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           The deceased worked and paid Social Security taxes
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_citizen_status"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           You are a U.S. citizen or eligible non-citizen
                         </li>
                       </ul>
@@ -3756,12 +4181,46 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_paid_into_SS"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           The deceased worked and paid Social Security taxes
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_citizen_status"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           You are a U.S. citizen or eligible non-citizen
                         </li>
                       </ul>
@@ -3948,24 +4407,92 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_paid_into_SS"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           The deceased worked and paid Social Security taxes
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_marital_status"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your marital status is unmarried or widowed
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_citizen_status"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           You are a US citizen or eligible non-citizen
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_care_for_child"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           You are caring for a child of someone who is retired, has a disability, or has died, and the child is disabled or under the age of 16
                         </li>
                       </ul>
@@ -4103,18 +4630,69 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_paid_into_SS"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           The deceased worked and paid Social Security taxes
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_date_of_birth"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           You are over 62 years
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_citizen_status"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           You are a US citizen or eligible non-citizen
                         </li>
                       </ul>
@@ -4268,30 +4846,115 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_paid_into_SS"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           The deceased worked and paid Social Security taxes
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_date_of_birth"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           You are over 60 years
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_marital_status"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your marital status is widowed or divorced
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_citizen_status"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           You are a US citizen or eligible non-citizen
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your relationship to the deceased is: spouse
                         </li>
                       </ul>
@@ -4428,30 +5091,115 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_paid_into_SS"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           The deceased worked and paid Social Security taxes
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_date_of_birth"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           You are over 50 years
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_marital_status"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your marital status is widowed or divorced
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_citizen_status"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           You are a US citizen or eligible non-citizen
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your relationship to the deceased is: spouse
                         </li>
                       </ul>
@@ -4791,6 +5539,23 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_date_of_birth"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           You are under 18 years
                         </li>
                       </ul>
@@ -4978,12 +5743,46 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_marital_status"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your marital status is unmarried or widowed
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your relationship to the deceased is: spouse
                         </li>
                       </ul>
@@ -5162,18 +5961,69 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="deceased_date_of_death"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           The deceased died within the last two years
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your relationship to the deceased is: spouse, child, parent, or other family member
                         </li>
                         <li
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_paid_funeral_expenses"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           You paid for funeral or burial expenses
                         </li>
                       </ul>
@@ -5351,6 +6201,23 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your relationship to the deceased is: spouse, child, parent, or other family member
                         </li>
                       </ul>
@@ -5528,6 +6395,23 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           data-testid="applicant_relationship_to_the_deceased"
                         >
+                          <div>
+                            <svg
+                              class="bf-checkmark--green"
+                              fill="none"
+                              height="20"
+                              viewBox="0 0 24 20"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M24 4.15417C23.9925 4.52794 23.8515 4.88618 23.6033 5.16208L12.2975 16.6522L10.1157 18.8696C9.84423 19.1219 9.49174 19.2651 9.12397 19.2727C8.7562 19.2651 8.40371 19.1219 8.13223 18.8696L5.95041 16.6522L0.396694 11.0079C0.148478 10.732 0.00748054 10.3738 0 10C0.00748054 9.62626 0.148478 9.26802 0.396694 8.99212L2.57851 6.77473C2.84999 6.52246 3.20248 6.37917 3.57025 6.37156C3.93802 6.37917 4.29051 6.52246 4.56198 6.77473L9.12397 11.4111L19.2397 1.13046C19.5111 0.878193 19.8636 0.734897 20.2314 0.727295C20.5992 0.734897 20.9517 0.878193 21.2231 1.13046L23.405 3.34785C23.8017 3.54943 24 3.75101 24 4.15417Z"
+                                fill="#009831"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           Your relationship to the deceased is: spouse, child, parent, or other family member
                         </li>
                       </ul>


### PR DESCRIPTION
## PR Summary

This updates the `KeyElegibilityCrieriaList` component to include a green checkmark with eligible items

## Related Github Issue

- fixes #710 

## Detailed Testing steps

- [x] pull changes locally
- [x] npm install
- [x] npm run start
- [x] complete form
- [x] open benefit accordion
- [x] note green checkmark icon is now included with eligible items

should appear same as below

<img width="1434" alt="Screenshot 2024-02-12 at 11 57 04 AM" src="https://github.com/GSA/px-benefit-finder/assets/37077057/772b8645-2e31-4268-8227-9f3742498587">

