### PR TITLE
1183 fix hidden info alerts

### DIFF
--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
@@ -130,7 +130,7 @@ exports[`loads intro 1`] = `
                     class="bf-notice"
                   >
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
                       role="alert"
@@ -159,7 +159,7 @@ exports[`loads intro 1`] = `
                     class="bf-notice"
                   >
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
                       role="alert"
@@ -187,7 +187,7 @@ exports[`loads intro 1`] = `
                     class="bf-notice"
                   >
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
                       role="alert"
@@ -501,7 +501,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -720,7 +720,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -934,7 +934,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -1153,7 +1153,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -1342,7 +1342,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -1545,7 +1545,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -1842,7 +1842,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -2046,7 +2046,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -2245,7 +2245,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -2494,7 +2494,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -2718,7 +2718,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -2901,7 +2901,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -3151,7 +3151,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -3365,7 +3365,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -3621,7 +3621,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -3840,7 +3840,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -4037,7 +4037,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -4233,7 +4233,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -4452,7 +4452,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -4688,7 +4688,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -4947,7 +4947,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -5214,7 +5214,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -5471,7 +5471,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -5768,7 +5768,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -6089,7 +6089,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -6287,7 +6287,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -6516,7 +6516,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -6765,7 +6765,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -7020,7 +7020,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -7239,7 +7239,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -7458,7 +7458,7 @@ exports[`loads window query scenario 1 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -8055,7 +8055,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -8274,7 +8274,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -8488,7 +8488,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -8707,7 +8707,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -8896,7 +8896,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -9099,7 +9099,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -9396,7 +9396,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -9600,7 +9600,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -9799,7 +9799,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -10048,7 +10048,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -10272,7 +10272,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -10468,7 +10468,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -10718,7 +10718,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -10932,7 +10932,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -11199,7 +11199,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -11418,7 +11418,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -11615,7 +11615,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -11811,7 +11811,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -12030,7 +12030,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -12266,7 +12266,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -12525,7 +12525,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -12792,7 +12792,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -13024,7 +13024,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -13310,7 +13310,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -13619,7 +13619,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -13817,7 +13817,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -14046,7 +14046,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -14295,7 +14295,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -14575,7 +14575,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -14794,7 +14794,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"
@@ -15013,7 +15013,7 @@ exports[`loads window query scenario 2 1`] = `
                         </ul>
                       </div>
                       <div
-                        aria-hidden="true"
+                        aria-hidden="false"
                         aria-live="polite"
                         class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                         role="alert"

--- a/benefit-finder/src/shared/components/Alert/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/Alert/__tests__/__snapshots__/index.spec.jsx.snap
@@ -3,7 +3,7 @@
 exports[`Alert > renders a match to the previous snapshot 1`] = `
 <DocumentFragment>
   <div
-    aria-hidden="true"
+    aria-hidden="false"
     aria-live="polite"
     class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
     role="alert"

