### PR TITLE
PXBF-1203-e2e-benefits-results-view: add coverage benefits results view

### DIFF
--- a/benefit-finder/cypress/e2e/storybook/selected-criteria-eligibility-benefits.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/selected-criteria-eligibility-benefits.cy.js
@@ -104,7 +104,6 @@ describe('Validate correct eligibility benefits display based on selected criter
     delete selectedData.shared // We don't want to include the "shared" param
     const selectDataLength = Object.keys(selectedData).length
     const benefitsCount = data.benefits.length
-    // console.log(EN_DOLO_MOCK_DATA.data.benefits)
 
     cy.visit(`${utils.storybookUri}${scenario}`)
 

--- a/benefit-finder/cypress/e2e/storybook/selected-criteria-eligibility-benefits.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/selected-criteria-eligibility-benefits.cy.js
@@ -110,6 +110,41 @@ describe('Validate correct eligibility benefits display based on selected criter
       .and('contain', enResults.eligible.eligible_benefits[0])
       .and('contain', enResults.eligible.eligible_benefits[1])
       .and('contain', enResults.eligible.eligible_benefits[2])
+
+    pageObjects
+      .benefitResultsView()
+      .invoke('attr', 'data-analytics')
+      .should('eq', 'bf-result-view')
+
+    pageObjects
+      .benefitResultsView()
+      .invoke('attr', 'data-analytics-content')
+      .should('eq', 'bf-eligible-view')
+
+    pageObjects
+      .benefitResultsView()
+      .invoke('attr', 'data-analytics-content-criteria-values')
+      .should('eq', '14')
+
+    pageObjects
+      .benefitResultsView()
+      .invoke('attr', 'data-analytics-content-benefits')
+      .should('eq', '31')
+
+    pageObjects
+      .benefitResultsView()
+      .invoke('attr', 'data-analytics-content-eligible')
+      .should('eq', `${enResults.eligible.length}`)
+
+    pageObjects
+      .benefitResultsView()
+      .invoke('attr', 'data-analytics-content-not-eligible')
+      .should('eq', '27')
+
+    pageObjects
+      .benefitResultsView()
+      .invoke('attr', 'data-analytics-content-more-info')
+      .should('eq', '1')
   })
 
   it('QA scenario 2 Veteran EN - Verify correct benefit results for query values that includes veteran in search parameter of URL', () => {

--- a/benefit-finder/cypress/e2e/storybook/selected-criteria-eligibility-benefits.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/selected-criteria-eligibility-benefits.cy.js
@@ -4,6 +4,8 @@ import { pageObjects } from '../../support/pageObjects'
 import * as utils from '../../support/utils'
 import * as EN_DOLO_MOCK_DATA from '../../../../benefit-finder/src/shared/api/mock-data/current.json'
 import * as BENEFITS_ELIBILITY_DATA from '../../fixtures/benefits-eligibility.json'
+import content from '../../../../benefit-finder/src/shared/api/mock-data/current.js'
+const { data } = JSON.parse(content)
 
 describe('Validate correct eligibility benefits display based on selected criteria/options', () => {
   it('Should render Survivor Benefits for Child benefit accordion correctly based on selected cretiria options', () => {
@@ -99,6 +101,10 @@ describe('Validate correct eligibility benefits display based on selected criter
     const selectedData = BENEFITS_ELIBILITY_DATA.scenario_1_covid.en.param
     const enResults = BENEFITS_ELIBILITY_DATA.scenario_1_covid.en.results
     const scenario = utils.encodeURIFromObject(selectedData)
+    delete selectedData.shared // We don't want to include the "shared" param
+    const selectDataLength = Object.keys(selectedData).length
+    const benefitsCount = data.benefits.length
+    // console.log(EN_DOLO_MOCK_DATA.data.benefits)
 
     cy.visit(`${utils.storybookUri}${scenario}`)
 
@@ -124,12 +130,12 @@ describe('Validate correct eligibility benefits display based on selected criter
     pageObjects
       .benefitResultsView()
       .invoke('attr', 'data-analytics-content-criteria-values')
-      .should('eq', '14')
+      .should('eq', `${selectDataLength}`)
 
     pageObjects
       .benefitResultsView()
       .invoke('attr', 'data-analytics-content-benefits')
-      .should('eq', '31')
+      .should('eq', `${benefitsCount}`)
 
     pageObjects
       .benefitResultsView()
@@ -138,13 +144,16 @@ describe('Validate correct eligibility benefits display based on selected criter
 
     pageObjects
       .benefitResultsView()
-      .invoke('attr', 'data-analytics-content-not-eligible')
-      .should('eq', '27')
+      .invoke('attr', 'data-analytics-content-more-info')
+      .should('eq', `${enResults.moreInformationNeeded.length}`)
 
     pageObjects
       .benefitResultsView()
-      .invoke('attr', 'data-analytics-content-more-info')
-      .should('eq', '1')
+      .invoke('attr', 'data-analytics-content-not-eligible')
+      .should(
+        'eq',
+        `${benefitsCount - enResults.eligible.length - enResults.moreInformationNeeded.length}`
+      )
   })
 
   it('QA scenario 2 Veteran EN - Verify correct benefit results for query values that includes veteran in search parameter of URL', () => {

--- a/benefit-finder/cypress/fixtures/benefits-eligibility.json
+++ b/benefit-finder/cypress/fixtures/benefits-eligibility.json
@@ -27,6 +27,9 @@
         "shared": "true"
       },
       "results": {
+        "moreInformationNeeded": {
+          "length": 1
+        },
         "eligible": {
           "length": 3,
           "eligible_benefits": [
@@ -194,7 +197,6 @@
         "applicant_marital_status": "Unmarried",
         "shared": "true"
       }
-     
     },
     "es": {
       "param": {

--- a/benefit-finder/cypress/support/pageObjects.js
+++ b/benefit-finder/cypress/support/pageObjects.js
@@ -112,6 +112,10 @@ class PageObjects {
   keyEligibilityCriteriaListIcon() {
     return cy.get('.usa-accordion .bf-usa-list svg')
   }
+
+  benefitResultsView() {
+    return cy.get('.bf-result-view')
+  }
 }
 
 export const pageObjects = new PageObjects()


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This PR adds cypress e2e test for virtual page attributes on benefit results view.

This includes
data-analytics="bf-result-view"
      data-analytics-content={
        notEligibleView === true ? 'bf-not-eligible-view' : 'bf-eligible-view'
      }
      data-analytics-content-criteria-values={criteriaValues}
      data-analytics-content-benefits={benefitsLength}
      data-analytics-content-eligible={eligibilityCount.eligible}
      data-analytics-content-not-eligible={eligibilityCount.notEligible}
      data-analytics-content-more-info={eligibilityCount.moreInfo}

## Related Github Issue

- Fixes #1203 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ]  `cd benefit finder`
- [ ] `npm run dev:storybook`
- [ ]  `npm run cy:run` and verify all test pass

<!--- If there are steps for user testing list them here -->
