### PR TITLE
1159 add dependency in criteria

### DIFF
--- a/usagov_benefit_finder/configuration/core.entity_form_display.node.bears_criteria.default.yml
+++ b/usagov_benefit_finder/configuration/core.entity_form_display.node.bears_criteria.default.yml
@@ -1,0 +1,193 @@
+uuid: 7b0ea4b3-ad18-416a-81a4-6515572f433f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.bears_criteria.field_b_child_dependency_option
+    - field.field.node.bears_criteria.field_b_criteria_key
+    - field.field.node.bears_criteria.field_b_has_child
+    - field.field.node.bears_criteria.field_b_id
+    - field.field.node.bears_criteria.field_b_label
+    - field.field.node.bears_criteria.field_b_name
+    - field.field.node.bears_criteria.field_b_type
+    - field.field.node.bears_criteria.field_b_values
+    - field.field.node.bears_criteria.field_language_toggle
+    - node.type.bears_criteria
+  module:
+    - content_moderation
+    - path
+id: node.bears_criteria.default
+targetEntityType: node
+bundle: bears_criteria
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_b_child_dependency_option:
+    type: string_textfield
+    weight: 16
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings:
+      conditional_fields:
+        7d256aff-5858-4005-83b2-7a6221d75c58:
+          entity_type: node
+          bundle: bears_criteria
+          dependee: field_b_has_child
+          settings:
+            state: required
+            reset: false
+            condition: checked
+            grouping: AND
+            values_set: 1
+            value: ''
+            values: {  }
+            value_form:
+              value: false
+            effect: show
+            effect_options: {  }
+            selector: ''
+  field_b_criteria_key:
+    type: string_textfield
+    weight: 9
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_has_child:
+    type: boolean_checkbox
+    weight: 15
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_b_id:
+    type: string_textfield
+    weight: 10
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_label:
+    type: string_textfield
+    weight: 12
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_name:
+    type: string_textfield
+    weight: 13
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_type:
+    type: options_select
+    weight: 11
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_b_values:
+    type: string_textfield
+    weight: 14
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_language_toggle:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 0
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 18
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 4
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 7
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 5
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 8
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 2
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 17
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  menu_entity_index: true

--- a/usagov_benefit_finder/configuration/core.entity_form_display.node.bears_criteria.default.yml
+++ b/usagov_benefit_finder/configuration/core.entity_form_display.node.bears_criteria.default.yml
@@ -53,6 +53,23 @@ content:
             effect: show
             effect_options: {  }
             selector: ''
+        91ce84c7-8a94-49dc-a41c-d5c0f369a2d0:
+          entity_type: node
+          bundle: bears_criteria
+          dependee: field_b_has_child
+          settings:
+            state: visible
+            reset: false
+            condition: checked
+            grouping: AND
+            values_set: 1
+            value: ''
+            values: {  }
+            value_form:
+              value: false
+            effect: show
+            effect_options: {  }
+            selector: ''
   field_b_criteria_key:
     type: string_textfield
     weight: 9


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This work adds dependency in criteria. 
It makes child dependency option field depends on has child field. 
if has child field not checked, the child dependency option field in invisible.
If has child field checked, the child dependency option field becomes visible and required.

## Related Github Issue

- Fixes #1159

## Detailed Testing steps

To test in local development site or in Benefit Finder DEV site.

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally if test in local development site
- [ ] `bin/drush cim --partial --source=modules/custom/usagov_benefit_finder/configuration -y`
- [ ] make local development site up at http://localhost
- [ ] navigate to add criteria page: /node/add/bears_criteria
- [ ] confirm "Child dependency option" field is invisible if "has child" field not checked
<img width="200" src="https://github.com/GSA/px-benefit-finder/assets/88853916/4295a468-5c63-41a0-a68c-96432b66db9f">

- [ ] check "has child" field
- [ ] confirm "Child dependency option" field become visible and required
<img width="400" src="https://github.com/GSA/px-benefit-finder/assets/88853916/02fe844d-e895-4a9e-87aa-9e9c909b61ed">
<!--- If there are steps for user testing list them here -->
