### PR TITLE
1092 link validations test

### DIFF
--- a/.github/workflows/cypress-prod-links-e2e.yml
+++ b/.github/workflows/cypress-prod-links-e2e.yml
@@ -1,0 +1,39 @@
+name: Run Cypress e2e Prod Nightly Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions: read-all
+
+defaults:
+  run:
+    working-directory: ./benefit-finder
+
+jobs:
+  install:
+    name: cypress-run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: "./benefit-finder/package.json"
+
+      - name: Cypress Run
+        uses: cypress-io/github-action@v6
+        with:
+          browser: 'chrome'
+          config-file: cypress.prod.links.config.js
+          working-directory: benefit-finder
+          start: "npm run cy:run:prod:links:e2e"
+
+      - uses: actions/upload-artifact@v3
+        if: failure ()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots

--- a/benefit-finder/cypress.prod.config.js
+++ b/benefit-finder/cypress.prod.config.js
@@ -1,6 +1,10 @@
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
+  retries: {
+    runMode: 2,
+    openMode: 0,
+  },
   e2e: {
     baseUrl: 'https://www.usa.gov',
     specPattern: 'cypress/e2e/usagov-public-site/*.cy.js',

--- a/benefit-finder/cypress.prod.links.config.js
+++ b/benefit-finder/cypress.prod.links.config.js
@@ -1,9 +1,12 @@
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
+  retries: {
+    runMode: 2,
+    openMode: 0,
+  },
   e2e: {
     baseUrl: 'https://www.usa.gov',
-    specPattern: 'cypress/e2e/usagov-public-site/*.cy.js',
-    excludeSpecPattern: 'cypress/e2e/usagov-public-site/links.cy.js',
+    specPattern: 'cypress/e2e/usagov-public-site/links.cy.js',
   },
 })

--- a/benefit-finder/cypress/e2e/usagov-public-site/links.cy.js
+++ b/benefit-finder/cypress/e2e/usagov-public-site/links.cy.js
@@ -3,8 +3,8 @@
 import * as utils from '../../support/utils'
 import * as BENEFITS_ELIBILITY_DATA from '../../fixtures/benefits-eligibility.json'
 
