### PR TITLE
PXBF-977-icons-green-check-eligible-items: validate green check icon on eligible benefits

### DIFF
--- a/benefit-finder/cypress/e2e/storybook/selected-criteria-eligibility-benefits.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/selected-criteria-eligibility-benefits.cy.js
@@ -141,4 +141,14 @@ describe('Validate correct eligibility benefits display based on selected criter
       .and('contain', 'Likely eligible')
       .and('contain', enResults.eligible.eligible_benefits[0])
   })
+
+  it('Should display green check icons on eligible benefits', () => {
+    const selectedData = BENEFITS_ELIBILITY_DATA.scenario_2_veteran.en.param
+    const scenario = utils.encodeURIFromObject(selectedData)
+    cy.visit(`${utils.storybookUri}${scenario}`)
+    pageObjects.expandAll().click()
+    pageObjects
+      .keyEligibilityCriteriaListIcon()
+      .should('have.class', 'bf-checkmark--green')
+  })
 })

--- a/benefit-finder/cypress/support/pageObjects.js
+++ b/benefit-finder/cypress/support/pageObjects.js
@@ -104,6 +104,14 @@ class PageObjects {
   radioGroup() {
     return cy.get('main .radio-group')
   }
+
+  expandAll() {
+    return cy.get('.bf-expand-all')
+  }
+
+  keyEligibilityCriteriaListIcon() {
+    return cy.get('.usa-accordion .bf-usa-list svg')
+  }
 }
 
 export const pageObjects = new PageObjects()


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

## Related Github Issue

- Fixes #977 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] `cd benefit finder`
- [ ] `npm install`
- [ ] `npm run dev:storybook` to start storybook
- [ ] `npm run cy:run` and verify the newly added test in `selected-criteria-eligibility-benefits.cy.js ` pass as well component and other e2e test

<!--- If there are steps for user testing list them here -->
