### PR TITLE
924 include life event id in relative benefit object

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
@@ -207,6 +207,7 @@ class LifeEventController {
         "body" => $relevant_benefit->get('field_b_body')->value ?? "",
         "link" => $relevant_benefit->get('field_b_link')->value ?? "",
         "cta" => $relevant_benefit->get('field_b_cta')->value ?? "",
+        "lifeEventId" => current($relevant_benefit->get('field_b_life_event_form')->referencedEntities())->get('field_b_id')->value ?? "",
       ];
       $life_event_form_relevant_benefits[]['lifeEvent'] = $life_event_form_relevant_benefit;
     }


### PR DESCRIPTION
## PR Summary

This PR includes life event id in relative benefit object.

## Related Github Issue

- fixes #924 

## Detailed Testing steps

Go to http://localhost/benefit-finder/api/life-event/death

Check that the JSON data includes life event id in relative benefit object.

<img width="600" alt="image" src="https://github.com/GSA/px-benefit-finder/assets/88853916/35b5b657-410e-48bb-ba48-880644f227cd">