--- a/benefit-finder/src/shared/components/Alert/index.jsx
+++ b/benefit-finder/src/shared/components/Alert/index.jsx
@@ -24,6 +24,7 @@ const Alert = ({
   hasError,
   noBackground,
   tabIndex,
+  ariaHidden,
 }) => {
   const defaultClasses = error
     ? [
@@ -48,7 +49,7 @@ const Alert = ({
       ref={alertFieldRef}
       tabIndex={tabIndex || 0}
       aria-live={hasError === true ? 'assertive' : 'polite'}
-      aria-hidden={!hasError}
+      aria-hidden={ariaHidden || !hasError}
     >
       {children ? (
         <div className="bf-usa-alert__body usa-alert__body">

--- a/benefit-finder/src/shared/components/Alert/index.jsx
+++ b/benefit-finder/src/shared/components/Alert/index.jsx
@@ -24,7 +24,6 @@ const Alert = ({
   hasError,
   noBackground,
   tabIndex,
-  ariaHidden,
 }) => {
   const defaultClasses = error
     ? [
@@ -32,7 +31,7 @@ const Alert = ({
         'usa-alert',
         'bf-usa-alert--error',
         'usa-alert--error',
-        'display-none',
+        `${hasError === false ? 'display-none' : ''}`,
       ]
     : [
         'bf-usa-alert',
@@ -49,7 +48,7 @@ const Alert = ({
       ref={alertFieldRef}
       tabIndex={tabIndex || 0}
       aria-live={hasError === true ? 'assertive' : 'polite'}
-      aria-hidden={ariaHidden || !hasError}
+      aria-hidden={hasError === undefined ? false : !hasError}
     >
       {children ? (
         <div className="bf-usa-alert__body usa-alert__body">

--- a/benefit-finder/src/shared/components/Alert/index.jsx
+++ b/benefit-finder/src/shared/components/Alert/index.jsx
@@ -10,7 +10,10 @@ import './_index.scss'
  * @param {any} alertFieldRef - inherited ref hook
  * @param {string} heading - inherited heading
  * @param {string} description - inherited description
- * @param {bool} error - variant
+ * @param {bool} type - string
+ * @param {bool}  hasError - checks for current error state of parent value
+ * @param {bool} noBackground - style variant
+ * @param {number} tabIndex - index value of tab order
  * @return {html} returns a wrapped paragraph styled as usa-alert
  */
 
@@ -20,26 +23,27 @@ const Alert = ({
   alertFieldRef,
   heading,
   description,
-  error,
+  type,
   hasError,
   noBackground,
   tabIndex,
 }) => {
-  const defaultClasses = error
-    ? [
-        'bf-usa-alert',
-        'usa-alert',
-        'bf-usa-alert--error',
-        'usa-alert--error',
-        `${hasError === false ? 'display-none' : ''}`,
-      ]
-    : [
-        'bf-usa-alert',
-        'usa-alert',
-        'bf-usa-alert--info',
-        'usa-alert--info',
-        `${noBackground ? 'no-background' : ''}`,
-      ]
+  const defaultClasses =
+    type === 'error'
+      ? [
+          'bf-usa-alert',
+          'usa-alert',
+          'bf-usa-alert--error',
+          'usa-alert--error',
+          `${hasError === false ? 'display-none' : ''}`,
+        ]
+      : [
+          'bf-usa-alert',
+          'usa-alert',
+          'bf-usa-alert--info',
+          'usa-alert--info',
+          `${noBackground ? 'no-background' : ''}`,
+        ]
 
   return (
     <div
@@ -72,7 +76,10 @@ Alert.propTypes = {
   alertFieldRef: PropTypes.any,
   heading: PropTypes.string,
   description: PropTypes.string,
-  error: PropTypes.bool,
+  type: PropTypes.string,
+  hasError: PropTypes.bool,
+  noBackground: PropTypes.bool,
+  tabIndex: PropTypes.number,
 }
 
 export default Alert

--- a/benefit-finder/src/shared/components/Alert/index.stories.jsx
+++ b/benefit-finder/src/shared/components/Alert/index.stories.jsx
@@ -9,3 +9,11 @@ export default {
 }
 
 export const Primary = {}
+
+export const HasError = {
+  args: {
+    ...Primary.args,
+    error: true,
+    hasError: true,
+  },
+}

--- a/benefit-finder/src/shared/components/Alert/index.stories.jsx
+++ b/benefit-finder/src/shared/components/Alert/index.stories.jsx
@@ -13,7 +13,7 @@ export const Primary = {}
 export const HasError = {
   args: {
     ...Primary.args,
-    error: true,
+    type: 'error',
     hasError: true,
   },
 }

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/__snapshots__/index.spec.jsx.snap
@@ -133,7 +133,7 @@ exports[`BenefitAccordionGroup > renders a match to the previous snapshot 1`] = 
             </ul>
           </div>
           <div
-            aria-hidden="true"
+            aria-hidden="false"
             aria-live="polite"
             class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
             role="alert"

--- a/benefit-finder/src/shared/components/Date/index.jsx
+++ b/benefit-finder/src/shared/components/Date/index.jsx
@@ -27,7 +27,7 @@ const Date = ({ onChange, value, required, ui, id, invalid }) => {
           className="bf-usa-date-alert"
           heading={ui.alertBanner.heading}
           description={alert}
-          error
+          type="error"
           hasError={invalid}
         ></Alert>
       )}

--- a/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.jsx.snap
@@ -116,7 +116,7 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                 class="bf-notice"
               >
                 <div
-                  aria-hidden="true"
+                  aria-hidden="false"
                   aria-live="polite"
                   class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
                   role="alert"
@@ -145,7 +145,7 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                 class="bf-notice"
               >
                 <div
-                  aria-hidden="true"
+                  aria-hidden="false"
                   aria-live="polite"
                   class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
                   role="alert"
@@ -173,7 +173,7 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                 class="bf-notice"
               >
                 <div
-                  aria-hidden="true"
+                  aria-hidden="false"
                   aria-live="polite"
                   class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
                   role="alert"

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -219,7 +219,6 @@ const LifeEventSection = ({
     )
     updateAlertArray(hasError, event)
   }
-  // console.log(hasError)
 
   /**
    * a function that handles the current selected value of our radio
@@ -463,7 +462,7 @@ const LifeEventSection = ({
                                   ui={ui}
                                   id={fieldSetId}
                                   invalid={
-                                    hasError.length &&
+                                    hasError.length > 0 &&
                                     hasError
                                       .map(item => item.id.includes(fieldSetId))
                                       .includes(true)

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -285,7 +285,7 @@ const LifeEventSection = ({
                   alertFieldRef={alertFieldRef}
                   heading={ui.alertBanner.heading}
                   description={ui.alertBanner.description}
-                  error
+                  type="error"
                   hasError={hasError.length > 0}
                 ></Alert>
                 <Heading className="bf-usa-section-heading" headingLevel={2}>

--- a/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.jsx.snap
@@ -12,7 +12,7 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
         class="bf-notice"
       >
         <div
-          aria-hidden="true"
+          aria-hidden="false"
           aria-live="polite"
           class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
           role="alert"
@@ -41,7 +41,7 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
         class="bf-notice"
       >
         <div
-          aria-hidden="true"
+          aria-hidden="false"
           aria-live="polite"
           class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
           role="alert"
@@ -69,7 +69,7 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
         class="bf-notice"
       >
         <div
-          aria-hidden="true"
+          aria-hidden="false"
           aria-live="polite"
           class="bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info no-background"
           role="alert"

--- a/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
@@ -255,7 +255,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -474,7 +474,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -688,7 +688,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -907,7 +907,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -1096,7 +1096,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -1299,7 +1299,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -1596,7 +1596,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -1800,7 +1800,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -1999,7 +1999,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -2248,7 +2248,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -2472,7 +2472,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -2655,7 +2655,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -2905,7 +2905,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -3119,7 +3119,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -3386,7 +3386,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -3605,7 +3605,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -3802,7 +3802,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -3998,7 +3998,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -4217,7 +4217,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -4453,7 +4453,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -4712,7 +4712,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -4979,7 +4979,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -5236,7 +5236,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -5533,7 +5533,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -5854,7 +5854,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -6052,7 +6052,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -6281,7 +6281,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -6530,7 +6530,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -6810,7 +6810,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -7029,7 +7029,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -7248,7 +7248,7 @@ exports[`loads view 1`] = `
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -7659,7 +7659,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -7878,7 +7878,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -8092,7 +8092,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -8311,7 +8311,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -8500,7 +8500,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -8703,7 +8703,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -9000,7 +9000,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -9204,7 +9204,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -9403,7 +9403,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -9652,7 +9652,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -9876,7 +9876,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -10059,7 +10059,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -10309,7 +10309,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -10523,7 +10523,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -10790,7 +10790,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -11009,7 +11009,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -11206,7 +11206,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -11402,7 +11402,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -11621,7 +11621,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -11857,7 +11857,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -12116,7 +12116,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -12383,7 +12383,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -12640,7 +12640,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -12937,7 +12937,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -13258,7 +13258,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -13456,7 +13456,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -13685,7 +13685,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -13934,7 +13934,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -14214,7 +14214,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -14433,7 +14433,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"
@@ -14652,7 +14652,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       </ul>
                     </div>
                     <div
-                      aria-hidden="true"
+                      aria-hidden="false"
                       aria-live="polite"
                       class="bf-usa-alert bf-usa-alert usa-alert bf-usa-alert--info usa-alert--info "
                       role="alert"


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This addresses a few issues with the default and error states of alerts.

- default state should have `aria-hidden="false"`
- error state should have `aria-hidden="true"`

## Related Github Issue

- Fixes #1183 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] `cd benefit finder`
- [ ] `npm install`
- [ ] `npm run start` || `npm run dev:storybook"

<!--- If there are steps for user testing list them here -->
- [ ] navigate to inital questions
- [ ] confirm default state of error alert is `aria-hidden="true"`
- [ ] trigger error by moving forward without completing required fields
- [ ] confirm defualt state updated to `aria-hidden="false"`

additional storybook testing
- [ ] navigate to alert component story for "Has Error" http://localhost:6006/?path=/story/shared-components-alert--has-error
- [ ] note that control for hasError is true and `aria-hidden="false"`
- [ ] toggle hasError to `false`
- [ ] note that `aria-hidden="true"`
