### PR TITLE
1058 resolve skipped heading level

### DIFF
--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
@@ -306,15 +306,16 @@ exports[`loads window query scenario 1 1`] = `
             >
               Results
             </h2>
-            <div
-              class="bf-result-view-description"
+            <h3
+              aria-level="3"
+              class="bf-result-view-description font-family-sans"
+              id=""
+              role="heading"
             >
-              <div>
-                <strong>
-                  You may be eligible for these benefits:
-                </strong>
-              </div>
-            </div>
+              <strong>
+                You may be eligible for these benefits:
+              </strong>
+            </h3>
             <div
               class="bf-result-view-benefits"
             >
@@ -6262,15 +6263,16 @@ exports[`loads window query scenario 2 1`] = `
             >
               Results
             </h2>
-            <div
-              class="bf-result-view-description"
+            <h3
+              aria-level="3"
+              class="bf-result-view-description font-family-sans"
+              id=""
+              role="heading"
             >
-              <div>
-                <strong>
-                  You may be eligible for these benefits:
-                </strong>
-              </div>
-            </div>
+              <strong>
+                You may be eligible for these benefits:
+              </strong>
+            </h3>
             <div
               class="bf-result-view-benefits"
             >

--- a/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
@@ -58,15 +58,16 @@ exports[`loads view 1`] = `
           >
             Results
           </h2>
-          <div
-            class="bf-result-view-description"
+          <h3
+            aria-level="3"
+            class="bf-result-view-description font-family-sans"
+            id=""
+            role="heading"
           >
-            <div>
-              <strong>
-                You may be eligible for these benefits:
-              </strong>
-            </div>
-          </div>
+            <strong>
+              You may be eligible for these benefits:
+            </strong>
+          </h3>
           <div
             class="bf-result-view-benefits"
           >
@@ -239,15 +240,16 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
           >
             Results
           </h2>
-          <div
-            class="bf-result-view-description"
+          <h3
+            aria-level="3"
+            class="bf-result-view-description font-family-sans"
+            id=""
+            role="heading"
           >
-            <div>
-              <strong>
-                You may be eligible for these benefits:
-              </strong>
-            </div>
-          </div>
+            <strong>
+              You may be eligible for these benefits:
+            </strong>
+          </h3>
           <div
             class="bf-result-view-benefits"
           >

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -94,8 +94,9 @@ const ResultsView = ({
           <Heading className="bf-result-view-heading" headingLevel={2}>
             {notQualifiedView ? notQualified.heading : qualified.heading}
           </Heading>
-          <div
+          <Heading
             className="bf-result-view-description"
+            headingLevel={3}
             dangerouslySetInnerHTML={
               notQualifiedView
                 ? createMarkup(notQualified.description)

--- a/benefit-finder/src/shared/locales/en/en.json
+++ b/benefit-finder/src/shared/locales/en/en.json
@@ -79,7 +79,7 @@
         "description": "<div><p>Visit each agency to find true eligibility and to apply. Check with your city, state, or employer for other benefits.</p></div>"
       },
       "heading": "Results",
-      "description": "<div><strong>You may be eligible for these benefits:</strong></div>"
+      "description": "<strong>You may be eligible for these benefits:</strong>"
     },
     "notQualified": {
       "chevron": {
@@ -87,7 +87,7 @@
         "description": "According to your answers you are not eligible for these benefits."
       },
       "heading": "Results",
-      "description": "<div><strong>Based on your answers you are not eligible for these benefits.</strong>You may become eligible if you enter additional information or your situation changes.</div>"
+      "description": "<strong>Based on your answers you are not eligible for these benefits.</strong>You may become eligible if you enter additional information or your situation changes."
     },
     "stepBackLink": "Back",
     "eligibleResults": {

--- a/benefit-finder/src/shared/locales/es/es.json
+++ b/benefit-finder/src/shared/locales/es/es.json
@@ -79,7 +79,7 @@
         "description": "<div><p>Visite la página de cada agencia para verificar los requisitos y aplicar. Para conocer otros beneficios, consulte a su ciudad, estado, o trabajo.</p></div>"
       },
       "heading": "Resultados",
-      "description": "<div><strong>Podría ser elegible para estos beneficios:<strong/></div>"
+      "description": "<strong>Podría ser elegible para estos beneficios:<strong/>"
     },
     "notQualified": {
       "chevron": {
@@ -87,7 +87,7 @@
         "description": "Según sus respuestas usted no es elegible para estos beneficios."
       },
       "heading": "Resultados",
-      "description": "<div><strong>Según sus respuestas no es elegible para estos beneficios.<strong/> Podría calificar si tiene información adicional o si su situación cambia.</div>"
+      "description": "<strong>Según sus respuestas no es elegible para estos beneficios.<strong/> Podría calificar si tiene información adicional o si su situación cambia."
     },
     "stepBackLink": "Volver",
     "eligibleResults": {


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
updates heading levels in results view

## Related Github Issue

- Fixes #1058 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [x] pull changes locally
- [x] `cd benefit finder`
- [x] `npm install`
- [x] `npm run start`

<!--- If there are steps for user testing list them here -->
- [x] navigate to results view
- [x] open console, ensure that there are no axe errors for heading levels logged

or

- [x] view heading structure using ANDI
- [x] ensure error reported in initial ticket is resolved
<img width="674" alt="Capture" src="https://github.com/GSA/px-benefit-finder/assets/142342010/6ec4ef40-50f7-4b0e-99fa-b8c844ef0d1b">
