### PR TITLE
ignore lint errors for jest in cy files

### DIFF
--- a/benefit-finder/.eslintrc.json
+++ b/benefit-finder/.eslintrc.json
@@ -21,7 +21,7 @@
     {
       "files": ["**/*.cy.jsx"],
       "rules": {
-        "jest/expect-expect": "off"
+        "jest/valid-expect": "off"
       }
     }
   ],

--- a/benefit-finder/.eslintrc.json
+++ b/benefit-finder/.eslintrc.json
@@ -15,10 +15,16 @@
     "sourceType": "module"
   },
   "settings": {
-    "react": {
-      "version": "18.2"
-    }
+    "react": { "version": "18.2" }
   },
+  "overrides": [
+    {
+      "files": ["**/*.cy.jsx"],
+      "rules": {
+        "jest/expect-expect": "off"
+      }
+    }
+  ],
   "rules": {
     "react/prop-types": "off",
     "eqeqeq": [2, "smart"],


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

overrides lint config to ignore jest linters in `*.cy.jsx` files

## Detailed Testing steps

<!--- Link to testing steps in the issue or list them here -->

- [x] check out `862-component-button-group-automation` locally
- [x] remove eslint ignore comments
- [x] pull changes from `ignore-jest-in-cy`
- [x] reload ide
- [x] confirm that lint errors are no longer appearing in `.cy.jsx` files
