### PR TITLE
1141 generate only draft json file for content draft

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_api/usagov_benefit_finder_api.module
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_api/usagov_benefit_finder_api.module
@@ -56,8 +56,10 @@ function usagov_benefit_finder_api_save_json_data(Node $node) {
         ->fetchAll();
       foreach ($result as $record) {
         $id = $record->field_b_id_value;
-        $lifeEventController->mode = "published";
-        $lifeEventController->saveJsonData($id);
+        if ($node->isPublished()) {
+          $lifeEventController->mode = "published";
+          $lifeEventController->saveJsonData($id);
+        }
         $lifeEventController->mode = "draft";
         $lifeEventController->saveJsonData($id);
       }


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

This work generates only draft JSON data files for content changed and saved as draft.

## Related Github Issue

- Fixes #1141

## Detailed Testing steps

Test in local development site.

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] `bash mv-usagov_benefit_finder.sh`
- [ ] `cd usagov-2021`
- [ ] make local development site up at http://localhost
- [ ] Go to /admin/content?combine=&type=bears_criteria&status=All&langcode=All
- [ ] Edit criteria "Deceased died of COVID"
- [ ] Save as draft
- [ ] `ls -lR s3/local/cms/public/benefit-finder/api`
- [ ] Check the timestamp draft and published JSON data files to see only generate new draft JSON data files.
- [ ] Edit criteria "Deceased died of COVID"
- [ ] Save as published
- [ ] `ls -lR s3/local/cms/public/benefit-finder/api`
- [ ] Check the timestamp draft and published JSON data files to see generate both draft and published JSON data files.



<!--- If there are steps for user testing list them here -->
