### PR TITLE
1227 remove life event in building benefit for JSON data generation

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
@@ -465,14 +465,6 @@ class LifeEventController {
       $benefit["tags"][] = $tag->get('name')->value;
     }
 
-    // Build life event.
-    $lifeEvents = $node->get('field_b_life_events')->getValue();
-    foreach ($lifeEvents as $lifeEvent) {
-      $service = $this->entityTypeManager->getStorage('node');
-      $node1 = $service->load($lifeEvent['target_id']);
-      $benefit['lifeEvents'][] = $node1->get('title')->value;
-    }
-
     // Build eligibilities.
     $benefit_eligibilitys = [];
     $eligibilities = $node->get('field_b_eligibility')->referencedEntities();


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This work removes life event in building benefit for JSON data generation.

## Related Github Issue

- Fixes #1227 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->

<!--- If there are steps for user testing list them here -->
