### PR TITLE
1073 remove duplicate aria expanded

### DIFF
--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
@@ -336,7 +336,6 @@ exports[`loads window query scenario 1 1`] = `
                   Open all +
                 </button>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Burial benefits"
@@ -347,7 +346,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="0-Burial benefits"
+                      aria-controls="Burial benefits"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -390,7 +389,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="0-Burial benefits"
+                    id="Burial benefits"
                   >
                     <div>
                       <h4
@@ -555,7 +554,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Death gratuity"
@@ -566,7 +564,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="1-Death gratuity"
+                      aria-controls="Death gratuity"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -609,7 +607,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="1-Death gratuity"
+                    id="Death gratuity"
                   >
                     <div>
                       <h4
@@ -774,7 +772,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Burial flag"
@@ -785,7 +782,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="2-Burial flag"
+                      aria-controls="Burial flag"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -828,7 +825,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="2-Burial flag"
+                    id="Burial flag"
                   >
                     <div>
                       <h4
@@ -988,7 +985,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Annuity for certain military surviving spouses"
@@ -999,7 +995,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="3-Annuity for certain military surviving spouses"
+                      aria-controls="Annuity for certain military surviving spouses"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -1042,7 +1038,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="3-Annuity for certain military surviving spouses"
+                    id="Annuity for certain military surviving spouses"
                   >
                     <div>
                       <h4
@@ -1207,7 +1203,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Burial in VA national cemetery"
@@ -1218,7 +1213,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="4-Burial in VA national cemetery"
+                      aria-controls="Burial in VA national cemetery"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -1261,7 +1256,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="4-Burial in VA national cemetery"
+                    id="Burial in VA national cemetery"
                   >
                     <div>
                       <h4
@@ -1396,7 +1391,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Civilian Health and Medical Program of the VA (CHAMPVA) for child"
@@ -1407,7 +1401,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="5-Civilian Health and Medical Program of the VA (CHAMPVA) for child"
+                      aria-controls="Civilian Health and Medical Program of the VA (CHAMPVA) for child"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -1450,7 +1444,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="5-Civilian Health and Medical Program of the VA (CHAMPVA) for child"
+                    id="Civilian Health and Medical Program of the VA (CHAMPVA) for child"
                   >
                     <div>
                       <h4
@@ -1599,7 +1593,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="COVID-19 funeral assistance"
@@ -1609,7 +1602,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="6-COVID-19 funeral assistance"
+                      aria-controls="COVID-19 funeral assistance"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -1652,7 +1645,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="6-COVID-19 funeral assistance"
+                    id="COVID-19 funeral assistance"
                   >
                     <div>
                       <h4
@@ -1896,7 +1889,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Dependency and Indemnity Compensation (DIC) for child"
@@ -1907,7 +1899,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="7-Dependency and Indemnity Compensation (DIC) for child"
+                      aria-controls="Dependency and Indemnity Compensation (DIC) for child"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -1950,7 +1942,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="7-Dependency and Indemnity Compensation (DIC) for child"
+                    id="Dependency and Indemnity Compensation (DIC) for child"
                   >
                     <div>
                       <h4
@@ -2100,7 +2092,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Dependency and Indemnity Compensation (DIC) for parent"
@@ -2111,7 +2102,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="8-Dependency and Indemnity Compensation (DIC) for parent"
+                      aria-controls="Dependency and Indemnity Compensation (DIC) for parent"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -2154,7 +2145,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="8-Dependency and Indemnity Compensation (DIC) for parent"
+                    id="Dependency and Indemnity Compensation (DIC) for parent"
                   >
                     <div>
                       <h4
@@ -2299,7 +2290,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Dependency and Indemnity Compensation (DIC) for spouse"
@@ -2310,7 +2300,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="9-Dependency and Indemnity Compensation (DIC) for spouse"
+                      aria-controls="Dependency and Indemnity Compensation (DIC) for spouse"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -2353,7 +2343,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="9-Dependency and Indemnity Compensation (DIC) for spouse"
+                    id="Dependency and Indemnity Compensation (DIC) for spouse"
                   >
                     <div>
                       <h4
@@ -2548,7 +2538,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Education benefits (GI Bill) for survivors"
@@ -2559,7 +2548,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="10-Education benefits (GI Bill) for survivors"
+                      aria-controls="Education benefits (GI Bill) for survivors"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -2602,7 +2591,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="10-Education benefits (GI Bill) for survivors"
+                    id="Education benefits (GI Bill) for survivors"
                   >
                     <div>
                       <h4
@@ -2772,7 +2761,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Financial Assistance and Social Services (FASS) for deceased"
@@ -2783,7 +2771,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="11-Financial Assistance and Social Services (FASS) for deceased"
+                      aria-controls="Financial Assistance and Social Services (FASS) for deceased"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -2826,7 +2814,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="11-Financial Assistance and Social Services (FASS) for deceased"
+                    id="Financial Assistance and Social Services (FASS) for deceased"
                   >
                     <div>
                       <h4
@@ -2955,7 +2943,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Home loan program for survivors"
@@ -2966,7 +2953,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="12-Home loan program for survivors"
+                      aria-controls="Home loan program for survivors"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -3009,7 +2996,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="12-Home loan program for survivors"
+                    id="Home loan program for survivors"
                   >
                     <div>
                       <h4
@@ -3205,7 +3192,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Life insurance for survivors of veterans"
@@ -3216,7 +3202,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="13-Life insurance for survivors of veterans"
+                      aria-controls="Life insurance for survivors of veterans"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -3259,7 +3245,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="13-Life insurance for survivors of veterans"
+                    id="Life insurance for survivors of veterans"
                   >
                     <div>
                       <h4
@@ -3419,7 +3405,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Lump-sum death benefit"
@@ -3430,7 +3415,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="14-Lump-sum death benefit"
+                      aria-controls="Lump-sum death benefit"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -3473,7 +3458,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="14-Lump-sum death benefit"
+                    id="Lump-sum death benefit"
                   >
                     <div>
                       <h4
@@ -3675,7 +3660,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Presidential Memorial Certificate"
@@ -3686,7 +3670,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="15-Presidential Memorial Certificate"
+                      aria-controls="Presidential Memorial Certificate"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -3729,7 +3713,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="15-Presidential Memorial Certificate"
+                    id="Presidential Memorial Certificate"
                   >
                     <div>
                       <h4
@@ -3894,7 +3878,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Public safety officers' death benefits"
@@ -3905,7 +3888,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="16-Public safety officers' death benefits"
+                      aria-controls="Public safety officers' death benefits"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -3948,7 +3931,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="16-Public safety officers' death benefits"
+                    id="Public safety officers' death benefits"
                   >
                     <div>
                       <h4
@@ -4091,7 +4074,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Public safety officers' Educational Assistance Program"
@@ -4102,7 +4084,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="17-Public safety officers' Educational Assistance Program"
+                      aria-controls="Public safety officers' Educational Assistance Program"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -4145,7 +4127,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="17-Public safety officers' Educational Assistance Program"
+                    id="Public safety officers' Educational Assistance Program"
                   >
                     <div>
                       <h4
@@ -4287,7 +4269,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivor benefit plan"
@@ -4298,7 +4279,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="18-Survivor benefit plan"
+                      aria-controls="Survivor benefit plan"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -4341,7 +4322,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="18-Survivor benefit plan"
+                    id="Survivor benefit plan"
                   >
                     <div>
                       <h4
@@ -4506,7 +4487,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors benefits for child"
@@ -4517,7 +4497,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="19-Survivors benefits for child"
+                      aria-controls="Survivors benefits for child"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -4560,7 +4540,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="19-Survivors benefits for child"
+                    id="Survivors benefits for child"
                   >
                     <div>
                       <h4
@@ -4742,7 +4722,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors benefits for child with disabilities"
@@ -4753,7 +4732,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="20-Survivors benefits for child with disabilities"
+                      aria-controls="Survivors benefits for child with disabilities"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -4796,7 +4775,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="20-Survivors benefits for child with disabilities"
+                    id="Survivors benefits for child with disabilities"
                   >
                     <div>
                       <h4
@@ -5001,7 +4980,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors benefits for mothers/fathers"
@@ -5011,7 +4989,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="21-Survivors benefits for mothers/fathers"
+                      aria-controls="Survivors benefits for mothers/fathers"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -5054,7 +5032,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="21-Survivors benefits for mothers/fathers"
+                    id="Survivors benefits for mothers/fathers"
                   >
                     <div>
                       <h4
@@ -5268,7 +5246,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors benefits for parents"
@@ -5279,7 +5256,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="22-Survivors benefits for parents"
+                      aria-controls="Survivors benefits for parents"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -5322,7 +5299,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="22-Survivors benefits for parents"
+                    id="Survivors benefits for parents"
                   >
                     <div>
                       <h4
@@ -5525,7 +5502,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors benefits for spouse"
@@ -5535,7 +5511,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="23-Survivors benefits for spouse"
+                      aria-controls="Survivors benefits for spouse"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -5578,7 +5554,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="23-Survivors benefits for spouse"
+                    id="Survivors benefits for spouse"
                   >
                     <div>
                       <h4
@@ -5822,7 +5798,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors benefits for spouse with disabilities"
@@ -5833,7 +5808,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="24-Survivors benefits for spouse with disabilities"
+                      aria-controls="Survivors benefits for spouse with disabilities"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -5876,7 +5851,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="24-Survivors benefits for spouse with disabilities"
+                    id="Survivors benefits for spouse with disabilities"
                   >
                     <div>
                       <h4
@@ -6143,7 +6118,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors pension for child"
@@ -6154,7 +6128,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="25-Survivors pension for child"
+                      aria-controls="Survivors pension for child"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -6197,7 +6171,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="25-Survivors pension for child"
+                    id="Survivors pension for child"
                   >
                     <div>
                       <h4
@@ -6341,7 +6315,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors pension for child with disabilities"
@@ -6352,7 +6325,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="26-Survivors pension for child with disabilities"
+                      aria-controls="Survivors pension for child with disabilities"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -6395,7 +6368,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="26-Survivors pension for child with disabilities"
+                    id="Survivors pension for child with disabilities"
                   >
                     <div>
                       <h4
@@ -6570,7 +6543,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors pension for spouse"
@@ -6581,7 +6553,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="27-Survivors pension for spouse"
+                      aria-controls="Survivors pension for spouse"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -6624,7 +6596,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="27-Survivors pension for spouse"
+                    id="Survivors pension for spouse"
                   >
                     <div>
                       <h4
@@ -6819,7 +6791,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Veterans burial allowance"
@@ -6830,7 +6801,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="28-Veterans burial allowance"
+                      aria-controls="Veterans burial allowance"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -6873,7 +6844,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="28-Veterans burial allowance"
+                    id="Veterans burial allowance"
                   >
                     <div>
                       <h4
@@ -7074,7 +7045,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Veterans headstone and grave marker"
@@ -7085,7 +7055,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="29-Veterans headstone and grave marker"
+                      aria-controls="Veterans headstone and grave marker"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -7128,7 +7098,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="29-Veterans headstone and grave marker"
+                    id="Veterans headstone and grave marker"
                   >
                     <div>
                       <h4
@@ -7293,7 +7263,6 @@ exports[`loads window query scenario 1 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Veterans medallion"
@@ -7304,7 +7273,7 @@ exports[`loads window query scenario 1 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="30-Veterans medallion"
+                      aria-controls="Veterans medallion"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -7347,7 +7316,7 @@ exports[`loads window query scenario 1 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="30-Veterans medallion"
+                    id="Veterans medallion"
                   >
                     <div>
                       <h4
@@ -7890,7 +7859,6 @@ exports[`loads window query scenario 2 1`] = `
                   Open all +
                 </button>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Burial benefits"
@@ -7901,7 +7869,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="0-Burial benefits"
+                      aria-controls="Burial benefits"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -7944,7 +7912,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="0-Burial benefits"
+                    id="Burial benefits"
                   >
                     <div>
                       <h4
@@ -8109,7 +8077,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Death gratuity"
@@ -8120,7 +8087,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="1-Death gratuity"
+                      aria-controls="Death gratuity"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -8163,7 +8130,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="1-Death gratuity"
+                    id="Death gratuity"
                   >
                     <div>
                       <h4
@@ -8328,7 +8295,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Burial flag"
@@ -8339,7 +8305,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="2-Burial flag"
+                      aria-controls="Burial flag"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -8382,7 +8348,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="2-Burial flag"
+                    id="Burial flag"
                   >
                     <div>
                       <h4
@@ -8542,7 +8508,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Annuity for certain military surviving spouses"
@@ -8553,7 +8518,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="3-Annuity for certain military surviving spouses"
+                      aria-controls="Annuity for certain military surviving spouses"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -8596,7 +8561,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="3-Annuity for certain military surviving spouses"
+                    id="Annuity for certain military surviving spouses"
                   >
                     <div>
                       <h4
@@ -8761,7 +8726,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Burial in VA national cemetery"
@@ -8772,7 +8736,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="4-Burial in VA national cemetery"
+                      aria-controls="Burial in VA national cemetery"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -8815,7 +8779,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="4-Burial in VA national cemetery"
+                    id="Burial in VA national cemetery"
                   >
                     <div>
                       <h4
@@ -8950,7 +8914,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Civilian Health and Medical Program of the VA (CHAMPVA) for child"
@@ -8961,7 +8924,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="5-Civilian Health and Medical Program of the VA (CHAMPVA) for child"
+                      aria-controls="Civilian Health and Medical Program of the VA (CHAMPVA) for child"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -9004,7 +8967,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="5-Civilian Health and Medical Program of the VA (CHAMPVA) for child"
+                    id="Civilian Health and Medical Program of the VA (CHAMPVA) for child"
                   >
                     <div>
                       <h4
@@ -9153,7 +9116,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="COVID-19 funeral assistance"
@@ -9163,7 +9125,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="6-COVID-19 funeral assistance"
+                      aria-controls="COVID-19 funeral assistance"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -9206,7 +9168,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="6-COVID-19 funeral assistance"
+                    id="COVID-19 funeral assistance"
                   >
                     <div>
                       <h4
@@ -9450,7 +9412,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Dependency and Indemnity Compensation (DIC) for child"
@@ -9461,7 +9422,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="7-Dependency and Indemnity Compensation (DIC) for child"
+                      aria-controls="Dependency and Indemnity Compensation (DIC) for child"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -9504,7 +9465,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="7-Dependency and Indemnity Compensation (DIC) for child"
+                    id="Dependency and Indemnity Compensation (DIC) for child"
                   >
                     <div>
                       <h4
@@ -9654,7 +9615,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Dependency and Indemnity Compensation (DIC) for parent"
@@ -9665,7 +9625,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="8-Dependency and Indemnity Compensation (DIC) for parent"
+                      aria-controls="Dependency and Indemnity Compensation (DIC) for parent"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -9708,7 +9668,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="8-Dependency and Indemnity Compensation (DIC) for parent"
+                    id="Dependency and Indemnity Compensation (DIC) for parent"
                   >
                     <div>
                       <h4
@@ -9853,7 +9813,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Dependency and Indemnity Compensation (DIC) for spouse"
@@ -9864,7 +9823,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="9-Dependency and Indemnity Compensation (DIC) for spouse"
+                      aria-controls="Dependency and Indemnity Compensation (DIC) for spouse"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -9907,7 +9866,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="9-Dependency and Indemnity Compensation (DIC) for spouse"
+                    id="Dependency and Indemnity Compensation (DIC) for spouse"
                   >
                     <div>
                       <h4
@@ -10102,7 +10061,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Education benefits (GI Bill) for survivors"
@@ -10113,7 +10071,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="10-Education benefits (GI Bill) for survivors"
+                      aria-controls="Education benefits (GI Bill) for survivors"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -10156,7 +10114,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="10-Education benefits (GI Bill) for survivors"
+                    id="Education benefits (GI Bill) for survivors"
                   >
                     <div>
                       <h4
@@ -10326,7 +10284,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Financial Assistance and Social Services (FASS) for deceased"
@@ -10337,7 +10294,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="11-Financial Assistance and Social Services (FASS) for deceased"
+                      aria-controls="Financial Assistance and Social Services (FASS) for deceased"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -10380,7 +10337,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="11-Financial Assistance and Social Services (FASS) for deceased"
+                    id="Financial Assistance and Social Services (FASS) for deceased"
                   >
                     <div>
                       <h4
@@ -10522,7 +10479,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Home loan program for survivors"
@@ -10533,7 +10489,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="12-Home loan program for survivors"
+                      aria-controls="Home loan program for survivors"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -10576,7 +10532,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="12-Home loan program for survivors"
+                    id="Home loan program for survivors"
                   >
                     <div>
                       <h4
@@ -10772,7 +10728,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Life insurance for survivors of veterans"
@@ -10783,7 +10738,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="13-Life insurance for survivors of veterans"
+                      aria-controls="Life insurance for survivors of veterans"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -10826,7 +10781,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="13-Life insurance for survivors of veterans"
+                    id="Life insurance for survivors of veterans"
                   >
                     <div>
                       <h4
@@ -10986,7 +10941,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Lump-sum death benefit"
@@ -10996,7 +10950,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="14-Lump-sum death benefit"
+                      aria-controls="Lump-sum death benefit"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -11039,7 +10993,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="14-Lump-sum death benefit"
+                    id="Lump-sum death benefit"
                   >
                     <div>
                       <h4
@@ -11253,7 +11207,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Presidential Memorial Certificate"
@@ -11264,7 +11217,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="15-Presidential Memorial Certificate"
+                      aria-controls="Presidential Memorial Certificate"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -11307,7 +11260,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="15-Presidential Memorial Certificate"
+                    id="Presidential Memorial Certificate"
                   >
                     <div>
                       <h4
@@ -11472,7 +11425,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Public safety officers' death benefits"
@@ -11483,7 +11435,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="16-Public safety officers' death benefits"
+                      aria-controls="Public safety officers' death benefits"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -11526,7 +11478,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="16-Public safety officers' death benefits"
+                    id="Public safety officers' death benefits"
                   >
                     <div>
                       <h4
@@ -11669,7 +11621,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Public safety officers' Educational Assistance Program"
@@ -11680,7 +11631,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="17-Public safety officers' Educational Assistance Program"
+                      aria-controls="Public safety officers' Educational Assistance Program"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -11723,7 +11674,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="17-Public safety officers' Educational Assistance Program"
+                    id="Public safety officers' Educational Assistance Program"
                   >
                     <div>
                       <h4
@@ -11865,7 +11816,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivor benefit plan"
@@ -11876,7 +11826,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="18-Survivor benefit plan"
+                      aria-controls="Survivor benefit plan"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -11919,7 +11869,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="18-Survivor benefit plan"
+                    id="Survivor benefit plan"
                   >
                     <div>
                       <h4
@@ -12084,7 +12034,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors benefits for child"
@@ -12095,7 +12044,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="19-Survivors benefits for child"
+                      aria-controls="Survivors benefits for child"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -12138,7 +12087,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="19-Survivors benefits for child"
+                    id="Survivors benefits for child"
                   >
                     <div>
                       <h4
@@ -12320,7 +12269,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors benefits for child with disabilities"
@@ -12331,7 +12279,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="20-Survivors benefits for child with disabilities"
+                      aria-controls="Survivors benefits for child with disabilities"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -12374,7 +12322,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="20-Survivors benefits for child with disabilities"
+                    id="Survivors benefits for child with disabilities"
                   >
                     <div>
                       <h4
@@ -12579,7 +12527,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors benefits for mothers/fathers"
@@ -12589,7 +12536,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="21-Survivors benefits for mothers/fathers"
+                      aria-controls="Survivors benefits for mothers/fathers"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -12632,7 +12579,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="21-Survivors benefits for mothers/fathers"
+                    id="Survivors benefits for mothers/fathers"
                   >
                     <div>
                       <h4
@@ -12846,7 +12793,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors benefits for parents"
@@ -12857,7 +12803,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="22-Survivors benefits for parents"
+                      aria-controls="Survivors benefits for parents"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -12900,7 +12846,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="22-Survivors benefits for parents"
+                    id="Survivors benefits for parents"
                   >
                     <div>
                       <h4
@@ -13078,7 +13024,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors benefits for spouse"
@@ -13089,7 +13034,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="23-Survivors benefits for spouse"
+                      aria-controls="Survivors benefits for spouse"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -13132,7 +13077,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="23-Survivors benefits for spouse"
+                    id="Survivors benefits for spouse"
                   >
                     <div>
                       <h4
@@ -13364,7 +13309,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors benefits for spouse with disabilities"
@@ -13375,7 +13319,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="24-Survivors benefits for spouse with disabilities"
+                      aria-controls="Survivors benefits for spouse with disabilities"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -13418,7 +13362,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="24-Survivors benefits for spouse with disabilities"
+                    id="Survivors benefits for spouse with disabilities"
                   >
                     <div>
                       <h4
@@ -13673,7 +13617,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors pension for child"
@@ -13684,7 +13627,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="25-Survivors pension for child"
+                      aria-controls="Survivors pension for child"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -13727,7 +13670,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="25-Survivors pension for child"
+                    id="Survivors pension for child"
                   >
                     <div>
                       <h4
@@ -13871,7 +13814,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors pension for child with disabilities"
@@ -13882,7 +13824,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="26-Survivors pension for child with disabilities"
+                      aria-controls="Survivors pension for child with disabilities"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -13925,7 +13867,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="26-Survivors pension for child with disabilities"
+                    id="Survivors pension for child with disabilities"
                   >
                     <div>
                       <h4
@@ -14100,7 +14042,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Survivors pension for spouse"
@@ -14111,7 +14052,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="27-Survivors pension for spouse"
+                      aria-controls="Survivors pension for spouse"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -14154,7 +14095,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="27-Survivors pension for spouse"
+                    id="Survivors pension for spouse"
                   >
                     <div>
                       <h4
@@ -14349,7 +14290,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Veterans burial allowance"
@@ -14360,7 +14300,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="28-Veterans burial allowance"
+                      aria-controls="Veterans burial allowance"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -14403,7 +14343,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="28-Veterans burial allowance"
+                    id="Veterans burial allowance"
                   >
                     <div>
                       <h4
@@ -14629,7 +14569,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Veterans headstone and grave marker"
@@ -14640,7 +14579,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="29-Veterans headstone and grave marker"
+                      aria-controls="Veterans headstone and grave marker"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -14683,7 +14622,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="29-Veterans headstone and grave marker"
+                    id="Veterans headstone and grave marker"
                   >
                     <div>
                       <h4
@@ -14848,7 +14787,6 @@ exports[`loads window query scenario 2 1`] = `
                   </div>
                 </div>
                 <div
-                  aria-expanded="false"
                   class="bf-usa-accordion usa-accordion"
                   data-analytics="bf-usa-accordion"
                   data-analytics-content="Veterans medallion"
@@ -14859,7 +14797,7 @@ exports[`loads window query scenario 2 1`] = `
                     class="bf-usa-accordion__heading usa-accordion__heading"
                   >
                     <button
-                      aria-controls="30-Veterans medallion"
+                      aria-controls="Veterans medallion"
                       aria-expanded="false"
                       class="bf-usa-accordion__button usa-accordion__button"
                       type="button"
@@ -14902,7 +14840,7 @@ exports[`loads window query scenario 2 1`] = `
                   <div
                     class="bf-usa-accordion__content usa-accordion__content usa-prose"
                     hidden=""
-                    id="30-Veterans medallion"
+                    id="Veterans medallion"
                   >
                     <div>
                       <h4

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/__snapshots__/index.spec.jsx.snap
@@ -6,7 +6,6 @@ exports[`BenefitAccordionGroup > renders a match to the previous snapshot 1`] = 
     class="bf-usa-accordion-group"
   >
     <div
-      aria-expanded="false"
       class="bf-usa-accordion usa-accordion"
       data-analytics="bf-usa-accordion"
       data-analytics-content="Burial benefits"
@@ -16,7 +15,7 @@ exports[`BenefitAccordionGroup > renders a match to the previous snapshot 1`] = 
         class="bf-usa-accordion__heading usa-accordion__heading"
       >
         <button
-          aria-controls="0-Burial benefits"
+          aria-controls="Burial benefits"
           aria-expanded="false"
           class="bf-usa-accordion__button usa-accordion__button"
           type="button"
@@ -59,7 +58,7 @@ exports[`BenefitAccordionGroup > renders a match to the previous snapshot 1`] = 
       <div
         class="bf-usa-accordion__content usa-accordion__content usa-prose"
         hidden=""
-        id="0-Burial benefits"
+        id="Burial benefits"
       >
         <div>
           <h4

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/index.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/index.jsx
@@ -177,10 +177,9 @@ const BenefitAccordionGroup = ({
           return (
             <Accordion
               key={`${index}-${title}`}
-              id={`${index}-${title}`}
+              id={`${title}`}
               heading={title}
               subHeading={eligibleStatus}
-              aria-expanded={isExpandAll}
               isExpanded={isExpandAll}
               data-analytics="bf-usa-accordion"
               data-analytics-content={title}

--- a/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
@@ -88,7 +88,6 @@ exports[`loads view 1`] = `
                 Open all +
               </button>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Burial benefits"
@@ -99,7 +98,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="0-Burial benefits"
+                    aria-controls="Burial benefits"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -142,7 +141,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="0-Burial benefits"
+                  id="Burial benefits"
                 >
                   <div>
                     <h4
@@ -307,7 +306,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Death gratuity"
@@ -318,7 +316,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="1-Death gratuity"
+                    aria-controls="Death gratuity"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -361,7 +359,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="1-Death gratuity"
+                  id="Death gratuity"
                 >
                   <div>
                     <h4
@@ -526,7 +524,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Burial flag"
@@ -537,7 +534,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="2-Burial flag"
+                    aria-controls="Burial flag"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -580,7 +577,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="2-Burial flag"
+                  id="Burial flag"
                 >
                   <div>
                     <h4
@@ -740,7 +737,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Annuity for certain military surviving spouses"
@@ -751,7 +747,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="3-Annuity for certain military surviving spouses"
+                    aria-controls="Annuity for certain military surviving spouses"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -794,7 +790,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="3-Annuity for certain military surviving spouses"
+                  id="Annuity for certain military surviving spouses"
                 >
                   <div>
                     <h4
@@ -959,7 +955,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Burial in VA national cemetery"
@@ -970,7 +965,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="4-Burial in VA national cemetery"
+                    aria-controls="Burial in VA national cemetery"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -1013,7 +1008,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="4-Burial in VA national cemetery"
+                  id="Burial in VA national cemetery"
                 >
                   <div>
                     <h4
@@ -1148,7 +1143,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Civilian Health and Medical Program of the VA (CHAMPVA) for child"
@@ -1159,7 +1153,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="5-Civilian Health and Medical Program of the VA (CHAMPVA) for child"
+                    aria-controls="Civilian Health and Medical Program of the VA (CHAMPVA) for child"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -1202,7 +1196,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="5-Civilian Health and Medical Program of the VA (CHAMPVA) for child"
+                  id="Civilian Health and Medical Program of the VA (CHAMPVA) for child"
                 >
                   <div>
                     <h4
@@ -1351,7 +1345,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="COVID-19 funeral assistance"
@@ -1361,7 +1354,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="6-COVID-19 funeral assistance"
+                    aria-controls="COVID-19 funeral assistance"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -1404,7 +1397,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="6-COVID-19 funeral assistance"
+                  id="COVID-19 funeral assistance"
                 >
                   <div>
                     <h4
@@ -1648,7 +1641,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Dependency and Indemnity Compensation (DIC) for child"
@@ -1659,7 +1651,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="7-Dependency and Indemnity Compensation (DIC) for child"
+                    aria-controls="Dependency and Indemnity Compensation (DIC) for child"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -1702,7 +1694,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="7-Dependency and Indemnity Compensation (DIC) for child"
+                  id="Dependency and Indemnity Compensation (DIC) for child"
                 >
                   <div>
                     <h4
@@ -1852,7 +1844,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Dependency and Indemnity Compensation (DIC) for parent"
@@ -1863,7 +1854,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="8-Dependency and Indemnity Compensation (DIC) for parent"
+                    aria-controls="Dependency and Indemnity Compensation (DIC) for parent"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -1906,7 +1897,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="8-Dependency and Indemnity Compensation (DIC) for parent"
+                  id="Dependency and Indemnity Compensation (DIC) for parent"
                 >
                   <div>
                     <h4
@@ -2051,7 +2042,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Dependency and Indemnity Compensation (DIC) for spouse"
@@ -2062,7 +2052,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="9-Dependency and Indemnity Compensation (DIC) for spouse"
+                    aria-controls="Dependency and Indemnity Compensation (DIC) for spouse"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -2105,7 +2095,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="9-Dependency and Indemnity Compensation (DIC) for spouse"
+                  id="Dependency and Indemnity Compensation (DIC) for spouse"
                 >
                   <div>
                     <h4
@@ -2300,7 +2290,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Education benefits (GI Bill) for survivors"
@@ -2311,7 +2300,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="10-Education benefits (GI Bill) for survivors"
+                    aria-controls="Education benefits (GI Bill) for survivors"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -2354,7 +2343,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="10-Education benefits (GI Bill) for survivors"
+                  id="Education benefits (GI Bill) for survivors"
                 >
                   <div>
                     <h4
@@ -2524,7 +2513,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Financial Assistance and Social Services (FASS) for deceased"
@@ -2535,7 +2523,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="11-Financial Assistance and Social Services (FASS) for deceased"
+                    aria-controls="Financial Assistance and Social Services (FASS) for deceased"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -2578,7 +2566,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="11-Financial Assistance and Social Services (FASS) for deceased"
+                  id="Financial Assistance and Social Services (FASS) for deceased"
                 >
                   <div>
                     <h4
@@ -2707,7 +2695,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Home loan program for survivors"
@@ -2718,7 +2705,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="12-Home loan program for survivors"
+                    aria-controls="Home loan program for survivors"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -2761,7 +2748,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="12-Home loan program for survivors"
+                  id="Home loan program for survivors"
                 >
                   <div>
                     <h4
@@ -2957,7 +2944,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Life insurance for survivors of veterans"
@@ -2968,7 +2954,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="13-Life insurance for survivors of veterans"
+                    aria-controls="Life insurance for survivors of veterans"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -3011,7 +2997,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="13-Life insurance for survivors of veterans"
+                  id="Life insurance for survivors of veterans"
                 >
                   <div>
                     <h4
@@ -3171,7 +3157,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Lump-sum death benefit"
@@ -3181,7 +3166,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="14-Lump-sum death benefit"
+                    aria-controls="Lump-sum death benefit"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -3224,7 +3209,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="14-Lump-sum death benefit"
+                  id="Lump-sum death benefit"
                 >
                   <div>
                     <h4
@@ -3438,7 +3423,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Presidential Memorial Certificate"
@@ -3449,7 +3433,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="15-Presidential Memorial Certificate"
+                    aria-controls="Presidential Memorial Certificate"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -3492,7 +3476,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="15-Presidential Memorial Certificate"
+                  id="Presidential Memorial Certificate"
                 >
                   <div>
                     <h4
@@ -3657,7 +3641,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Public safety officers' death benefits"
@@ -3668,7 +3651,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="16-Public safety officers' death benefits"
+                    aria-controls="Public safety officers' death benefits"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -3711,7 +3694,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="16-Public safety officers' death benefits"
+                  id="Public safety officers' death benefits"
                 >
                   <div>
                     <h4
@@ -3854,7 +3837,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Public safety officers' Educational Assistance Program"
@@ -3865,7 +3847,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="17-Public safety officers' Educational Assistance Program"
+                    aria-controls="Public safety officers' Educational Assistance Program"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -3908,7 +3890,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="17-Public safety officers' Educational Assistance Program"
+                  id="Public safety officers' Educational Assistance Program"
                 >
                   <div>
                     <h4
@@ -4050,7 +4032,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivor benefit plan"
@@ -4061,7 +4042,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="18-Survivor benefit plan"
+                    aria-controls="Survivor benefit plan"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -4104,7 +4085,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="18-Survivor benefit plan"
+                  id="Survivor benefit plan"
                 >
                   <div>
                     <h4
@@ -4269,7 +4250,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors benefits for child"
@@ -4280,7 +4260,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="19-Survivors benefits for child"
+                    aria-controls="Survivors benefits for child"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -4323,7 +4303,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="19-Survivors benefits for child"
+                  id="Survivors benefits for child"
                 >
                   <div>
                     <h4
@@ -4505,7 +4485,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors benefits for child with disabilities"
@@ -4516,7 +4495,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="20-Survivors benefits for child with disabilities"
+                    aria-controls="Survivors benefits for child with disabilities"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -4559,7 +4538,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="20-Survivors benefits for child with disabilities"
+                  id="Survivors benefits for child with disabilities"
                 >
                   <div>
                     <h4
@@ -4764,7 +4743,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors benefits for mothers/fathers"
@@ -4774,7 +4752,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="21-Survivors benefits for mothers/fathers"
+                    aria-controls="Survivors benefits for mothers/fathers"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -4817,7 +4795,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="21-Survivors benefits for mothers/fathers"
+                  id="Survivors benefits for mothers/fathers"
                 >
                   <div>
                     <h4
@@ -5031,7 +5009,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors benefits for parents"
@@ -5042,7 +5019,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="22-Survivors benefits for parents"
+                    aria-controls="Survivors benefits for parents"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -5085,7 +5062,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="22-Survivors benefits for parents"
+                  id="Survivors benefits for parents"
                 >
                   <div>
                     <h4
@@ -5288,7 +5265,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors benefits for spouse"
@@ -5298,7 +5274,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="23-Survivors benefits for spouse"
+                    aria-controls="Survivors benefits for spouse"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -5341,7 +5317,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="23-Survivors benefits for spouse"
+                  id="Survivors benefits for spouse"
                 >
                   <div>
                     <h4
@@ -5585,7 +5561,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors benefits for spouse with disabilities"
@@ -5596,7 +5571,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="24-Survivors benefits for spouse with disabilities"
+                    aria-controls="Survivors benefits for spouse with disabilities"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -5639,7 +5614,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="24-Survivors benefits for spouse with disabilities"
+                  id="Survivors benefits for spouse with disabilities"
                 >
                   <div>
                     <h4
@@ -5906,7 +5881,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors pension for child"
@@ -5917,7 +5891,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="25-Survivors pension for child"
+                    aria-controls="Survivors pension for child"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -5960,7 +5934,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="25-Survivors pension for child"
+                  id="Survivors pension for child"
                 >
                   <div>
                     <h4
@@ -6104,7 +6078,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors pension for child with disabilities"
@@ -6115,7 +6088,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="26-Survivors pension for child with disabilities"
+                    aria-controls="Survivors pension for child with disabilities"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -6158,7 +6131,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="26-Survivors pension for child with disabilities"
+                  id="Survivors pension for child with disabilities"
                 >
                   <div>
                     <h4
@@ -6333,7 +6306,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors pension for spouse"
@@ -6344,7 +6316,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="27-Survivors pension for spouse"
+                    aria-controls="Survivors pension for spouse"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -6387,7 +6359,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="27-Survivors pension for spouse"
+                  id="Survivors pension for spouse"
                 >
                   <div>
                     <h4
@@ -6582,7 +6554,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Veterans burial allowance"
@@ -6593,7 +6564,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="28-Veterans burial allowance"
+                    aria-controls="Veterans burial allowance"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -6636,7 +6607,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="28-Veterans burial allowance"
+                  id="Veterans burial allowance"
                 >
                   <div>
                     <h4
@@ -6862,7 +6833,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Veterans headstone and grave marker"
@@ -6873,7 +6843,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="29-Veterans headstone and grave marker"
+                    aria-controls="Veterans headstone and grave marker"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -6916,7 +6886,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="29-Veterans headstone and grave marker"
+                  id="Veterans headstone and grave marker"
                 >
                   <div>
                     <h4
@@ -7081,7 +7051,6 @@ exports[`loads view 1`] = `
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Veterans medallion"
@@ -7092,7 +7061,7 @@ exports[`loads view 1`] = `
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="30-Veterans medallion"
+                    aria-controls="Veterans medallion"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -7135,7 +7104,7 @@ exports[`loads view 1`] = `
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="30-Veterans medallion"
+                  id="Veterans medallion"
                 >
                   <div>
                     <h4
@@ -7492,7 +7461,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 Open all +
               </button>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Burial benefits"
@@ -7503,7 +7471,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="0-Burial benefits"
+                    aria-controls="Burial benefits"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -7546,7 +7514,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="0-Burial benefits"
+                  id="Burial benefits"
                 >
                   <div>
                     <h4
@@ -7711,7 +7679,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Death gratuity"
@@ -7722,7 +7689,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="1-Death gratuity"
+                    aria-controls="Death gratuity"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -7765,7 +7732,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="1-Death gratuity"
+                  id="Death gratuity"
                 >
                   <div>
                     <h4
@@ -7930,7 +7897,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Burial flag"
@@ -7941,7 +7907,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="2-Burial flag"
+                    aria-controls="Burial flag"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -7984,7 +7950,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="2-Burial flag"
+                  id="Burial flag"
                 >
                   <div>
                     <h4
@@ -8144,7 +8110,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Annuity for certain military surviving spouses"
@@ -8155,7 +8120,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="3-Annuity for certain military surviving spouses"
+                    aria-controls="Annuity for certain military surviving spouses"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -8198,7 +8163,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="3-Annuity for certain military surviving spouses"
+                  id="Annuity for certain military surviving spouses"
                 >
                   <div>
                     <h4
@@ -8363,7 +8328,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Burial in VA national cemetery"
@@ -8374,7 +8338,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="4-Burial in VA national cemetery"
+                    aria-controls="Burial in VA national cemetery"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -8417,7 +8381,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="4-Burial in VA national cemetery"
+                  id="Burial in VA national cemetery"
                 >
                   <div>
                     <h4
@@ -8552,7 +8516,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Civilian Health and Medical Program of the VA (CHAMPVA) for child"
@@ -8563,7 +8526,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="5-Civilian Health and Medical Program of the VA (CHAMPVA) for child"
+                    aria-controls="Civilian Health and Medical Program of the VA (CHAMPVA) for child"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -8606,7 +8569,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="5-Civilian Health and Medical Program of the VA (CHAMPVA) for child"
+                  id="Civilian Health and Medical Program of the VA (CHAMPVA) for child"
                 >
                   <div>
                     <h4
@@ -8755,7 +8718,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="COVID-19 funeral assistance"
@@ -8765,7 +8727,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="6-COVID-19 funeral assistance"
+                    aria-controls="COVID-19 funeral assistance"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -8808,7 +8770,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="6-COVID-19 funeral assistance"
+                  id="COVID-19 funeral assistance"
                 >
                   <div>
                     <h4
@@ -9052,7 +9014,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Dependency and Indemnity Compensation (DIC) for child"
@@ -9063,7 +9024,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="7-Dependency and Indemnity Compensation (DIC) for child"
+                    aria-controls="Dependency and Indemnity Compensation (DIC) for child"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -9106,7 +9067,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="7-Dependency and Indemnity Compensation (DIC) for child"
+                  id="Dependency and Indemnity Compensation (DIC) for child"
                 >
                   <div>
                     <h4
@@ -9256,7 +9217,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Dependency and Indemnity Compensation (DIC) for parent"
@@ -9267,7 +9227,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="8-Dependency and Indemnity Compensation (DIC) for parent"
+                    aria-controls="Dependency and Indemnity Compensation (DIC) for parent"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -9310,7 +9270,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="8-Dependency and Indemnity Compensation (DIC) for parent"
+                  id="Dependency and Indemnity Compensation (DIC) for parent"
                 >
                   <div>
                     <h4
@@ -9455,7 +9415,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Dependency and Indemnity Compensation (DIC) for spouse"
@@ -9466,7 +9425,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="9-Dependency and Indemnity Compensation (DIC) for spouse"
+                    aria-controls="Dependency and Indemnity Compensation (DIC) for spouse"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -9509,7 +9468,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="9-Dependency and Indemnity Compensation (DIC) for spouse"
+                  id="Dependency and Indemnity Compensation (DIC) for spouse"
                 >
                   <div>
                     <h4
@@ -9704,7 +9663,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Education benefits (GI Bill) for survivors"
@@ -9715,7 +9673,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="10-Education benefits (GI Bill) for survivors"
+                    aria-controls="Education benefits (GI Bill) for survivors"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -9758,7 +9716,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="10-Education benefits (GI Bill) for survivors"
+                  id="Education benefits (GI Bill) for survivors"
                 >
                   <div>
                     <h4
@@ -9928,7 +9886,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Financial Assistance and Social Services (FASS) for deceased"
@@ -9939,7 +9896,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="11-Financial Assistance and Social Services (FASS) for deceased"
+                    aria-controls="Financial Assistance and Social Services (FASS) for deceased"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -9982,7 +9939,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="11-Financial Assistance and Social Services (FASS) for deceased"
+                  id="Financial Assistance and Social Services (FASS) for deceased"
                 >
                   <div>
                     <h4
@@ -10111,7 +10068,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Home loan program for survivors"
@@ -10122,7 +10078,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="12-Home loan program for survivors"
+                    aria-controls="Home loan program for survivors"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -10165,7 +10121,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="12-Home loan program for survivors"
+                  id="Home loan program for survivors"
                 >
                   <div>
                     <h4
@@ -10361,7 +10317,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Life insurance for survivors of veterans"
@@ -10372,7 +10327,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="13-Life insurance for survivors of veterans"
+                    aria-controls="Life insurance for survivors of veterans"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -10415,7 +10370,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="13-Life insurance for survivors of veterans"
+                  id="Life insurance for survivors of veterans"
                 >
                   <div>
                     <h4
@@ -10575,7 +10530,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Lump-sum death benefit"
@@ -10585,7 +10539,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="14-Lump-sum death benefit"
+                    aria-controls="Lump-sum death benefit"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -10628,7 +10582,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="14-Lump-sum death benefit"
+                  id="Lump-sum death benefit"
                 >
                   <div>
                     <h4
@@ -10842,7 +10796,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Presidential Memorial Certificate"
@@ -10853,7 +10806,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="15-Presidential Memorial Certificate"
+                    aria-controls="Presidential Memorial Certificate"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -10896,7 +10849,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="15-Presidential Memorial Certificate"
+                  id="Presidential Memorial Certificate"
                 >
                   <div>
                     <h4
@@ -11061,7 +11014,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Public safety officers' death benefits"
@@ -11072,7 +11024,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="16-Public safety officers' death benefits"
+                    aria-controls="Public safety officers' death benefits"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -11115,7 +11067,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="16-Public safety officers' death benefits"
+                  id="Public safety officers' death benefits"
                 >
                   <div>
                     <h4
@@ -11258,7 +11210,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Public safety officers' Educational Assistance Program"
@@ -11269,7 +11220,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="17-Public safety officers' Educational Assistance Program"
+                    aria-controls="Public safety officers' Educational Assistance Program"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -11312,7 +11263,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="17-Public safety officers' Educational Assistance Program"
+                  id="Public safety officers' Educational Assistance Program"
                 >
                   <div>
                     <h4
@@ -11454,7 +11405,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivor benefit plan"
@@ -11465,7 +11415,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="18-Survivor benefit plan"
+                    aria-controls="Survivor benefit plan"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -11508,7 +11458,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="18-Survivor benefit plan"
+                  id="Survivor benefit plan"
                 >
                   <div>
                     <h4
@@ -11673,7 +11623,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors benefits for child"
@@ -11684,7 +11633,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="19-Survivors benefits for child"
+                    aria-controls="Survivors benefits for child"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -11727,7 +11676,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="19-Survivors benefits for child"
+                  id="Survivors benefits for child"
                 >
                   <div>
                     <h4
@@ -11909,7 +11858,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors benefits for child with disabilities"
@@ -11920,7 +11868,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="20-Survivors benefits for child with disabilities"
+                    aria-controls="Survivors benefits for child with disabilities"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -11963,7 +11911,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="20-Survivors benefits for child with disabilities"
+                  id="Survivors benefits for child with disabilities"
                 >
                   <div>
                     <h4
@@ -12168,7 +12116,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors benefits for mothers/fathers"
@@ -12178,7 +12125,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="21-Survivors benefits for mothers/fathers"
+                    aria-controls="Survivors benefits for mothers/fathers"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -12221,7 +12168,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="21-Survivors benefits for mothers/fathers"
+                  id="Survivors benefits for mothers/fathers"
                 >
                   <div>
                     <h4
@@ -12435,7 +12382,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors benefits for parents"
@@ -12446,7 +12392,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="22-Survivors benefits for parents"
+                    aria-controls="Survivors benefits for parents"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -12489,7 +12435,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="22-Survivors benefits for parents"
+                  id="Survivors benefits for parents"
                 >
                   <div>
                     <h4
@@ -12692,7 +12638,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors benefits for spouse"
@@ -12702,7 +12647,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="23-Survivors benefits for spouse"
+                    aria-controls="Survivors benefits for spouse"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -12745,7 +12690,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="23-Survivors benefits for spouse"
+                  id="Survivors benefits for spouse"
                 >
                   <div>
                     <h4
@@ -12989,7 +12934,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors benefits for spouse with disabilities"
@@ -13000,7 +12944,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="24-Survivors benefits for spouse with disabilities"
+                    aria-controls="Survivors benefits for spouse with disabilities"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -13043,7 +12987,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="24-Survivors benefits for spouse with disabilities"
+                  id="Survivors benefits for spouse with disabilities"
                 >
                   <div>
                     <h4
@@ -13310,7 +13254,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors pension for child"
@@ -13321,7 +13264,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="25-Survivors pension for child"
+                    aria-controls="Survivors pension for child"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -13364,7 +13307,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="25-Survivors pension for child"
+                  id="Survivors pension for child"
                 >
                   <div>
                     <h4
@@ -13508,7 +13451,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors pension for child with disabilities"
@@ -13519,7 +13461,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="26-Survivors pension for child with disabilities"
+                    aria-controls="Survivors pension for child with disabilities"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -13562,7 +13504,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="26-Survivors pension for child with disabilities"
+                  id="Survivors pension for child with disabilities"
                 >
                   <div>
                     <h4
@@ -13737,7 +13679,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Survivors pension for spouse"
@@ -13748,7 +13689,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="27-Survivors pension for spouse"
+                    aria-controls="Survivors pension for spouse"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -13791,7 +13732,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="27-Survivors pension for spouse"
+                  id="Survivors pension for spouse"
                 >
                   <div>
                     <h4
@@ -13986,7 +13927,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Veterans burial allowance"
@@ -13997,7 +13937,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="28-Veterans burial allowance"
+                    aria-controls="Veterans burial allowance"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -14040,7 +13980,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="28-Veterans burial allowance"
+                  id="Veterans burial allowance"
                 >
                   <div>
                     <h4
@@ -14266,7 +14206,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Veterans headstone and grave marker"
@@ -14277,7 +14216,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="29-Veterans headstone and grave marker"
+                    aria-controls="Veterans headstone and grave marker"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -14320,7 +14259,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="29-Veterans headstone and grave marker"
+                  id="Veterans headstone and grave marker"
                 >
                   <div>
                     <h4
@@ -14485,7 +14424,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 </div>
               </div>
               <div
-                aria-expanded="false"
                 class="bf-usa-accordion usa-accordion"
                 data-analytics="bf-usa-accordion"
                 data-analytics-content="Veterans medallion"
@@ -14496,7 +14434,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                   class="bf-usa-accordion__heading usa-accordion__heading"
                 >
                   <button
-                    aria-controls="30-Veterans medallion"
+                    aria-controls="Veterans medallion"
                     aria-expanded="false"
                     class="bf-usa-accordion__button usa-accordion__button"
                     type="button"
@@ -14539,7 +14477,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <div
                   class="bf-usa-accordion__content usa-accordion__content usa-prose"
                   hidden=""
-                  id="30-Veterans medallion"
+                  id="Veterans medallion"
                 >
                   <div>
                     <h4


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

This work removes the duplicate aria attribute on accordions

## Related Github Issue

- Fixes #1073 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] `cd benefit-finder`
- [ ] `npm install`
- [ ] `npm run start`


<!--- If there are steps for user testing list them here -->

- [ ] navigate to results view
- [ ] toggle on axeDev tool
- [ ] run scan
- [ ] confirm aria error is resolved
- [ ] inspect elements
- [ ] confirm that only the `<button />` elements in the accordion components have `aria-extended` attributes

expected:
<img width="1437" alt="Screenshot 2024-04-11 at 10 45 10 AM" src="https://github.com/GSA/px-benefit-finder/assets/37077057/4cdb70aa-a19d-4881-9d21-7cce7dd0c052">

