### PR TITLE
PXBF-984-modal-styles-build: build modal styles as custom group

### DIFF
--- a/benefit-finder/vite.config.mjs
+++ b/benefit-finder/vite.config.mjs
@@ -64,6 +64,7 @@ export default defineConfig({
         plugins: [
           transformers.wrapStyles({
             id: 'benefit-finder',
+            customGroup: '#benefit-finder-modal',
           }),
         ],
       },


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This updates our bundler to build modal styles as a custom group of selectors wrapped with the modal ID

## Related Github Issue

- Fixes #984 

## Detailed Testing steps

<!--- Link to testing steps in the issue or list them here -->

local set up:
- [ ] pull changes locally
- [ ] cd
- [ ] npm install
- [ ] npm run build
- [ ] cd `usagov-2021` submodule
- [ ] set up usagov project for local testing
- [ ] `bash ../mv-benefit-finder-app.sh`
- [ ] `bash ../mv-usagov_benefit_finder.sh`
- [ ] `bin/drush cr`

user testing:
- [ ] localhost/benefit-finder/death
- [ ] navigate to last step in form
- [ ] click continue to trigger modal
- [ ] ensure styles are rendering in modal as expected

expected
![Screenshot 2024-03-04 125148](https://github.com/GSA/px-benefit-finder/assets/37077057/8bb5bf34-fec0-4af5-b9fe-fe57e4b1eafc)

