### PR TITLE
update heading level in modal

### DIFF
--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import NavModal from 'react-modal'
 import PropTypes from 'prop-types'
-import { ObfuscatedLink, Icon } from '../index'
+import { ObfuscatedLink, Icon, Heading } from '../index'
 import { scrollLock } from '../../utils'
 
 import './_index.scss'
@@ -205,7 +205,9 @@ const Modal = ({
         >
           <Icon type="modal-close" color="black" alt="a close out icon" />
         </button>
-        <div className="bf-modal-heading">{modalHeading}</div>
+        <Heading headingLevel={1} className="bf-modal-heading">
+          {modalHeading}
+        </Heading>
         {children || (
           <GroupNavigation
             navItemOneLabel={navItemOneLabel}


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
Updates modal element heading to `<h1/>`

## Related Github Issue

- Fixes #1119 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [x] pull changes locally
- [x] cd `benefit-finder`
- [x] `npm install`
- [x] `npm run start`

<!--- If there are steps for user testing list them here -->
- [x] navigate to modal step
- [x] inspect
- [x] ensure that heading in modal is`<h1 />`
- [x] ensure that styles did not change

<img width="1439" alt="Screenshot 2024-04-05 at 2 09 47 PM" src="https://github.com/GSA/px-benefit-finder/assets/37077057/995793be-7249-40d3-a892-cb26920f8b36">

