### PR TITLE
1016 run partial config import in deployment

### DIFF
--- a/bin/cloudgov/entrypoint.sh
+++ b/bin/cloudgov/entrypoint.sh
@@ -3,4 +3,6 @@
 /var/www/vendor/bin/drush state:set system.maintenance_mode 0
 /var/www/vendor/bin/drush pm:uninstall usagov_login || true
 /var/www/vendor/bin/drush cr
+/var/www/vendor/bin/drush cim --partial --source=modules/custom/usagov_benefit_finder/configuration -y
+/var/www/vendor/bin/drush cr
 /init &


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This PR adds partial config import command in entrypoint.sh to run in deployment.

## Related Github Issue

- Fixes #1016 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
In Benefit Finder DEV site, make ID field of life event and life event form not required.
The partial config import will run in deployment.
After deployment, check ID field of life event and life event form to become required.

<!--- If there are steps for user testing list them here -->
