### PR TITLE
1271 add short description and page intro field in life event

### DIFF
--- a/usagov_benefit_finder/configuration/core.entity_form_display.node.bears_life_event.default.yml
+++ b/usagov_benefit_finder/configuration/core.entity_form_display.node.bears_life_event.default.yml
@@ -11,6 +11,8 @@ dependencies:
     - field.field.node.bears_life_event.field_json_data_file_path
     - field.field.node.bears_life_event.field_language_toggle
     - field.field.node.bears_life_event.field_meta_description
+    - field.field.node.bears_life_event.field_page_intro
+    - field.field.node.bears_life_event.field_short_description
     - field.field.node.bears_life_event.field_summary
     - node.type.bears_life_event
   module:
@@ -26,7 +28,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 6
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -40,14 +42,14 @@ content:
     third_party_settings: {  }
   field_draft_json_data_file:
     type: file_generic
-    weight: 16
+    weight: 20
     region: content
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
   field_draft_json_data_file_path:
     type: string_textfield
-    weight: 14
+    weight: 18
     region: content
     settings:
       size: 60
@@ -55,7 +57,7 @@ content:
     third_party_settings: {  }
   field_header_html:
     type: text_textarea
-    weight: 20
+    weight: 21
     region: content
     settings:
       rows: 5
@@ -66,14 +68,14 @@ content:
         hide_guidelines: '0'
   field_json_data_file:
     type: file_generic
-    weight: 15
+    weight: 19
     region: content
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
   field_json_data_file_path:
     type: string_textfield
-    weight: 13
+    weight: 17
     region: content
     settings:
       size: 60
@@ -91,7 +93,23 @@ content:
     third_party_settings: {  }
   field_meta_description:
     type: string_textarea
-    weight: 3
+    weight: 5
+    region: content
+    settings:
+      rows: 1
+      placeholder: ''
+    third_party_settings: {  }
+  field_page_intro:
+    type: string_textarea
+    weight: 4
+    region: content
+    settings:
+      rows: 1
+      placeholder: ''
+    third_party_settings: {  }
+  field_short_description:
+    type: string_textarea
+    weight: 6
     region: content
     settings:
       rows: 1
@@ -99,7 +117,7 @@ content:
     third_party_settings: {  }
   field_summary:
     type: string_textarea
-    weight: 4
+    weight: 7
     region: content
     settings:
       rows: 5
@@ -114,38 +132,38 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 11
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 9
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 7
+    weight: 10
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   simple_sitemap:
-    weight: 10
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 12
+    weight: 16
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 8
+    weight: 11
     region: content
     settings:
       display_label: true
@@ -165,7 +183,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 8
     region: content
     settings:
       match_operator: CONTAINS
@@ -174,7 +192,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 10
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_life_event.default.yml
+++ b/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_life_event.default.yml
@@ -11,6 +11,8 @@ dependencies:
     - field.field.node.bears_life_event.field_json_data_file_path
     - field.field.node.bears_life_event.field_language_toggle
     - field.field.node.bears_life_event.field_meta_description
+    - field.field.node.bears_life_event.field_page_intro
+    - field.field.node.bears_life_event.field_short_description
     - field.field.node.bears_life_event.field_summary
     - node.type.bears_life_event
   module:
@@ -88,6 +90,20 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_page_intro:
+    type: basic_string
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_short_description:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 11
     region: content
   field_summary:
     type: basic_string

--- a/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_life_event.teaser.yml
+++ b/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_life_event.teaser.yml
@@ -12,6 +12,8 @@ dependencies:
     - field.field.node.bears_life_event.field_json_data_file_path
     - field.field.node.bears_life_event.field_language_toggle
     - field.field.node.bears_life_event.field_meta_description
+    - field.field.node.bears_life_event.field_page_intro
+    - field.field.node.bears_life_event.field_short_description
     - field.field.node.bears_life_event.field_summary
     - node.type.bears_life_event
   module:
@@ -40,5 +42,7 @@ hidden:
   field_json_data_file_path: true
   field_language_toggle: true
   field_meta_description: true
+  field_page_intro: true
+  field_short_description: true
   field_summary: true
   langcode: true

--- a/usagov_benefit_finder/configuration/field.field.node.bears_life_event.field_page_intro.yml
+++ b/usagov_benefit_finder/configuration/field.field.node.bears_life_event.field_page_intro.yml
@@ -1,0 +1,19 @@
+uuid: 1f6b04ec-e649-4672-8405-32a594ad93cb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_page_intro
+    - node.type.bears_life_event
+id: node.bears_life_event.field_page_intro
+field_name: field_page_intro
+entity_type: node
+bundle: bears_life_event
+label: 'Page Intro'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/usagov_benefit_finder/configuration/field.field.node.bears_life_event.field_short_description.yml
+++ b/usagov_benefit_finder/configuration/field.field.node.bears_life_event.field_short_description.yml
@@ -1,0 +1,19 @@
+uuid: d892bc96-def5-4e8f-9725-d670fdc2c382
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_short_description
+    - node.type.bears_life_event
+id: node.bears_life_event.field_short_description
+field_name: field_short_description
+entity_type: node
+bundle: bears_life_event
+label: 'Short Description'
+description: 'The short description appears on cards for the homepage and nav pages. Aim for less than 80 characters. If left blank the page intro will be used.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long


### PR DESCRIPTION
## PR Summary

This work adds short description and page intro field in life event content type.

## Related Github Issue

- Fixes #1271 

## Detailed Testing steps

To test in local development site or in dev site.

- [ ] pull changes locally
- [ ] make local development site up at http://localhost
- [ ] navigate to http://localhost/admin/content?combine=&type=bears_life_event&status=All&langcode=All
- [ ] select life event form Benefit finder: death of a loved one
- [ ] verify that it has short description and page intro field

<img width="800" src="https://github.com/GSA/px-benefit-finder/assets/88853916/b34031b5-f2de-4849-8cc5-5c0779d58dd8">

