### PR TITLE
1166 add meta description field in life event

### DIFF
--- a/usagov_benefit_finder/configuration/core.entity_form_display.node.bears_life_event.default.yml
+++ b/usagov_benefit_finder/configuration/core.entity_form_display.node.bears_life_event.default.yml
@@ -1,0 +1,182 @@
+uuid: 99c745fb-37ed-4061-89ac-3bf52d328117
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.bears_life_event.field_b_id
+    - field.field.node.bears_life_event.field_draft_json_data_file
+    - field.field.node.bears_life_event.field_draft_json_data_file_path
+    - field.field.node.bears_life_event.field_header_html
+    - field.field.node.bears_life_event.field_json_data_file
+    - field.field.node.bears_life_event.field_json_data_file_path
+    - field.field.node.bears_life_event.field_language_toggle
+    - field.field.node.bears_life_event.field_meta_description
+    - field.field.node.bears_life_event.field_summary
+    - node.type.bears_life_event
+  module:
+    - allowed_formats
+    - content_moderation
+    - file
+    - path
+    - text
+id: node.bears_life_event.default
+targetEntityType: node
+bundle: bears_life_event
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_b_id:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_draft_json_data_file:
+    type: file_generic
+    weight: 16
+    region: content
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+  field_draft_json_data_file_path:
+    type: string_textfield
+    weight: 14
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_header_html:
+    type: text_textarea
+    weight: 20
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '0'
+  field_json_data_file:
+    type: file_generic
+    weight: 15
+    region: content
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+  field_json_data_file_path:
+    type: string_textfield
+    weight: 13
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_language_toggle:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_meta_description:
+    type: string_textarea
+    weight: 3
+    region: content
+    settings:
+      rows: 1
+      placeholder: ''
+    third_party_settings: {  }
+  field_summary:
+    type: string_textarea
+    weight: 4
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 0
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 11
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 9
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 7
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 12
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 8
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  menu_entity_index: true

--- a/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_life_event.default.yml
+++ b/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_life_event.default.yml
@@ -1,0 +1,113 @@
+uuid: 6a658720-5cd1-4c61-bf1c-a8f0c9a40680
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.bears_life_event.field_b_id
+    - field.field.node.bears_life_event.field_draft_json_data_file
+    - field.field.node.bears_life_event.field_draft_json_data_file_path
+    - field.field.node.bears_life_event.field_header_html
+    - field.field.node.bears_life_event.field_json_data_file
+    - field.field.node.bears_life_event.field_json_data_file_path
+    - field.field.node.bears_life_event.field_language_toggle
+    - field.field.node.bears_life_event.field_meta_description
+    - field.field.node.bears_life_event.field_summary
+    - node.type.bears_life_event
+  module:
+    - file
+    - text
+    - user
+id: node.bears_life_event.default
+targetEntityType: node
+bundle: bears_life_event
+mode: default
+content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
+  field_b_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_draft_json_data_file:
+    type: file_default
+    label: above
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
+    weight: 9
+    region: content
+  field_draft_json_data_file_path:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  field_header_html:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  field_json_data_file:
+    type: file_default
+    label: above
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
+    weight: 8
+    region: content
+  field_json_data_file_path:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  field_language_toggle:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_meta_description:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_summary:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  langcode:
+    type: language
+    label: above
+    settings:
+      link_to_entity: false
+      native_language: false
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_life_event.teaser.yml
+++ b/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_life_event.teaser.yml
@@ -1,0 +1,44 @@
+uuid: 75f24593-dd3f-4f75-aea4-27d8ca76f40b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.bears_life_event.field_b_id
+    - field.field.node.bears_life_event.field_draft_json_data_file
+    - field.field.node.bears_life_event.field_draft_json_data_file_path
+    - field.field.node.bears_life_event.field_header_html
+    - field.field.node.bears_life_event.field_json_data_file
+    - field.field.node.bears_life_event.field_json_data_file_path
+    - field.field.node.bears_life_event.field_language_toggle
+    - field.field.node.bears_life_event.field_meta_description
+    - field.field.node.bears_life_event.field_summary
+    - node.type.bears_life_event
+  module:
+    - user
+id: node.bears_life_event.teaser
+targetEntityType: node
+bundle: bears_life_event
+mode: teaser
+content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  field_b_id: true
+  field_draft_json_data_file: true
+  field_draft_json_data_file_path: true
+  field_header_html: true
+  field_json_data_file: true
+  field_json_data_file_path: true
+  field_language_toggle: true
+  field_meta_description: true
+  field_summary: true
+  langcode: true

--- a/usagov_benefit_finder/configuration/field.field.node.bears_life_event.field_meta_description.yml
+++ b/usagov_benefit_finder/configuration/field.field.node.bears_life_event.field_meta_description.yml
@@ -1,0 +1,19 @@
+uuid: b3333760-014c-45c3-9ac9-1d5c9a3e6a91
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_description
+    - node.type.bears_life_event
+id: node.bears_life_event.field_meta_description
+field_name: field_meta_description
+entity_type: node
+bundle: bears_life_event
+label: 'Meta Description'
+description: 'Text to place in a "meta description" tag on this page. If this field is empty, the Page Intro will be used for the meta description. '
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This work adds meta description field in life event.

## Related Github Issue

- Fixes #1166 

## Detailed Testing steps

Test in local development site or in dev.

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] make local development site up at http://localhost
- [ ] navigate to http://localhost/admin/content?combine=&type=bears_life_event&status=All&langcode=All
- [ ] edit life event Benefit finder: death of a loved one 
- [ ] add meta description "Find federal benefits fast. Answer a few questions and in a few minutes get your list of possible benefits across different agencies."
- [ ] save
- [ ] navigate to http://localhost/benefit-finder/death
- [ ] examine meta description in header

![image](https://github.com/GSA/px-benefit-finder/assets/88853916/510f8579-c4a3-45af-8df8-f49ee0bd866e)

<!--- If there are steps for user testing list them here -->
