### PR TITLE
1072 update heading level on formgroup alerts

### DIFF
--- a/benefit-finder/src/shared/components/Alert/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/Alert/__tests__/__snapshots__/index.spec.jsx.snap
@@ -12,8 +12,11 @@ exports[`Alert > renders a match to the previous snapshot 1`] = `
     <div
       class="bf-usa-alert__body usa-alert__body"
     >
-      <h4
-        class="bf-usa-alert__heading usa-alert__heading"
+      <h2
+        aria-level="2"
+        class="bf-usa-alert__heading usa-alert__heading font-family-sans"
+        id=""
+        role="heading"
       />
       <p
         class="bf-usa-alert__text usa-alert__text"

--- a/benefit-finder/src/shared/components/Alert/_index.scss
+++ b/benefit-finder/src/shared/components/Alert/_index.scss
@@ -6,7 +6,7 @@
   border-left-color: color.$white;
 }
 
-h4.bf-usa-alert__heading {
+h2.bf-usa-alert__heading {
   @include h6;
 }
 

--- a/benefit-finder/src/shared/components/Alert/index.jsx
+++ b/benefit-finder/src/shared/components/Alert/index.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import { Heading } from '../index'
 import { useHandleClassName } from '../../hooks'
 import './_index.scss'
 
@@ -56,9 +57,12 @@ const Alert = ({
         </div>
       ) : (
         <div className="bf-usa-alert__body usa-alert__body">
-          <h4 className="bf-usa-alert__heading usa-alert__heading">
+          <Heading
+            headingLevel={2}
+            className="bf-usa-alert__heading usa-alert__heading"
+          >
             {heading}
-          </h4>
+          </Heading>
           <p className="bf-usa-alert__text usa-alert__text">{description}</p>
         </div>
       )}

--- a/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.jsx.snap
@@ -77,11 +77,14 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
           <div
             class="bf-usa-alert__body usa-alert__body"
           >
-            <h4
-              class="bf-usa-alert__heading usa-alert__heading"
+            <h2
+              aria-level="2"
+              class="bf-usa-alert__heading usa-alert__heading font-family-sans"
+              id=""
+              role="heading"
             >
               Error
-            </h4>
+            </h2>
             <p
               class="bf-usa-alert__text usa-alert__text"
             >


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
Updates Alert Headings in Forms to `<h2/>` for better accessibility structure.

## Related Github Issue

- Fixes #1072 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [x] pull changes locally
- [x] `cd benefit-finder`
- [x] `npm install`
- [x] `npm run start`

<!--- If there are steps for user testing list them here -->

- [x] navigate to step one of the form
- [x] tigger an error by clicking continue
- [x] inspect DOM
- [x] ensure that heading levels in errors are `<h2>` while remaining consistent in style to production

<img width="1440" alt="Screenshot 2024-04-05 at 2 27 20 PM" src="https://github.com/GSA/px-benefit-finder/assets/37077057/01d16763-4524-4ae4-8717-0589c2ba413c">

