### PR TITLE
1296 set life event form of paragraph relevant benefit required

### DIFF
--- a/usagov_benefit_finder/configuration/field.field.paragraph.b_levent_relevant_benefit.field_b_life_event_form.yml
+++ b/usagov_benefit_finder/configuration/field.field.paragraph.b_levent_relevant_benefit.field_b_life_event_form.yml
@@ -1,0 +1,25 @@
+uuid: ec5f36b1-45d7-4c91-b74d-3d8a49dd348f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_b_life_event_form
+    - paragraphs.paragraphs_type.b_levent_relevant_benefit
+id: paragraph.b_levent_relevant_benefit.field_b_life_event_form
+field_name: field_b_life_event_form
+entity_type: paragraph
+bundle: b_levent_relevant_benefit
+label: 'Life Event Form'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: views
+  handler_settings:
+    view:
+      view_name: benefit_finder
+      display_name: entity_reference_3
+      arguments: {  }
+field_type: entity_reference


### PR DESCRIPTION
## PR Summary

This work sets life event form of paragraph relevant benefit to be required field.

## Related Github Issue

- Fixes #1296 

## Detailed Testing steps

To test in local development site or in dev site.

- [ ] Pull changes locally
- [ ] Make local development site up at http://localhost
- [ ] Navigate to `/admin/content?combine=&type=bears_life_event_form&status=All&langcode=All`
- [ ] Go to life event form "Benefit finder: death of a loved one" edit page
- [ ] Verify that the life event form field is required

<img width="600" src="https://github.com/GSA/px-benefit-finder/assets/88853916/577ac87b-d9ba-4730-a312-dd8110dd42c6">
