### PR TITLE
PXBF-1249-suppress-errors-prod-nightly-run: suppress error prod nightly run  scenarios

### DIFF
--- a/benefit-finder/cypress/e2e/usagov-public-site/mobile-menu-and-breadcrumb.cy.js
+++ b/benefit-finder/cypress/e2e/usagov-public-site/mobile-menu-and-breadcrumb.cy.js
@@ -3,6 +3,9 @@
 import { pageObjects } from '../../support/pageObjects'
 
 describe('Validate user can navigate each path of mobile menu and breadcrumb displays correctly', () => {
+  Cypress.on('uncaught:exception', (_err, runnable) => {
+    return false
+  })
   beforeEach(() => {
     cy.visit('/benefit-finder')
   })


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
When a user accesses various benefits on [www.usa.gov/benefit-finder](http://www.usa.gov/benefit-finder), the application should not display Uncaught Type Error – GoogleAnalyticsObject is not a function.

This causing cypress tests to fail as such we need to cypress the errors until the issue is resolved.
## Related Github Issue

- Fixes #1249 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] `cd benefit finder`
- [ ] `npm run cy:run:prod:e2e`
- [ ] Verify tests are passing

<!--- If there are steps for user testing list them here -->
