### PR TITLE
Remove hidden values in child inputs

### DIFF
--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -482,6 +482,11 @@ const LifeEventSection = ({
                   const checkParentValue = item => {
                     const selectedParentValue = apiCalls.GET.SelectedValue(item)
 
+                    /**
+                     * a value that checks the selected parent validator to expose child inputs in the form
+                     * @return {boolean} returns true or false
+                     */
+
                     const hidden =
                       selectedParentValue?.value !==
                       item.fieldset.inputs[0].inputCriteria
@@ -497,13 +502,26 @@ const LifeEventSection = ({
                       children: item.fieldset.children.map(
                         (child, i) =>
                           child.fieldsets.length &&
-                          child.fieldsets.map((childItem, childItemIndex) =>
-                            Input({
+                          child.fieldsets.map((childItem, childItemIndex) => {
+                            // if a parent determines the children inputs are hidden, we expect that the seleted values in child items are de-selected
+                            const selectedValue =
+                              childItem && apiCalls.GET.SelectedValue(childItem)
+
+                            const isHidden = checkParentValue(item)
+
+                            if (
+                              isHidden === true &&
+                              selectedValue !== undefined
+                            ) {
+                              delete selectedValue.selected
+                            }
+
+                            return Input({
                               item: childItem,
                               index: childItemIndex,
-                              hidden: checkParentValue(item),
+                              hidden: isHidden,
                             })
-                          )
+                          })
                       ),
                     })
                   }


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This works to resolve a bug where deselecting parent inputs did not clear the children input values.

## Related Github Issue

- Fixes #1108 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] `cd benefit-finder`
- [ ] `npm install`
- [ ] `npm run start`


<!--- If there are steps for user testing list them here -->
- [ ] navigate to `/death`
- [ ] fill out required fields in form
- [ ] on last question "Did the deceased actively serve in the U.S. military?" select "yes"
- [ ] fill out required child values
- [ ] click continue
- [ ] click see results
- [ ] share resutls
- [ ] paste values back into url
- [ ] navigate back to final step
- [ ] ensure child values of parent input are still populated
- [ ] on last question "Did the deceased actively serve in the U.S. military?" select "no"
- [ ] on last question "Did the deceased actively serve in the U.S. military?" select "yes"
- [ ] ensure child values are not populated
- [ ] on last question "Did the deceased actively serve in the U.S. military?" select "no"
- [ ]  click continue
- [ ] click see results
- [ ] share resutls
- [ ] paste values back into url
- [ ] navigate back to final step
- [ ] ensure child values of parent input are not populated



https://github.com/GSA/px-benefit-finder/assets/37077057/1dbcc5dd-26b7-4fae-b44e-6fa6c042201d


