### PR TITLE
 update sr label "not completed" in step indicator

### DIFF
--- a/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.jsx.snap
@@ -33,6 +33,11 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
                 class="bf-usa-step-indicator__segment-label usa-step-indicator__segment-label"
               >
                 About the applicant
+                <span
+                  class="usa-sr-only"
+                >
+                   not-completed
+                </span>
               </span>
             </li>
             <li
@@ -46,7 +51,7 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
                 <span
                   class="usa-sr-only"
                 >
-                  not-completed
+                   not-completed
                 </span>
               </span>
             </li>

--- a/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.jsx.snap
@@ -36,7 +36,7 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
                 <span
                   class="usa-sr-only"
                 >
-                   not-completed
+                   not completed
                 </span>
               </span>
             </li>
@@ -51,7 +51,7 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
                 <span
                   class="usa-sr-only"
                 >
-                   not-completed
+                   not completed
                 </span>
               </span>
             </li>

--- a/benefit-finder/src/shared/components/StepIndicator/index.jsx
+++ b/benefit-finder/src/shared/components/StepIndicator/index.jsx
@@ -32,7 +32,7 @@ const StepIndicator = ({
   const CompletedSR = ({ completed }) => {
     return (
       <span className="usa-sr-only">
-        {completed ? ' completed' : ' not-completed'}
+        {completed ? ' completed' : ' not completed'}
       </span>
     )
   }

--- a/benefit-finder/src/shared/components/StepIndicator/index.jsx
+++ b/benefit-finder/src/shared/components/StepIndicator/index.jsx
@@ -29,10 +29,10 @@ const StepIndicator = ({
    * @param {boolean} noHeadings - determinate to render headings or not
    * @return {html} returns markup for a usa step indicator
    */
-  const CompletedSR = ({ current, index }) => {
+  const CompletedSR = ({ completed }) => {
     return (
       <span className="usa-sr-only">
-        {current < index ? 'not-completed' : 'completed'}
+        {completed ? ' completed' : ' not-completed'}
       </span>
     )
   }
@@ -76,13 +76,10 @@ const StepIndicator = ({
           className="bf-usa-step-indicator__segment-label usa-step-indicator__segment-label"
         >
           {!noHeadings && heading}
-          {current === index && completed !== true ? null : (
-            <CompletedSR
-              key={`step-indicator-sr-${index}`}
-              current={current}
-              index={index}
-            />
-          )}
+          <CompletedSR
+            key={`step-indicator-sr-${index}`}
+            completed={completed}
+          />
         </span>
       </li>
     )


### PR DESCRIPTION
## PR Summary

This works to ensure that "not completed" is announced based on the completed status of the step.

## Related Github Issue

- fixes #933 

## Detailed Testing steps

<!--- Link to testing steps in the issue or list them here -->

- [x] pull changes locally
- [x] `npm install`
- [x] `npm run start`
- [x] turn voice over on
- [x] navigate to first step, step nav
- [x] note if two items are listed as "not-complete"
- [x] compete required fields
- [x] navigate to second step, step nav
- [x] note if two items are listed, first as "completed", second as "not completed"
- [x] navigate back to the first step
- [x] navigate to the first step, step nav
- [x] note if two items are listed, first as "completed", second as "not completed"

Expected:


https://github.com/GSA/px-benefit-finder/assets/37077057/181098c1-5c14-446e-be47-c9080f4258e6




