### PR TITLE
1157 disable delete criteria if still used

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
@@ -171,3 +171,138 @@ function _usagov_benefit_finder_content_check_agency_usage(array &$form) {
     $form['actions']['submit']['#access'] = FALSE;
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function usagov_benefit_finder_content_form_node_bears_criteria_delete_form_alter(array &$form, FormStateInterface $form_state) {
+  _usagov_benefit_finder_content_check_criteria_usage($form);
+}
+
+/**
+ * It checks criteria usage in benefits and life event forms.
+ * If still used, it lists the benefits and life event forms and disables the criteria delete confirmation button.
+ *
+ * @param array $form
+ *   Form array.
+ */
+function _usagov_benefit_finder_content_check_criteria_usage(array &$form) {
+  $description = '';
+
+  $node = \Drupal::routeMatch()->getParameter('node');
+  $nid = $node->id();
+
+  $result = _usagov_benefit_finder_content_check_criteria_usage_in_life_event_form($nid);
+  foreach ($result as $row) {
+    $description .= "<li>Life event form: $row[title] ($row[nid])</li>";
+  }
+
+  $result = _usagov_benefit_finder_content_check_criteria_usage_in_benefit($nid);
+  foreach ($result as $row) {
+    $description .= "<li>Benefit: $row[title] ($row[nid])</li>";
+  }
+
+  if (!empty($description)) {
+    $description = '<div class="entity-skip">'
+      . '<span>This criteria cannot be deleted as it is still used in following content:</span>'
+      . "<ul>$description</ul>"
+      . '</div>';
+    $form['description']['#markup'] = t($description);
+    $form['actions']['submit']['#access'] = FALSE;
+  }
+}
+
+/**
+ * It checks criteria usage in life event forms.
+ *
+ * @param int $nid
+ *   Node ID of given criteria.
+ */
+function _usagov_benefit_finder_content_check_criteria_usage_in_life_event_form(int $nid) {
+  $return = [];
+
+  $connection = Database::getConnection();
+
+  $query = $connection->select('paragraph__field_b_criteria_key', 't');
+  $query->fields('t', ['entity_id']);
+  $query->condition('t.bundle', 'b_levent_elg_criteria');
+  $query->condition('t.field_b_criteria_key_target_id', $nid);
+  $result = $query->execute();
+
+  $entity_ids = [];
+  foreach ($result as $row) {
+    $entity_ids[] = $row->entity_id;
+  }
+
+  if (!empty($entity_ids)) {
+    $first_level_entity_ids = [];
+    do {
+      $new_entity_ids = [];
+      foreach ($entity_ids as $entity_id) {
+        $query = $connection->select('paragraph__field_b_children', 't');
+        $query->fields('t', ['entity_id']);
+        $query->condition('t.bundle', 'b_levent_elg_criteria');
+        $query->condition('t.field_b_children_target_id', $entity_id);
+        $result = $query->execute()->fetchField();
+        if ($result) {
+          $new_entity_ids[] = $result;
+        }
+        else {
+          $first_level_entity_ids[] = $entity_id;
+        }
+      }
+      if (empty($new_entity_ids)) {
+        break;
+      }
+      else {
+        $entity_ids = $new_entity_ids;
+      }
+    } while (1);
+
+    $query = $connection->select('node_field_data', 't1');
+    $query->join('node__field_b_sections_elg_criteria', 't2', 't1.nid = t2.entity_id');
+    $query->join('paragraph__field_b_criterias', 't3', 't2.field_b_sections_elg_criteria_target_id=  t3.entity_id');
+    $query->fields('t1', ['title', 'nid']);
+    $query->condition('t3.field_b_criterias_target_id', $first_level_entity_ids, 'IN');
+    $query->orderBy('title');
+    $result = $query->execute();
+
+    foreach ($result as $row) {
+      $return[] = array(
+        'nid' => $row->nid,
+        'title' => $row->title,
+      );
+    }
+  }
+
+  return $return;
+}
+
+/**
+ * It checks criteria usage in benefit.
+ *
+ * @param int $nid
+ *   Node ID of given criteria.
+ */
+function _usagov_benefit_finder_content_check_criteria_usage_in_benefit(int $nid) {
+  $return = [];
+
+  $connection = Database::getConnection();
+
+  $query = $connection->select('node_field_data', 't1');
+  $query->join('node__field_b_eligibility', 't2', 't1.nid = t2.entity_id');
+  $query->join('paragraph__field_b_criteria_key', 't3', 't2.field_b_eligibility_target_id = t3.entity_id');
+  $query->fields('t1', ['title', 'nid']);
+  $query->condition('t3.field_b_criteria_key_target_id', $nid);
+  $query->orderBy('title');
+  $result = $query->execute();
+
+  foreach ($result as $row) {
+    $return[] = array(
+      'nid' => $row->nid,
+      'title' => $row->title,
+    );
+  }
+
+  return $return;
+}

--- a/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
@@ -268,7 +268,7 @@ function _usagov_benefit_finder_content_check_criteria_usage_in_life_event_form(
     $result = $query->execute();
 
     foreach ($result as $row) {
-      $return[] = [ 'nid' => $row->nid, 'title' => $row->title ];
+      $return[] = ['nid' => $row->nid, 'title' => $row->title];
     }
   }
 
@@ -295,7 +295,7 @@ function _usagov_benefit_finder_content_check_criteria_usage_in_benefit(int $nid
   $result = $query->execute();
 
   foreach ($result as $row) {
-    $return[] = [ 'nid' => $row->nid, 'title' => $row->title ];
+    $return[] = ['nid' => $row->nid, 'title' => $row->title];
   }
 
   return $return;

--- a/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
@@ -268,10 +268,7 @@ function _usagov_benefit_finder_content_check_criteria_usage_in_life_event_form(
     $result = $query->execute();
 
     foreach ($result as $row) {
-      $return[] = array(
-        'nid' => $row->nid,
-        'title' => $row->title,
-      );
+      $return[] = [ 'nid' => $row->nid, 'title' => $row->title ];
     }
   }
 
@@ -298,10 +295,7 @@ function _usagov_benefit_finder_content_check_criteria_usage_in_benefit(int $nid
   $result = $query->execute();
 
   foreach ($result as $row) {
-    $return[] = array(
-      'nid' => $row->nid,
-      'title' => $row->title,
-    );
+    $return[] = [ 'nid' => $row->nid, 'title' => $row->title ];
   }
 
   return $return;


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This work ensures criteria content can not be delete if still used.
If a criteria still used, it lists the contents that use this criteria and disables the criteria delete confirmation button.

## Related Github Issue

- Fixes #1157 

## Detailed Testing steps

To test in local development site or in dev site.

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] make local development site up at http://localhost
- [ ] navigate to http://localhost/admin/content?combine=&type=bears_criteria&status=All&langcode=All
- [ ] select a criteria to edit, for example Applicant date of birth
- [ ] click Delete button
- [ ] verify that it lists the contents that still use the criteria Applicant date of birth
- [ ] verify that no Delete button

![image](https://github.com/GSA/px-benefit-finder/assets/88853916/a93f8623-998e-45d3-a195-8e6808f34a86)

- [ ] navigate to http://localhost/node/add/bears_criteria
- [ ] create a criteria
- [ ] edit the newly created criteria
- [ ] click Delete button
- [ ] verify that no content listed as this criteria is not used in any content
- [ ] verify that Delete button showing

<img width="600" src="https://github.com/GSA/px-benefit-finder/assets/88853916/7670c341-c81f-4ee3-a4c6-3552835cb615">

- [ ] click Delete button
- [ ] verify that the criteria is deleted

<!--- If there are steps for user testing list them here -->