### PR TITLE
fix error hidden

### DIFF
--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
@@ -130,6 +130,7 @@ exports[`loads intro 1`] = `
                     class="bf-notice"
                   >
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
                       role="alert"
@@ -159,6 +160,7 @@ exports[`loads intro 1`] = `
                     class="bf-notice"
                   >
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
                       role="alert"
@@ -187,6 +189,7 @@ exports[`loads intro 1`] = `
                     class="bf-notice"
                   >
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
                       role="alert"
@@ -452,6 +455,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -628,6 +632,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -799,6 +804,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -975,6 +981,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -1147,6 +1154,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -1333,6 +1341,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -1514,6 +1523,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -1701,6 +1711,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -1883,6 +1894,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -2064,6 +2076,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -2245,6 +2258,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -2411,6 +2425,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -2593,6 +2608,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -2764,6 +2780,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -2940,6 +2957,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -3116,6 +3134,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -3283,6 +3302,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -3449,6 +3469,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -3625,6 +3646,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -3806,6 +3828,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -3997,6 +4020,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -4173,6 +4197,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -4350,6 +4375,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -4531,6 +4557,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -4722,6 +4749,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -4903,6 +4931,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -5089,6 +5118,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -5270,6 +5300,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -5457,6 +5488,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -5633,6 +5665,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -5809,6 +5842,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -6384,6 +6418,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -6598,6 +6633,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -6807,6 +6843,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -7021,6 +7058,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -7206,6 +7244,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -7405,6 +7444,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -7693,6 +7733,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -7893,6 +7934,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -8088,6 +8130,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -8331,6 +8374,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -8550,6 +8594,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -8729,6 +8774,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -8973,6 +9019,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -9182,6 +9229,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -9431,6 +9479,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -9645,6 +9694,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -9837,6 +9887,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -10028,6 +10079,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -10242,6 +10294,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -10472,6 +10525,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -10725,6 +10779,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -10984,6 +11039,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -11234,6 +11290,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -11522,6 +11579,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -11834,6 +11892,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -12028,6 +12087,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -12252,6 +12312,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -12495,6 +12556,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -12744,6 +12806,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -12958,6 +13021,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -13172,6 +13236,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
+                        aria-hidden="true"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"

--- a/benefit-finder/src/shared/components/Alert/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/Alert/__tests__/__snapshots__/index.spec.jsx.snap
@@ -3,6 +3,7 @@
 exports[`Alert > renders a match to the previous snapshot 1`] = `
 <DocumentFragment>
   <div
+    aria-hidden="true"
     aria-live="polite"
     class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
     role="alert"

--- a/benefit-finder/src/shared/components/Alert/index.jsx
+++ b/benefit-finder/src/shared/components/Alert/index.jsx
@@ -21,6 +21,7 @@ const Alert = ({
   heading,
   description,
   error,
+  hasError,
   noBackground,
   tabIndex,
 }) => {
@@ -46,8 +47,8 @@ const Alert = ({
       role="alert"
       ref={alertFieldRef}
       tabIndex={tabIndex || 0}
-      aria-live="polite"
-      aria-hidden={error}
+      aria-live={hasError === true ? 'assertive' : 'polite'}
+      aria-hidden={!hasError}
     >
       {children ? (
         <div className="bf-usa-alert__body usa-alert__body">

--- a/benefit-finder/src/shared/components/Date/index.jsx
+++ b/benefit-finder/src/shared/components/Date/index.jsx
@@ -28,6 +28,7 @@ const Date = ({ onChange, value, required, ui, id, invalid }) => {
           heading={ui.alertBanner.heading}
           description={alert}
           error
+          hasError={invalid}
         ></Alert>
       )}
       <div className="bf-usa-form-group usa-form-group bf-usa-form-group--month usa-form-group--month bf-usa-form-group--select usa-form-group--select">

--- a/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.jsx.snap
@@ -116,6 +116,7 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                 class="bf-notice"
               >
                 <div
+                  aria-hidden="true"
                   aria-live="polite"
                   class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
                   role="alert"
@@ -145,6 +146,7 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                 class="bf-notice"
               >
                 <div
+                  aria-hidden="true"
                   aria-live="polite"
                   class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
                   role="alert"
@@ -173,6 +175,7 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                 class="bf-notice"
               >
                 <div
+                  aria-hidden="true"
                   aria-live="polite"
                   class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
                   role="alert"

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -287,6 +287,7 @@ const LifeEventSection = ({
                   heading={ui.alertBanner.heading}
                   description={ui.alertBanner.description}
                   error
+                  hasError={hasError.length > 0}
                 ></Alert>
                 <Heading className="bf-usa-section-heading" headingLevel={2}>
                   {currentData.section.heading}

--- a/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.jsx.snap
@@ -12,6 +12,7 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
         class="bf-notice"
       >
         <div
+          aria-hidden="true"
           aria-live="polite"
           class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
           role="alert"
@@ -41,6 +42,7 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
         class="bf-notice"
       >
         <div
+          aria-hidden="true"
           aria-live="polite"
           class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
           role="alert"
@@ -69,6 +71,7 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
         class="bf-notice"
       >
         <div
+          aria-hidden="true"
           aria-live="polite"
           class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
           role="alert"

--- a/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
@@ -426,6 +426,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -640,6 +641,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -849,6 +851,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -1063,6 +1066,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -1248,6 +1252,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -1447,6 +1452,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -1735,6 +1741,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -1935,6 +1942,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -2130,6 +2138,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -2373,6 +2382,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -2592,6 +2602,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -2771,6 +2782,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -3015,6 +3027,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -3224,6 +3237,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -3483,6 +3497,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -3697,6 +3712,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -3889,6 +3905,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -4080,6 +4097,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -4294,6 +4312,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -4524,6 +4543,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -4777,6 +4797,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -5036,6 +5057,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -5286,6 +5308,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -5574,6 +5597,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -5886,6 +5910,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -6080,6 +6105,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -6304,6 +6330,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -6547,6 +6574,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -6820,6 +6848,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -7034,6 +7063,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -7248,6 +7278,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
+                      aria-hidden="true"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"


### PR DESCRIPTION
## PR Summary

This works to pass error state for both `aria-live` and `aria-hidden` values making it accessible to screen readers

## Related Github Issue

- fixes #956 

## Detailed Testing steps

<!--- Link to testing steps in the issue or list them here -->

- [x] pull changes locally
- [x] `npm install`
- [x] `npm run start`
- [x] turn voice over on
- [x] navigate through first step without entry
- [x] click continue
- [x] note if error takes focus
- [x] note if error is announced to voice over
- [x] tab
- [x] note if inline error takes focus
- [x] note if error is announced to voice over
- [x] turn voiceover off
- [x] inspect the DOM
- [ ] refresh the page
- [ ] find error in DOM
- [ ] note if `aria-live="polite"`
- [ ] note if `aria-hidden="true"`
- [ ] navigate through first step without entry
- [ ] click continue
- [ ] find error in DOM
- [ ] note if `aria-live="assertive"`
- [ ] note if `aria-hidden="false"`

Expected:

https://github.com/GSA/px-benefit-finder/assets/37077057/7de8d299-b214-4b28-97aa-362c89771390



