### PR TITLE
1137 safari date fix

### DIFF
--- a/benefit-finder/src/shared/api/apiCalls.js
+++ b/benefit-finder/src/shared/api/apiCalls.js
@@ -27,14 +27,21 @@ export const DateEligibility = ({ selectedValue, conditional }) => {
   const operators = /['>', '>=', '<', '<=', '=']/g
   const operator = text.match(operators)
   const integer = text.match(/\d+/)[0]
+  const regExOperator = new RegExp(`[${operator}]`, 'g')
+
+  // !!we have to replace the dashes ("-") in the date because Safari can only parse ("/") in new Date evaluation!!
+
+  // after we fix safari we remove the operator values to give us only the date
+  const trimmedText = text.replace(/-/g, '/').replace(regExOperator, '')
 
   // calculate back
   // get current date
   // subtract integer
   // if a date comes back in date format
+
   const pattern = /-/
   const conditionalDate = pattern.test(text)
-    ? new window.Date(text)
+    ? new window.Date(trimmedText)
     : new window.Date(
         new Date().getFullYear() - integer,
         new Date().getMonth(),
@@ -59,6 +66,8 @@ export const DateEligibility = ({ selectedValue, conditional }) => {
       0
     )
   )
+
+  console.log(conditionalDate, selectedDate)
 
   const isDateEligible = (operator, conditionalDate, selectedDate) => {
     // ['>', '>=', '<', '<=', '=']
@@ -305,6 +314,7 @@ export const ElegibilityByCriteria = (selectedCriteria, data) => {
             let eligibility
 
             if (typeof selected.values.value === 'object') {
+              console.log(selected.values.value)
               eligibility = criteriaEligibility.acceptableValues.find(value =>
                 UTILS.DateEligibility({
                   selectedValue: selected.values.value,

--- a/benefit-finder/src/shared/api/apiCalls.js
+++ b/benefit-finder/src/shared/api/apiCalls.js
@@ -12,7 +12,6 @@
  * @return {boolean} true or false based on the conditional
  */
 export const DateEligibility = ({ selectedValue, conditional }) => {
-  // console.log({ selectedValue, conditional })
   // date values
   // "<01-01-1978"
   // "<2years (the deceased died within the last two years)"
@@ -66,8 +65,6 @@ export const DateEligibility = ({ selectedValue, conditional }) => {
       0
     )
   )
-
-  console.log(conditionalDate, selectedDate)
 
   const isDateEligible = (operator, conditionalDate, selectedDate) => {
     // ['>', '>=', '<', '<=', '=']
@@ -314,7 +311,6 @@ export const ElegibilityByCriteria = (selectedCriteria, data) => {
             let eligibility
 
             if (typeof selected.values.value === 'object') {
-              console.log(selected.values.value)
               eligibility = criteriaEligibility.acceptableValues.find(value =>
                 UTILS.DateEligibility({
                   selectedValue: selected.values.value,


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
Safari date parsing in `new window.Date(<DATE>)` does not accept "-" and instead needs "/" between the integer values to correctly handle a valid date.

## Related Github Issue

- Fixes #1137 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [x] use safari
- [x] navigate to https://www.usa.gov/benefit-finder/death?applicant_date_of_birth=%7B%22month%22%3A%220%22%2C%22day%22%3A%2222%22%2C%22year%22%3A%222022%22%7D&applicant_relationship_to_the_deceased=Spouse&applicant_marital_status=Married&applicant_citizen_status=Yes&applicant_care_for_child=Yes&applicant_paid_funeral_expenses=Yes&deceased_date_of_death=%7B%22month%22%3A%220%22%2C%22day%22%3A%2222%22%2C%22year%22%3A%222022%22%7D&deceased_death_location_is_US=Yes&deceased_paid_into_SS=Yes&deceased_public_safety_officer=Yes&deceased_miner=Yes&deceased_american_indian=Yes&deceased_died_of_COVID=Yes&deceased_served_in_active_military=No&shared=true
- [x] navigate to benefits you did not qualify for
- [x] open "Covid 19 Funeral Assistance"
- [x] confirm that date is not eligible
- [x] pull changes locally
- [x] `cd benefit-finder`
- [x] `npm install`
- [x] `npm run start`

<!--- If there are steps for user testing list them here -->
- [x] navigate to `<localhost>/death?applicant_date_of_birth=%7B%22month%22%3A%220%22%2C%22day%22%3A%2222%22%2C%22year%22%3A%222022%22%7D&applicant_relationship_to_the_deceased=Spouse&applicant_marital_status=Married&applicant_citizen_status=Yes&applicant_care_for_child=Yes&applicant_paid_funeral_expenses=Yes&deceased_date_of_death=%7B%22month%22%3A%220%22%2C%22day%22%3A%2222%22%2C%22year%22%3A%222022%22%7D&deceased_death_location_is_US=Yes&deceased_paid_into_SS=Yes&deceased_public_safety_officer=Yes&deceased_miner=Yes&deceased_american_indian=Yes&deceased_died_of_COVID=Yes&deceased_served_in_active_military=No&shared=true`
- [x] confirm that "Covid 19 Funeral Assistance" is in the eligible benefits view
- [x] `npm run build`
- [x] `npm run serve`
- [x] navigate to `<localhost>/death?applicant_date_of_birth=%7B%22month%22%3A%220%22%2C%22day%22%3A%2222%22%2C%22year%22%3A%222022%22%7D&applicant_relationship_to_the_deceased=Spouse&applicant_marital_status=Married&applicant_citizen_status=Yes&applicant_care_for_child=Yes&applicant_paid_funeral_expenses=Yes&deceased_date_of_death=%7B%22month%22%3A%220%22%2C%22day%22%3A%2222%22%2C%22year%22%3A%222022%22%7D&deceased_death_location_is_US=Yes&deceased_paid_into_SS=Yes&deceased_public_safety_officer=Yes&deceased_miner=Yes&deceased_american_indian=Yes&deceased_died_of_COVID=Yes&deceased_served_in_active_military=No&shared=true`
- [x] confirm that "Covid 19 Funeral Assistance" is in the eligible benefits view
- [ ] confirm cross browser
- [x] Safari 16
- [x] Safari 17
- [x] Firefox
- [x] Edge
- [x] Chrome
- [x] Android
- [x] iOS
