### PR TITLE
PXBF-997-translated-relative-benefit-icons: trim es from the returned…

### DIFF
--- a/benefit-finder/src/shared/components/RelativeBenefitList/index.jsx
+++ b/benefit-finder/src/shared/components/RelativeBenefitList/index.jsx
@@ -14,6 +14,7 @@ const RelativeBenefitList = ({ data, carrotType }) => {
       {data &&
         data.map((item, i) => {
           const { title, link, cta, body, lifeEventId } = item.lifeEvent
+          const trimedLifeEventId = lifeEventId.replace('es_', '')
 
           return (
             <Card
@@ -24,7 +25,7 @@ const RelativeBenefitList = ({ data, carrotType }) => {
               body={body}
               key={`${title}-${i}`}
               carrotType={carrotType}
-              icon={lifeEventId}
+              icon={trimedLifeEventId}
             />
           )
         })}


### PR DESCRIPTION
… lifeEventId

## PR Summary

this works to trim our `lifeEventId` when being passed into the icons component from the `<RelativeBenefitList />` component

## Related Github Issue

- Fixes #997 

## Detailed Testing steps

<!--- Link to testing steps in the issue or list them here -->

Local Setup:
- [x] pull changes locally
- [x] `cd benefit-finder`
- [x] `npm install`
- [x] `npm run start`
- [x] proxy data from `dev`

User Testing:
- [x] navigate to `/death`
- [x] navigate to results view
- [x] confirm that relative benefits have expected icons
- [x] navigate to `es/death`
- [x] navigate to results view
- [x] confirm that relative benefits have expected icons
