### PR TITLE
960 release qa template step

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_qa_form.yml
+++ b/.github/ISSUE_TEMPLATE/release_qa_form.yml
@@ -1,0 +1,59 @@
+---
+name: Task
+description: Use this form to create a new release QA task(s)
+labels: ["QA"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Introduction
+
+  - type: markdown
+    attributes:
+      value: >
+        Release QA tasks are associated with and/or make reference to
+        work that is "Ready for Deployment".
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Required fields
+
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain
+      options:
+        - a11y
+        - design
+        - data
+        - ux
+        - product owner
+        - development
+        - other
+      default: 0
+    validations:
+      required: true
+
+  - type: textarea
+    id: related-issues
+    attributes:
+      label: Related Issue(s)
+      description: "What issues are related to this QA effort"
+      value: >
+        New issues that arise from this task should be created using the [Bug Report form](https://github.com/GSA/px-benefit-finder/issues/new?assignees=&labels=bug&projects=&template=bug_report_form.yml).
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Optional fields
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: "Include any additional context if needed"
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,8 @@
 
 ## Related Github Issue
 
-- fixes #(issue)
+<!--- Include "Fixes: #(issue) only if this work does not go upstream to the parent site". -->
+- #(issue)
 
 ## Detailed Testing steps
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,6 @@
+---
+title: '[ISSUE] <title>'
+---
 ## PR Summary
 
 <!--- Include a summary of the change, relevant motivation, and context. -->

--- a/.github/workflows/release-action.yml
+++ b/.github/workflows/release-action.yml
@@ -120,6 +120,17 @@ jobs:
           git tag $TAG_NAME
           git push origin $TAG_NAME
 
+      - name: Close release issues
+        run: |
+          # Get the list of open issues in the current release/milestone
+          issues=$(gh issue list --state open  --milestone "${{ github.event.inputs.tag_name }}")
+          echo $issues
+
+          # Iterate over each issue and move it to the "Done" column
+          for issue in $issues; do
+            gh issue $issue close --reason completed
+          done
+
       - name: Creating pre-release
         env:
           GITHUB_TOKEN: "${{ secrets.ADD_TO_PROJECT_PAT }}"


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This introduces: 
1. a new template for issues to be used with creating Release QA tasks
2. new step in release action to get all the open issues from that release, and set the state to closed (done)

## Related Github Issue

- Related #960 