### PR TITLE
Include class prefix with notice

### DIFF
--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
@@ -120,7 +120,7 @@ exports[`loads intro 1`] = `
                   class="notices-list add-list-reset"
                 >
                   <li
-                    class="notice"
+                    class="bf-notice"
                   >
                     <div
                       aria-live="polite"
@@ -135,7 +135,7 @@ exports[`loads intro 1`] = `
                           class="bf-usa-alert__text usa-alert__text"
                         >
                           <div
-                            class="notice-item"
+                            class="bf-notice-item"
                           >
                             <div>
                               Your information
@@ -150,7 +150,7 @@ exports[`loads intro 1`] = `
                     </div>
                   </li>
                   <li
-                    class="notice"
+                    class="bf-notice"
                   >
                     <div
                       aria-live="polite"
@@ -165,7 +165,7 @@ exports[`loads intro 1`] = `
                           class="bf-usa-alert__text usa-alert__text"
                         >
                           <div
-                            class="notice-item"
+                            class="bf-notice-item"
                           >
                             Provide complete info to get more relevant results.
                           </div>
@@ -174,7 +174,7 @@ exports[`loads intro 1`] = `
                     </div>
                   </li>
                   <li
-                    class="notice"
+                    class="bf-notice"
                   >
                     <div
                       aria-live="polite"
@@ -189,7 +189,7 @@ exports[`loads intro 1`] = `
                           class="bf-usa-alert__text usa-alert__text"
                         >
                           <div
-                            class="notice-item"
+                            class="bf-notice-item"
                           >
                             <div>
                               <strong>

--- a/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.jsx.snap
@@ -107,7 +107,7 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
               class="notices-list add-list-reset"
             >
               <li
-                class="notice"
+                class="bf-notice"
               >
                 <div
                   aria-live="polite"
@@ -122,7 +122,7 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                       class="bf-usa-alert__text usa-alert__text"
                     >
                       <div
-                        class="notice-item"
+                        class="bf-notice-item"
                       >
                         <div>
                           Your information
@@ -137,7 +137,7 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                 </div>
               </li>
               <li
-                class="notice"
+                class="bf-notice"
               >
                 <div
                   aria-live="polite"
@@ -152,7 +152,7 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                       class="bf-usa-alert__text usa-alert__text"
                     >
                       <div
-                        class="notice-item"
+                        class="bf-notice-item"
                       >
                         Provide complete info to get more relevant results.
                       </div>
@@ -161,7 +161,7 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                 </div>
               </li>
               <li
-                class="notice"
+                class="bf-notice"
               >
                 <div
                   aria-live="polite"
@@ -176,7 +176,7 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                       class="bf-usa-alert__text usa-alert__text"
                     >
                       <div
-                        class="notice-item"
+                        class="bf-notice-item"
                       >
                         <div>
                           <strong>

--- a/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/_index.scss
+++ b/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/_index.scss
@@ -17,28 +17,28 @@
   .bf-key-eligibility-criteria-sub-heading {
     margin-bottom: 0;
   }
-  
+
   .bf-key-eligibility-criteria-list {
     padding: 0;
     margin: 0;
 
     .bf-key-eligibility-criteria-list-item {
-        margin: 0;
-        padding: space.$space-md space.$space-lg;
-        border: 0.5px solid color.$pop-blue;
-        background-color: color.$sky;
-        display: flex;
-        flex-wrap: nowrap;
+      margin: 0;
+      padding: space.$space-md space.$space-lg;
+      border: 0.5px solid color.$pop-blue;
+      background-color: color.$sky;
+      display: flex;
+      flex-wrap: nowrap;
 
-        .bf-checkmark--green {
-          height: 100%;
-          margin-right: space.$space-lg;
-        }
+      .bf-checkmark--green {
+        height: 100%;
+        margin-right: space.$space-lg;
       }
+    }
 
-      li.bf-usa-list {
-        @include p2;
-      }
+    li.bf-usa-list {
+      @include p2;
+    }
 
     li.bf-unmet-criteria-item {
       @include p;
@@ -46,6 +46,6 @@
   }
 }
 
