### PR TITLE
1016 run partial config import in deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,9 @@ jobs:
             sed -i "s/\$settings\['hash_salt'\] = \$service\['credentials'\]\['HASH_SALT'\]/\$settings\['hash_salt'\] = \$service\['credentials'\]\['hash_salt'\]/"  web/sites/default/settings.php
             sed -i "s/\$service\['name'\] === 'storage'/stristr(\$service\['name'\], 'storage')/"  web/sites/default/settings.php
             sed -i "s/\$service\['name'\] === 'secrets'/stristr(\$service\['name'\], 'secrets')/"  web/sites/default/settings.php
-            echo -e "\n./scripts/entrypoint.sh" >> scripts/bootstrap.sh
+            echo -e "\nif [ "${CF_INSTANCE_INDEX:-''}" == "0" ] && [ -z "${SKIP_DRUPAL_BOOTSTRAP:-}" ]; then"
+            echo -e "\t./scripts/entrypoint.sh" >> scripts/bootstrap.sh
+            echo "fi"
 
       - run:
           name: Building, tagging, pushing the Docker Image


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This PR adds partial config import command in entrypoint.sh to run in deployment.

## Related Github Issue

- Fixes #1016 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
In Benefit Finder DEV site, make ID field of life event and life event form not required.
The partial config import will run in deployment.
After deployment, check ID field of life event and life event form to become required.

<!--- If there are steps for user testing list them here -->
