### PR TITLE
1164 add H1 in life event page template

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_app/usagov_benefit_finder_page/templates/page--benefit-finder-life-event.html.twig
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_app/usagov_benefit_finder_page/templates/page--benefit-finder-life-event.html.twig
@@ -123,7 +123,8 @@
     {{ page.breadcrumb }}
   </div>
   <div id="benefit-finder" json-data-file-path="{{ json_data_file_path }}" draft-json-data-file-path="{{ draft_json_data_file_path }}">
-    <h1 class="bf-chevron-heading font-family-sans" id="skip-to-h1" aria-level="1" role="heading">{{ node.label }}</h1>
+    {# app will rehydrate and replace innerHTML #}
+    <h1 class="usa-sr-only" id="skip-to-h1" aria-level="1" hidden role="heading">{{ node.label }}</h1>
   </div>
 
   {% else %}

--- a/usagov_benefit_finder/modules/usagov_benefit_finder_app/usagov_benefit_finder_page/templates/page--benefit-finder-life-event.html.twig
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_app/usagov_benefit_finder_page/templates/page--benefit-finder-life-event.html.twig
@@ -122,7 +122,9 @@
   <div class="grid-container">
     {{ page.breadcrumb }}
   </div>
-  <div id="benefit-finder" json-data-file-path="{{ json_data_file_path }}" draft-json-data-file-path="{{ draft_json_data_file_path }}"></div>
+  <div id="benefit-finder" json-data-file-path="{{ json_data_file_path }}" draft-json-data-file-path="{{ draft_json_data_file_path }}">
+    <h1 class="bf-chevron-heading font-family-sans" id="skip-to-h1" aria-level="1" role="heading">{{ node.label }}</h1>
+  </div>
 
   {% else %}
   <main class="main-content usa-layout-docs no-footer-gap {{ main_classes }}" role="main" id="main-content" data-pagetype="{{term_name}}">


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This work adds missing H1 in life event page template.

## Related Github Issue

- Fixes #1164

## Detailed Testing steps

Test in local development site or dev site.

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] make local development site up at http://localhost
- [ ] navigate to http://localhost/benefit-finder/death

<!--- If there are steps for user testing list them here -->

- [ ] open web browser  inspector
- [ ] In sources select, `benefit-finder.min.js`
- [ ] set a break point at line 1
- [ ] refresh web page
- [ ] examine H1 from life event page template
- [ ] ensure content from node is available to DOM but not visible in UI
- [ ] step forward
- [ ] note if JS rehydrates DOM
- [ ] examine H1 from React JS
- [ ] navigate app steps and ensure only one H1 is present in DOM

https://github.com/GSA/px-benefit-finder/assets/37077057/b65d005b-9ea4-4749-84c3-4035d45d8dd5