-// to be removed when uncaught exceptions are addressed
 describe('Verify correct status code when user navigates links', () => {
+  // to be removed when uncaught exceptions are addressed
   Cypress.on('uncaught:exception', (_err, runnable) => {
     return false
   })
@@ -13,7 +13,7 @@ describe('Verify correct status code when user navigates links', () => {
       BENEFITS_ELIBILITY_DATA['death-of-a-loved-one'].en.param
     const scenario = utils.encodeURIFromObject(selectedData)
     cy.visit(`benefit-finder/death?${scenario}`)
-    cy.get('a[href]').each(link => {
+    cy.get('main a[href]').each(link => {
       cy.request(link.prop('href'))
     })
   })
@@ -23,7 +23,7 @@ describe('Verify correct status code when user navigates links', () => {
       BENEFITS_ELIBILITY_DATA['death-of-a-loved-one'].es.param
     const scenario = utils.encodeURIFromObject(selectedData)
     cy.visit(`es/buscador-beneficios/muerte?${scenario}`)
-    cy.get('a[href]').each(link => {
+    cy.get('main a[href]').each(link => {
       cy.request(link.prop('href'))
     })
   })
@@ -32,7 +32,7 @@ describe('Verify correct status code when user navigates links', () => {
     const selectedData = BENEFITS_ELIBILITY_DATA.retirement.en.param
     const scenario = utils.encodeURIFromObject(selectedData)
     cy.visit(`benefit-finder/retirement?${scenario}`)
-    cy.get('a[href]').each(link => {
+    cy.get('main a[href]').each(link => {
       cy.request(link.prop('href'))
     })
   })
@@ -41,7 +41,7 @@ describe('Verify correct status code when user navigates links', () => {
     const selectedData = BENEFITS_ELIBILITY_DATA.retirement.es.param
     const scenario = utils.encodeURIFromObject(selectedData)
     cy.visit(`es/buscador-beneficios/jubilacion?${scenario}`)
-    cy.get('a[href]').each(link => {
+    cy.get('main a[href]').each(link => {
       cy.request(link.prop('href'))
     })
   })
@@ -50,7 +50,7 @@ describe('Verify correct status code when user navigates links', () => {
     const selectedData = BENEFITS_ELIBILITY_DATA.disability.en.param
     const scenario = utils.encodeURIFromObject(selectedData)
     cy.visit(`benefit-finder/disability?${scenario}`)
-    cy.get('a[href]').each(link => {
+    cy.get('main a[href]').each(link => {
       cy.request(link.prop('href'))
     })
   })
@@ -59,7 +59,7 @@ describe('Verify correct status code when user navigates links', () => {
     const selectedData = BENEFITS_ELIBILITY_DATA.disability.es.param
     const scenario = utils.encodeURIFromObject(selectedData)
     cy.visit(`es/buscador-beneficios/discapacidad?${scenario}`)
-    cy.get('a[href]').each(link => {
+    cy.get('main a[href]').each(link => {
       cy.request(link.prop('href'))
     })
   })

--- a/benefit-finder/cypress/e2e/usagov-public-site/links.cy.js
+++ b/benefit-finder/cypress/e2e/usagov-public-site/links.cy.js
@@ -1,0 +1,66 @@
+/// <reference types="cypress"/>
+
+import * as utils from '../../support/utils'
+import * as BENEFITS_ELIBILITY_DATA from '../../fixtures/benefits-eligibility.json'
+
+// to be removed when uncaught exceptions are addressed
+describe('Verify correct status code when user navigates links', () => {
+  Cypress.on('uncaught:exception', (_err, runnable) => {
+    return false
+  })
+  it('Verify success status code response for links in Death of a loved one English page', () => {
+    const selectedData =
+      BENEFITS_ELIBILITY_DATA['death-of-a-loved-one'].en.param
+    const scenario = utils.encodeURIFromObject(selectedData)
+    cy.visit(`benefit-finder/death?${scenario}`)
+    cy.get('a[href]').each(link => {
+      cy.request(link.prop('href'))
+    })
+  })
+
+  it('Verify success status code response for links in Death of a Loved One Spanish page', () => {
+    const selectedData =
+      BENEFITS_ELIBILITY_DATA['death-of-a-loved-one'].es.param
+    const scenario = utils.encodeURIFromObject(selectedData)
+    cy.visit(`es/buscador-beneficios/muerte?${scenario}`)
+    cy.get('a[href]').each(link => {
+      cy.request(link.prop('href'))
+    })
+  })
+
+  it('Verify success status code response for links in Retirement English page', () => {
+    const selectedData = BENEFITS_ELIBILITY_DATA.retirement.en.param
+    const scenario = utils.encodeURIFromObject(selectedData)
+    cy.visit(`benefit-finder/retirement?${scenario}`)
+    cy.get('a[href]').each(link => {
+      cy.request(link.prop('href'))
+    })
+  })
+
+  it('Verify success status code response for links in Retirement Spanish page', () => {
+    const selectedData = BENEFITS_ELIBILITY_DATA.retirement.es.param
+    const scenario = utils.encodeURIFromObject(selectedData)
+    cy.visit(`es/buscador-beneficios/jubilacion?${scenario}`)
+    cy.get('a[href]').each(link => {
+      cy.request(link.prop('href'))
+    })
+  })
+
+  it('Verify success status code response for links in Disability English page', () => {
+    const selectedData = BENEFITS_ELIBILITY_DATA.disability.en.param
+    const scenario = utils.encodeURIFromObject(selectedData)
+    cy.visit(`benefit-finder/disability?${scenario}`)
+    cy.get('a[href]').each(link => {
+      cy.request(link.prop('href'))
+    })
+  })
+
+  it('Verify success status code response for links in Disability English page', () => {
+    const selectedData = BENEFITS_ELIBILITY_DATA.disability.es.param
+    const scenario = utils.encodeURIFromObject(selectedData)
+    cy.visit(`es/buscador-beneficios/discapacidad?${scenario}`)
+    cy.get('a[href]').each(link => {
+      cy.request(link.prop('href'))
+    })
+  })
+})

--- a/benefit-finder/cypress/fixtures/benefits-eligibility.json
+++ b/benefit-finder/cypress/fixtures/benefits-eligibility.json
@@ -123,5 +123,80 @@
         "total_benefits": 30
       }
     }
+  },
+  "death-of-a-loved-one": {
+    "en": {
+      "param": {
+        "applicant_date_of_birth": {
+          "month": 1,
+          "day": 1,
+          "year": 1971
+        },
+        "applicant_relationship_to_the_deceased": "Child",
+        "applicant_marital_status": "Unmarried",
+        "deceased_date_of_death": {
+          "month": 1,
+          "day": 1,
+          "year": 2024
+        }
+      }
+    },
+    "es": {
+      "param": {
+        "es_applicant_date_of_birth": {
+          "month": 1,
+          "day": 1,
+          "year": 1971
+        },
+        "es_applicant_relationship_to_the_deceased": "Hija/o",
+        "es_applicant_marital_status": "No casada/o"
+      },
+      "es_deceased_date_of_death": {
+        "month": 1,
+        "day": 1,
+        "year": 2024
+      }
+    }
+  },
+  "retirement": {
+    "en": {
+      "param": {
+        "applicant_date_of_birth": {
+          "month": 1,
+          "day": 1,
+          "year": 1971
+        }
+      }
+    },
+    "es": {
+      "param": {
+        "es_applicant_date_of_birth": {
+          "month": 1,
+          "day": 1,
+          "year": 1971
+        }
+      }
+    }
+  },
+  "disability": {
+    "en": {
+      "param": {
+        "applicant_date_of_birth": {
+          "month": 1,
+          "day": 1,
+          "year": 1971
+        },
+        "applicant_marital_status": "Unmarried"
+      }
+    },
+    "es": {
+      "param": {
+        "es_applicant_date_of_birth": {
+          "month": 1,
+          "day": 1,
+          "year": 1971
+        }
+      }
+    }
   }
 }

--- a/benefit-finder/cypress/fixtures/benefits-eligibility.json
+++ b/benefit-finder/cypress/fixtures/benefits-eligibility.json
@@ -138,7 +138,8 @@
           "month": 1,
           "day": 1,
           "year": 2024
-        }
+        },
+        "shared": "true"
       }
     },
     "es": {
@@ -149,13 +150,15 @@
           "year": 1971
         },
         "es_applicant_relationship_to_the_deceased": "Hija/o",
-        "es_applicant_marital_status": "No casada/o"
+        "es_applicant_marital_status": "No casada/o",
+        "shared": "true"
       },
       "es_deceased_date_of_death": {
         "month": 1,
         "day": 1,
         "year": 2024
-      }
+      },
+      "shared": "true"
     }
   },
   "retirement": {
@@ -165,7 +168,8 @@
           "month": 1,
           "day": 1,
           "year": 1971
-        }
+        },
+        "shared": "true"
       }
     },
     "es": {
@@ -174,7 +178,8 @@
           "month": 1,
           "day": 1,
           "year": 1971
-        }
+        },
+        "shared": "true"
       }
     }
   },
@@ -186,8 +191,10 @@
           "day": 1,
           "year": 1971
         },
-        "applicant_marital_status": "Unmarried"
+        "applicant_marital_status": "Unmarried",
+        "shared": "true"
       }
+     
     },
     "es": {
       "param": {
@@ -195,7 +202,8 @@
           "month": 1,
           "day": 1,
           "year": 1971
-        }
+        },
+        "shared": "true"
       }
     }
   }


### PR DESCRIPTION
## PR Summary

This PR adds links validation cypress tests on benefit finder application English and Spanish pages
## Related Github Issue

- Fixes #1092

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] `cd benefit finder`
- [ ] `npm install`
- [ ] `npm run cy:run:prod:links:e2e` 
- [ ] Verify ` links.cy.js` tests are running. I am seeing 404 page not found seeing failures in retirement and disability page that need to be addressed.
<!--- If there are steps for user testing list them here -->
