### PR TITLE
PXBF-976 unit coverage in english modifier

### DIFF
--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/__snapshots__/index.spec.js.snap
@@ -1,7 +1,0 @@
-// Jest shot v1, https://goo.gl/fbAQLP
-
-exports[`BenefitAccordionGroup renders a match to the previous shot 1`] = `
-<div
-  className="bf-usa-accordion-group"
-/>
-`;

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/__snapshots__/index.spec.jsx.snap
@@ -4,6 +4,181 @@ exports[`BenefitAccordionGroup > renders a match to the previous snapshot 1`] = 
 <DocumentFragment>
   <div
     class="bf-usa-accordion-group"
-  />
+  >
+    <div
+      aria-expanded="false"
+      class="bf-usa-accordion usa-accordion"
+      data-analytics="bf-usa-accordion"
+      data-analytics-content="Burial benefits"
+      data-testid="benefit"
+    >
+      <h4
+        class="bf-usa-accordion__heading usa-accordion__heading"
+      >
+        <button
+          aria-controls="0-Burial benefits"
+          aria-expanded="false"
+          class="bf-usa-accordion__button usa-accordion__button"
+          type="button"
+        >
+          <span
+            class="bf-accordion-heading"
+          >
+            Burial benefits
+          </span>
+          <br />
+          <span
+            class="bf-accordion-sub-heading"
+          >
+            More information needed
+          </span>
+          <i
+            alt="a plus icon"
+            aria-hidden="true"
+          >
+            <svg
+              class="bf-open"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                fill="#1a4480"
+              />
+            </svg>
+          </i>
+        </button>
+      </h4>
+      <div
+        class="bf-usa-accordion__content usa-accordion__content usa-prose"
+        hidden=""
+        id="0-Burial benefits"
+      >
+        <div>
+          <h4
+            aria-level="4"
+            class="bf-usa-detail-title font-family-sans"
+            id=""
+            role="heading"
+          >
+            By Department of Defense (DOD)
+          </h4>
+          <div
+            class="bf-usa-detail-summary"
+          >
+            <p>
+              Burial and transport assistance for the deceased, and travel support for the spouse, children, and immediate family members of the service member.
+            </p>
+          </div>
+          <div
+            class="bf-usa-criteria-list bf-key-eligibility-criteria-group"
+          >
+             
+            <h5
+              aria-level="5"
+              class="bf-key-eligibility-criteria-heading font-family-sans"
+              id=""
+              role="heading"
+            >
+              Key eligibility criteria
+              <p
+                class="bf-key-eligibility-criteria-sub-heading"
+              >
+                Met  0 of
+            4
+              </p>
+            </h5>
+            <ul
+              class="bf-key-eligibility-criteria-list"
+            />
+          </div>
+          <div
+            class="bf-unmet-criteria-group"
+          >
+            <div
+              class="bf-unmet-criteria-title"
+            >
+              More information needed
+            </div>
+            <ul
+              class="bf-unmet-criteria-list"
+            >
+              <li
+                class="bf-unmet-criteria-item"
+              >
+                The deceased served in the active military
+              </li>
+              <li
+                class="bf-unmet-criteria-item"
+              >
+                The service status of the deceased is: active-duty member
+              </li>
+              <li
+                class="bf-unmet-criteria-item"
+              >
+                One of the following applies to the deceased: died on active duty
+              </li>
+              <li
+                class="bf-unmet-criteria-item"
+              >
+                Applicant's relationship to the deceased is: spouse, child, parent, or other family member
+              </li>
+            </ul>
+          </div>
+          <div
+            aria-hidden="true"
+            aria-live="polite"
+            class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
+            role="alert"
+            tabindex="0"
+          >
+            <div
+              class="bf-usa-alert__body usa-alert__body"
+            >
+              <div
+                class="bf-usa-alert__text usa-alert__text"
+              >
+                Additional eligibility criteria may apply. Visit the link below for more information and to apply.
+              </div>
+            </div>
+          </div>
+          <a
+            class="bf-usa-link bf-usa-button usa-button bf-obfuscated-link"
+            href="https://www.militaryonesource.mil/benefits/funeral-and-burial-benefits-for-service-members/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Visit Department of Defense (DOD) 
+            <i
+              aria-hidden="true"
+            >
+              <svg
+                class="bf-carrot-small"
+                fill="white"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="M7 10l5 5 5-5z"
+                />
+              </svg>
+            </i>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
 </DocumentFragment>
 `;

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/index.spec.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/index.spec.jsx
@@ -1,10 +1,49 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import BenefitAccordionGroup from '../index.jsx'
+import content from '../../../api/mock-data/current.js'
 import * as en from '../../../locales/en/en.json'
+import * as es from '../../../locales/es/es.json'
+
+const { data } = JSON.parse(content)
+const { benefits } = data
+const b = benefits[0]
+const entryKey = Object.keys(b)
 
 describe('BenefitAccordionGroup', () => {
   it('renders a match to the previous snapshot', () => {
-    const { asFragment } = render(<BenefitAccordionGroup ui={en.resultsView} />)
+    const { asFragment } = render(
+      <BenefitAccordionGroup
+        ui={en.resultsView}
+        data={[b]}
+        entryKey={entryKey[0]}
+      />
+    )
     expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('renders (en inglés) when flagged as TRUE', () => {
+    b.benefit.SourceIsEnglish = 'TRUE' // ensure true
+    render(
+      <BenefitAccordionGroup
+        ui={es.resultsView}
+        data={[b]}
+        entryKey={entryKey[0]}
+      />
+    )
+    const content = screen.queryByText(/en inglés/)
+    expect(content).toBeInTheDocument()
+  })
+
+  it('does not render (en inglés) when flagged as FALSE', () => {
+    b.benefit.SourceIsEnglish = 'FALSE' // ensure false
+    render(
+      <BenefitAccordionGroup
+        ui={es.resultsView}
+        data={[b]}
+        entryKey={entryKey[0]}
+      />
+    )
+    const content = screen.queryByText(/en inglés/)
+    expect(content).not.toBeInTheDocument()
   })
 })

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/indexBenefitAccordionGroup.cy.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/indexBenefitAccordionGroup.cy.jsx
@@ -1,20 +1,20 @@
 import { composeStories } from '@storybook/react'
 import * as stories from '../index.stories'
-const { Primary, ExpandAll } = composeStories(stories)
+const { Primary, ExpandAll, SourceIsEnglish } = composeStories(stories)
 
 describe('BenefitAccordionGroup component tests', () => {
   it('Validate opening individual accordion only expands the clicked accordion and clicking it again closes it', () => {
     cy.mount(<Primary />)
-    cy.get('.usa-accordion__button').contains('Burial benefits').click()
+    cy.get('.usa-accordion__button').contains('Burial flag').click()
     cy.get('.usa-accordion__button')
-      .contains('Burial benefits')
+      .contains('Burial flag')
       .parent()
       .should('have.attr', 'aria-expanded', 'true')
     cy.get('.usa-accordion__button')
       .contains('Death gratuity')
       .parent()
       .should('have.attr', 'aria-expanded', 'false')
-    cy.get('.usa-accordion__button').contains('Burial benefits').click()
+    cy.get('.usa-accordion__button').contains('Burial flag').click()
     cy.get('.usa-accordion__button').each(accordion => {
       cy.wrap(accordion).should('have.attr', 'aria-expanded', 'false')
     })
@@ -36,6 +36,16 @@ describe('BenefitAccordionGroup component tests', () => {
     cy.get('.bf-expand-all').should('contain.text', 'Open all')
     cy.get('.usa-accordion__button').each(accordion => {
       cy.wrap(accordion).should('have.attr', 'aria-expanded', 'false')
+    })
+  })
+
+  it('Validate SourceIsEnglish results in the display of (en inglés)', () => {
+    const content = '(en inglés)'
+    cy.mount(<SourceIsEnglish />)
+    cy.get('.bf-expand-all').click()
+    cy.get('.bf-usa-link').then(links => {
+      cy.wrap(links[0]).should('contain', content)
+      cy.wrap(links[1]).should('not.contain', content)
     })
   })
 })

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/index.stories.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/index.stories.jsx
@@ -1,28 +1,48 @@
 import BenefitAccordionGroup from './index.jsx'
 import content from '../../api/mock-data/current.js'
 import * as en from '../../locales/en/en.json'
+import * as es from '../../locales/es/es.json'
 
 const { data } = JSON.parse(content)
 const { benefits } = data
-const b = [benefits[0], benefits[1]]
+const b = benefits.slice(0, 7)
 const entryKey = Object.keys(b[0])
 const { resultsView } = en
+
+const SourceIsEnglishBenefits = b.slice(5, 7)
+SourceIsEnglishBenefits[0].benefit.SourceIsEnglish = 'TRUE' // ensure true
+SourceIsEnglishBenefits[1].benefit.SourceIsEnglish = 'FALSE' // ensure false
 
 export default {
   component: BenefitAccordionGroup,
   tags: ['autodocs'],
   args: {
-    data: b,
+    data: b.slice(0, 2),
     entryKey: entryKey[0],
     ui: resultsView,
   },
 }
 
-export const Primary = {}
+export const Primary = {
+  args: {
+    data: b.slice(1, 3),
+  },
+}
 
 export const ExpandAll = {
   args: {
     ...Primary.args,
+    data: b.slice(3, 5),
+    expandAll: true,
+  },
+}
+
+// we only indicate sourceIsEnglish in es locale
+export const SourceIsEnglish = {
+  args: {
+    ...Primary.args,
+    data: SourceIsEnglishBenefits,
+    ui: es.resultsView,
     expandAll: true,
   },
 }


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This works to add both e2e and unit testing coverage for the functionality of conditionally displaying `en ingles` when `SourceIsEnglish: "TRUE"`

## Related Github Issue

- Fixes #976 

## Detailed Testing steps

- [x] code review
- [x] ensure all cypress and unit test are passing