-.bf-usa-alert .usa-alert__text {
+.bf-usa-alert .bf-usa-alert__text {
   @include p3;
 }

--- a/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.jsx.snap
@@ -9,7 +9,7 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
       class="notices-list add-list-reset"
     >
       <li
-        class="notice"
+        class="bf-notice"
       >
         <div
           aria-live="polite"
@@ -24,7 +24,7 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
               class="bf-usa-alert__text usa-alert__text"
             >
               <div
-                class="notice-item"
+                class="bf-notice-item"
               >
                 <div>
                   Your information
@@ -39,7 +39,7 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
         </div>
       </li>
       <li
-        class="notice"
+        class="bf-notice"
       >
         <div
           aria-live="polite"
@@ -54,7 +54,7 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
               class="bf-usa-alert__text usa-alert__text"
             >
               <div
-                class="notice-item"
+                class="bf-notice-item"
               >
                 Provide complete info to get more relevant results.
               </div>
@@ -63,7 +63,7 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
         </div>
       </li>
       <li
-        class="notice"
+        class="bf-notice"
       >
         <div
           aria-live="polite"
@@ -78,7 +78,7 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
               class="bf-usa-alert__text usa-alert__text"
             >
               <div
-                class="notice-item"
+                class="bf-notice-item"
               >
                 <div>
                   <strong>

--- a/benefit-finder/src/shared/components/NoticesList/_index.scss
+++ b/benefit-finder/src/shared/components/NoticesList/_index.scss
@@ -3,50 +3,50 @@
 @use '../../styles/mixins/_index.scss' as *;
 @use '../../styles/breakpoints/_index.scss' as *;
 
-.notices-list {
+.bf-notices-list {
   margin-bottom: space.$space-xl;
 }
 
-.notice {
+.bf-notice {
   margin-bottom: space.$space-md-plus;
 }
 
-.notice-item {
+.bf-notice-item {
   @include important-bold;
 }
 
-.line-sperator-wrapper {
+.bf-line-sperator-wrapper {
   display: block;
   padding-top: space.$space-lg;
   padding-bottom: space.$padding-bottom-lg;
   margin: space.$space-lg;
 }
 
-.line-sperator {
+.bf-line-sperator {
   display: block;
   border-top: 2px solid color.$base-light-grey;
   width: 100%;
   height: 100%;
 }
 
-.line-sperator-wrapper--vertical {
+.bf-line-sperator-wrapper--vertical {
   display: none;
 }
 
-.line-sperator--vertical {
+.bf-line-sperator--vertical {
   display: none;
 }
 
 @media (width >= $desktop) {
-  .intro .line-sperator-wrapper {
+  .bf-intro .bf-line-sperator-wrapper {
     display: none;
   }
 
-  .intro .line-sperator {
+  .bf-intro .bf-line-sperator {
     display: none;
   }
 
-  .line-sperator-wrapper--vertical {
+  .bf-line-sperator-wrapper--vertical {
     display: block;
     padding-top: space.$space-lg;
     padding-bottom: space.$padding-bottom-lg;
@@ -54,7 +54,7 @@
     margin-right: space.$space-lg;
   }
 
-  .line-sperator--vertical {
+  .bf-line-sperator--vertical {
     display: block;
     border-left: 2px solid color.$base-light-grey;
     width: 100%;

--- a/benefit-finder/src/shared/components/NoticesList/index.jsx
+++ b/benefit-finder/src/shared/components/NoticesList/index.jsx
@@ -22,10 +22,10 @@ const NoticesList = ({ data }) => {
       data &&
       data.data.map((item, i) => {
         return (
-          <li className="notice" key={`notice-${i}`}>
+          <li className="bf-notice" key={`notice-${i}`}>
             <Alert noBackground tabIndex={-1}>
               <div
-                className="notice-item"
+                className="bf-notice-item"
                 dangerouslySetInnerHTML={createMarkup(item.notice)}
               ></div>
             </Alert>


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
this updates fixes a style regression that was caused by a missing prefix on the style class for notices lists

## Related Github Issue

- fixes #929 

## Detailed Testing steps

<!--- Link to testing steps in the issue or list them here -->

- [x] visit: https://bf-static-main.bxdev.net/benefit-finder/death

compare to,

- [x] dev branch on http://localhost:3000/death


Expected:
<img width="1437" alt="Screenshot 2024-02-22 at 3 25 47 PM" src="https://github.com/GSA/px-benefit-finder/assets/37077057/44fbfd34-625a-4078-91c2-f50e3a558524">

