### PR TITLE
893 storybook decorators cypress

### DIFF
--- a/benefit-finder/cypress/support/component.js
+++ b/benefit-finder/cypress/support/component.js
@@ -12,14 +12,13 @@
 // You can read more here:
 // https://on.cypress.io/configuration
 // ***********************************************************
-
-// Import commands.js using ES2015 syntax:
 import './commands'
 
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
-
+import * as sbPreview from '../../.storybook/preview'
+import { setProjectAnnotations } from '@storybook/react'
 import { mount } from 'cypress/react18'
+
+setProjectAnnotations(sbPreview) // set decorators from storybook
 
 Cypress.Commands.add('mount', mount)
 

--- a/benefit-finder/package.json
+++ b/benefit-finder/package.json
@@ -27,6 +27,7 @@
     "build:storybook": "npm run prebuild:storybook && storybook build",
     "cy:prebuild:storybook": "NODE_ENV=test npm run build && npm run mv:uswds:usagov",
     "cy:dev:storybook": "NODE_ENV=test npm run cy:prebuild:storybook && storybook dev -p 6006",
+    "cy:dev:components": "NODE_ENV=test npm run cy:prebuild:storybook && cypress open",
     "cy:build:storybook": "NODE_ENV=test npm run cy:prebuild:storybook && storybook build --test",
     "cy:run:component:chrome": "NODE_ENV=test npx cypress run --component --browser chrome",
     "cy:run:e2e:chrome": "NODE_ENV=test npx cypress run --browser chrome",


### PR DESCRIPTION
## PR Summary

updates `cypress/support/component.js` to use `.storybook/preview` as a global set up and wrapper

## Related Github Issue

- fixes #696 

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [ ] pull code locally
- [ ]  npm install
- [ ] npm run `cy:dev:components`
- [ ] launch component testing view
- [ ] select a spec
- [ ] confirm styles are displayed with component rendering
- [ ] inspect DOM
- [ ] ensure `#benefit-finder` div is wrapped around component
- [ ] inspect cypress network confirm the following files are loading 

```
`uswds.js`
`uswds.css`
`styles.css`
`benefit-finder.min.css`
```
