### PR TITLE
1156 disable delete agency if still used

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
@@ -5,6 +5,7 @@
  * Module contains functions related to usagov_benefit_finder_content.
  */
 
+use Drupal\Core\Database\Database;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\Entity\Node;
 
@@ -114,7 +115,7 @@ function usagov_benefit_finder_content_node_bears_benefit_edit_form_validate(arr
           else {
             $errors[] = t("Criteria \"$criteria_title\" acceptable value \"$value\" is incorrect.");
             $errors[] = t("---The prefix must include only one of the following comparison operators: '>', '<', '=', '>=', or '<='.
-            
+
 --- The suffix must be formatted as either 'MM-DD-YYYY' or '(d or dd)years'.");
           }
         }
@@ -126,5 +127,47 @@ function usagov_benefit_finder_content_node_bears_benefit_edit_form_validate(arr
     foreach ($errors as $error) {
       $form_state->setErrorByName((string) ++$error_count, $error);
     }
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function usagov_benefit_finder_content_form_node_bears_agency_delete_form_alter(array &$form, FormStateInterface $form_state) {
+  _usagov_benefit_finder_content_check_agency_usage($form);
+}
+
+/**
+ * It checks agency usage in benefits.
+ * If still used, it lists the benefits and disables the agency delete button.
+ *
+ * @param array $form
+ *   Form array.
+ */
+function _usagov_benefit_finder_content_check_agency_usage(array &$form) {
+  $description = '';
+
+  $node = \Drupal::routeMatch()->getParameter('node');
+  $nid = $node->id();
+
+  $connection = Database::getConnection();
+  $query = $connection->select('node_field_data', 't1');
+  $query->join('node__field_b_agency', 't2', 't1.nid = t2.entity_id');
+  $query->fields('t1', ['title', 'nid']);
+  $query->condition('t2.field_b_agency_target_id', $nid);
+  $query->orderBy('title');
+  $result = $query->execute();
+
+  foreach ($result as $row) {
+    $description .= "<li>$row->title ($row->nid)</li>";
+  }
+
+  if (!empty($description)) {
+    $description = '<div class="entity-skip">'
+      . '<span>This agency cannot be deleted as it is still used in following benefits:</span>'
+      . "<ul>$description</ul>"
+      . '</div>';
+    $form['description']['#markup'] = $description;
+    $form['actions']['submit']['#access'] = false;
   }
 }

--- a/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
@@ -168,6 +168,6 @@ function _usagov_benefit_finder_content_check_agency_usage(array &$form) {
       . "<ul>$description</ul>"
       . '</div>';
     $form['description']['#markup'] = $description;
-    $form['actions']['submit']['#access'] = false;
+    $form['actions']['submit']['#access'] = FALSE;
   }
 }


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This work checks agency usage in benefits. If an agency still used in benefits, it lists the benefits and disables the agency delete button.

## Related Github Issue

- Fixes #1156 

## Detailed Testing steps

To test in local development site or in dev site.

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] make local development site up at http://localhost
- [ ] navigate to http://localhost/admin/content?combine=&type=bears_agency&status=All&langcode=All
- [ ] select an agency to edit, for example Social Security Administration (SSA)
- [ ] click Delete button
- [ ] verify that it lists the benefits that still use the agency Social Security Administration (SSA)
- [ ] verify that no Delete button

![image](https://github.com/GSA/px-benefit-finder/assets/88853916/0fec0ae3-36de-491b-9af5-17d9f0636e0b)

- [ ] navigate to http://localhost/node/add/bears_agency
- [ ] create an agency
- [ ] edit the newly created agency
- [ ] click Delete button
- [ ] verify that no benefit listed as this agency is not used in any benefit
- [ ] verify that Delete button showing

<img width="600" src="https://github.com/GSA/px-benefit-finder/assets/88853916/d6c29656-6594-44bd-a99f-859e270e6bd0">

- [ ] click Delete button
- [ ] verify that the agency is deleted


<!--- If there are steps for user testing list them here -->
