### PR TITLE
1171 remove life event field in benefit

### DIFF
--- a/usagov_benefit_finder/configuration/core.entity_form_display.node.bears_benefit.default.yml
+++ b/usagov_benefit_finder/configuration/core.entity_form_display.node.bears_benefit.default.yml
@@ -1,0 +1,191 @@
+uuid: d4fdb095-25a3-43ea-879c-0ddf2ef649ae
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.bears_benefit.field_b_agency
+    - field.field.node.bears_benefit.field_b_eligibility
+    - field.field.node.bears_benefit.field_b_headline
+    - field.field.node.bears_benefit.field_b_initial_elg_length
+    - field.field.node.bears_benefit.field_b_life_event_forms
+    - field.field.node.bears_benefit.field_b_source_is_english
+    - field.field.node.bears_benefit.field_b_source_link
+    - field.field.node.bears_benefit.field_b_summary
+    - field.field.node.bears_benefit.field_b_tags
+    - field.field.node.bears_benefit.field_language_toggle
+    - node.type.bears_benefit
+  module:
+    - content_moderation
+    - paragraphs
+    - path
+    - text
+id: node.bears_benefit.default
+targetEntityType: node
+bundle: bears_benefit
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 12
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_b_agency:
+    type: options_select
+    weight: 8
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_b_eligibility:
+    type: paragraphs
+    weight: 18
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+  field_b_headline:
+    type: text_textarea
+    weight: 3
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_initial_elg_length:
+    type: number
+    weight: 17
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_life_event_forms:
+    type: options_buttons
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_b_source_is_english:
+    type: boolean_checkbox
+    weight: 10
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_b_source_link:
+    type: string_textfield
+    weight: 9
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_summary:
+    type: text_textarea
+    weight: 4
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_tags:
+    type: options_buttons
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_language_toggle:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 0
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 20
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 15
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 13
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 16
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 14
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 11
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 19
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  menu_entity_index: true

--- a/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_benefit.default.yml
+++ b/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_benefit.default.yml
@@ -1,0 +1,122 @@
+uuid: 6c74929f-e325-431f-be4a-a55e5ff5254f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.bears_benefit.field_b_agency
+    - field.field.node.bears_benefit.field_b_eligibility
+    - field.field.node.bears_benefit.field_b_headline
+    - field.field.node.bears_benefit.field_b_initial_elg_length
+    - field.field.node.bears_benefit.field_b_life_event_forms
+    - field.field.node.bears_benefit.field_b_source_is_english
+    - field.field.node.bears_benefit.field_b_source_link
+    - field.field.node.bears_benefit.field_b_summary
+    - field.field.node.bears_benefit.field_b_tags
+    - field.field.node.bears_benefit.field_language_toggle
+    - node.type.bears_benefit
+  module:
+    - entity_reference_revisions
+    - text
+    - user
+id: node.bears_benefit.default
+targetEntityType: node
+bundle: bears_benefit
+mode: default
+content:
+  field_b_agency:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  field_b_eligibility:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  field_b_headline:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_b_initial_elg_length:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 9
+    region: content
+  field_b_life_event_forms:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_b_source_is_english:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 8
+    region: content
+  field_b_source_link:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  field_b_summary:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_b_tags:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_language_toggle:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 12
+    region: content
+  langcode:
+    type: language
+    label: above
+    settings:
+      link_to_entity: false
+      native_language: false
+    third_party_settings: {  }
+    weight: 11
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_benefit.teaser.yml
+++ b/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_benefit.teaser.yml
@@ -1,0 +1,41 @@
+uuid: dab1fae4-5630-49c4-820a-d787fba71e65
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.bears_benefit.field_b_agency
+    - field.field.node.bears_benefit.field_b_eligibility
+    - field.field.node.bears_benefit.field_b_headline
+    - field.field.node.bears_benefit.field_b_initial_elg_length
+    - field.field.node.bears_benefit.field_b_life_event_forms
+    - field.field.node.bears_benefit.field_b_source_is_english
+    - field.field.node.bears_benefit.field_b_source_link
+    - field.field.node.bears_benefit.field_b_summary
+    - field.field.node.bears_benefit.field_b_tags
+    - field.field.node.bears_benefit.field_language_toggle
+    - node.type.bears_benefit
+  module:
+    - user
+id: node.bears_benefit.teaser
+targetEntityType: node
+bundle: bears_benefit
+mode: teaser
+content:
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  field_b_agency: true
+  field_b_eligibility: true
+  field_b_headline: true
+  field_b_initial_elg_length: true
+  field_b_life_event_forms: true
+  field_b_source_is_english: true
+  field_b_source_link: true
+  field_b_summary: true
+  field_b_tags: true
+  field_language_toggle: true
+  langcode: true


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This work removes life event field in benefit form.

Release note: delete these 2 configuration files after partial configuration import.
config/sync/field.field.node.bears_benefit.field_b_life_events.yml
config/sync/field.storage.node.field_b_life_events.yml

## Related Github Issue

- Fixes #1171 

## Detailed Testing steps

To test in local development site or in dev site.

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] make local development site up at http://localhost
- [ ] `drush cim --partial --source=modules/custom/usagov_benefit_finder/configuration -y`
- [ ] navigate to http://localhost/admin/content?combine=&type=bears_benefit&status=All&langcode=All
- [ ] select a benefit to edit
- [ ] verify the form no life events field above the life event form field

![image](https://github.com/GSA/px-benefit-finder/assets/88853916/49062525-06d2-4182-9d9e-7f7812a7aa0b)

<!--- If there are steps for user testing list them here -->
