### PR TITLE
Init local mv script

### DIFF
--- a/scripts/local/setup-usagov-benefit-finder.sh
+++ b/scripts/local/setup-usagov-benefit-finder.sh
@@ -25,11 +25,11 @@ for param in "$@"; do
 done
 
 
-# # build benefit finder app
-# bash "${SCRIPTS_LOCATION}/mv-benefit-finder-app.sh"
+# build benefit finder app
+bash "${SCRIPTS_LOCATION}/mv-benefit-finder-app.sh"
 
-# # move benefit finder app into module and move it to usagov-2021 custom modules
-# bash "${SCRIPTS_LOCATION}/mv-usagov_benefit_finder.sh"
+# move benefit finder app into module and move it to usagov-2021 custom modules
+bash "${SCRIPTS_LOCATION}/mv-usagov_benefit_finder.sh"
 
 cd "${USAGOV_PROJECT_LOCATION}"
 git fetch origin prod:prod

--- a/scripts/local/setup-usagov-benefit-finder.sh
+++ b/scripts/local/setup-usagov-benefit-finder.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # Set the root directory
-readonly ROOT_DIR=$(git rev-parse --show-toplevel)
+ROOT_DIR=$(git rev-parse --show-toplevel)
 
 # usagov-2021 project
-readonly USAGOV_PROJECT_LOCATION="${ROOT_DIR}/usagov-2021"
-readonly SCRIPTS_LOCATION="${ROOT_DIR}/scripts/pipeline"
+USAGOV_PROJECT_LOCATION="${ROOT_DIR}/usagov-2021"
+SCRIPTS_LOCATION="${ROOT_DIR}/scripts/pipeline"
 
 
 # make specific to usagov
@@ -47,18 +47,18 @@ then
     bin/db-update
     bin/drupal-update
     docker compose up -d
+
+    # build benefit finder app
+    bash "${SCRIPTS_LOCATION}/mv-benefit-finder-app.sh"
+
+    # move benefit finder app into module and move it to usagov-2021 custom modules
+    bash "${SCRIPTS_LOCATION}/mv-usagov_benefit_finder.sh"
+
+    # post build import
+    bin/drush cim --partial --source=modules/custom/usagov_benefit_finder/configuration -y
+    bin/drush cr
+    bin/drush state:set system.maintenance_mode 0 -y
 else
     echo "ERROR: missing database"
 fi
-
-# build benefit finder app
-bash "${SCRIPTS_LOCATION}/mv-benefit-finder-app.sh"
-
-# move benefit finder app into module and move it to usagov-2021 custom modules
-bash "${SCRIPTS_LOCATION}/mv-usagov_benefit_finder.sh"
-
-# post build import
-bin/drush cim --partial --source=modules/custom/usagov_benefit_finder/configuration -y
-bin/drush cr
-bin/drush state:set system.maintenance_mode 0 -y
 

--- a/scripts/local/setup-usagov-benefit-finder.sh
+++ b/scripts/local/setup-usagov-benefit-finder.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Set the root directory
+readonly ROOT_DIR=$(git rev-parse --show-toplevel)
+
+# usagov-2021 project
+readonly USAGOV_PROJECT_LOCATION="${ROOT_DIR}/usagov-2021"
+readonly SCRIPTS_LOCATION="${ROOT_DIR}/scripts/pipeline"
+
+
+# make specific to usagov
+for param in "$@"; do
+  # stop and remove any old docker stuff if --rebuild flag is passed
+    if [ "$param" = "--rebuild" ]; then
+        echo "Parameter found: ${param}"
+        echo "destroying all containers"
+        docker stop $(docker ps -aq)
+        docker rm $(docker ps -aq)
+        docker network prune -f
+        docker rmi -f $(docker images --filter dangling=true -qa)
+        docker volume rm $(docker volume ls --filter dangling=true -q)
+        docker rmi -f $(docker images -qa)
+        sudo service mysql restart
+    fi
+done
+
+
+# # build benefit finder app
+# bash "${SCRIPTS_LOCATION}/mv-benefit-finder-app.sh"
+
+# # move benefit finder app into module and move it to usagov-2021 custom modules
+# bash "${SCRIPTS_LOCATION}/mv-usagov_benefit_finder.sh"
+
+cd "${USAGOV_PROJECT_LOCATION}"
+git fetch origin prod:prod
+git checkout prod
+echo git branch
+
+for param in "$@"; do
+# stop and checkout if --dev flag is passed
+    if [ "$param" = "--dev" ]; then
+        echo "Parameter found: ${param}"
+        echo "checking out dev branch"
+        git fetch origin dev:dev
+        git checkout dev
+    fi
+done
+
+# check for database
+if test -f "${USAGOV_PROJECT_LOCATION}/usagov.sql"
+then
+    # set up usagov project
+    bin/init
+
+    # include benefit finder data
+    mkdir -p ./s3/local/cms/public/benefit-finder/api/life-event
+    curl -o ./s3/local/cms/public/benefit-finder/api/life-event/death.json https://www.usa.gov/s3/files/benefit-finder/api/life-event/death.json
+    curl -o ./s3/local/cms/public/benefit-finder/api/life-event/es_death.json https://www.usa.gov/s3/files/benefit-finder/api/life-event/es_death.json
+
+
+    bin/db-update
+    bin/drupal-update
+    bin/drush cim --partial --source=modules/custom/usagov_benefit_finder/configuration -y
+    bin/drush cr
+    bin/drush state:set system.maintenance_mode 0 -y
+    docker compose up
+else
+    echo "ERROR: missing database"
+fi
+

--- a/scripts/pipeline/mv-benefit-finder-app.sh
+++ b/scripts/pipeline/mv-benefit-finder-app.sh
@@ -19,7 +19,7 @@ readonly BENEFIT_FINDER_MODULE_CSS_FILE_LOCATION="${BENEFIT_FINDER_MODULE_LIBRAR
 
 # check if benefit-finder application exist
 if test -d "$BENEFIT_FINDER_LOCATION"; then
-    echo "\xE2\x9C\x94 App directory exists"
+    echo "App directory exists"
     # build benefit_finder_app
     cd "${BENEFIT_FINDER_LOCATION}" || exit 1
     echo -e "Building BENEFIT_FINDER app..."
@@ -29,19 +29,19 @@ fi
 
 # check if build file exist
 if test -f "$BENEFIT_FINDER_JS_FILE"; then
-    echo "\xE2\x9C\x94 App build file exist"
-    echo "\xE2\x9C\x94 Build successfull"
+    echo "App build file exist"
+    echo "Build successfull"
 
     # check if benefit-finder custom module library directory exist
     if test -d "$BENEFIT_FINDER_MODULE_JS_FILE_LOCATION"; then
-        echo "\xE2\x9C\x94 Custom module directory exists"
+        echo "Custom module directory exists"
         # move build file
         echo "Moving files to BENEFIT_FINDER module library..."
         cp "${BENEFIT_FINDER_JS_FILE}" "${BENEFIT_FINDER_MODULE_JS_FILE_LOCATION}"
         cp "${BENEFIT_FINDER_CSS_FILE}" "${BENEFIT_FINDER_MODULE_CSS_FILE_LOCATION}"
         test -f "${BENEFIT_FINDER_MODULE_JS_FILE_LOCATION}${BENEFIT_FINDER_JS_FILE_NAME}"
-        echo "\xE2\x9C\x94 JS build file successfully moved"
+        echo "JS build file successfully moved"
         test -f "${BENEFIT_FINDER_MODULE_CSS_FILE_LOCATION}${BENEFIT_FINDER_CSS_FILE_NAME}"
-        echo "\xE2\x9C\x94 CSS build file successfully moved"
+        echo "CSS build file successfully moved"
     fi
 fi

--- a/scripts/pipeline/mv-usagov_benefit_finder.sh
+++ b/scripts/pipeline/mv-usagov_benefit_finder.sh
@@ -14,20 +14,20 @@ readonly USAGOV_PROJECT_CUSTOM_MODULES_LOCATION="${USAGOV_PROJECT_LOCATION}/web/
 # check if usagov-2021 custom modules directory exist
 if test ! -d "$USAGOV_PROJECT_CUSTOM_MODULES_LOCATION"
 then
-    echo "\xE2\x9C\x94 usa.gov project directory does not exists, initializing submodule"
+    echo "usa.gov project directory does not exists, initializing submodule"
     # init submodule
     git submodule init
     git submodule update
 else
-    echo "\xE2\x9C\x94 usa.gov project directory exists, updating submodule"
+    echo "usa.gov project directory exists, updating submodule"
     git pull --recurse-submodules
 fi
 
 # check if module directory exist
 if test -d "$BENEFIT_FINDER_MODULE_LOCATION"
 then
-    echo "\xE2\x9C\x94 usa.gov benefit-finder module exist"
+    echo "usa.gov benefit-finder module exist"
     echo "Moving BENEFIT_FINDER custom module to usa.gov project..."
     cp -r "${BENEFIT_FINDER_MODULE_LOCATION}" "${USAGOV_PROJECT_CUSTOM_MODULES_LOCATION}" || exit 1
-    test -f "${USAGOV_PROJECT_CUSTOM_MODULES_LOCATION}${BENEFIT_FINDER_MODULE}"; echo -e "\xE2\x9C\x94 BENEFIT_FINDER Module successfully moved"
+    test -f "${USAGOV_PROJECT_CUSTOM_MODULES_LOCATION}${BENEFIT_FINDER_MODULE}"; echo -e "BENEFIT_FINDER Module successfully moved"
 fi

--- a/scripts/pipeline/mv-usagov_benefit_finder.sh
+++ b/scripts/pipeline/mv-usagov_benefit_finder.sh
@@ -18,6 +18,8 @@ then
     # init submodule
     git submodule init
     git submodule update
+    cd "${BENEFIT_FINDER_MODULE_LOCATION}"
+    git checkout dev
 else
     echo "usa.gov project directory exists, updating submodule"
     git pull --recurse-submodules

--- a/scripts/pipeline/mv-usagov_benefit_finder.sh
+++ b/scripts/pipeline/mv-usagov_benefit_finder.sh
@@ -19,6 +19,7 @@ then
     git submodule init
     git submodule update
     cd "${BENEFIT_FINDER_MODULE_LOCATION}"
+    git fetch origin prod:prod
     git checkout prod
 else
     echo "usa.gov project directory exists, updating submodule"

--- a/scripts/pipeline/mv-usagov_benefit_finder.sh
+++ b/scripts/pipeline/mv-usagov_benefit_finder.sh
@@ -19,7 +19,7 @@ then
     git submodule init
     git submodule update
     cd "${BENEFIT_FINDER_MODULE_LOCATION}"
-    git checkout dev
+    git checkout prod
 else
     echo "usa.gov project directory exists, updating submodule"
     git pull --recurse-submodules


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This works to make a new script that makes compiling and moving our benefit-finder app into the module, and move the module into the usagov project while initializing and building the usagov project for local testing or development.

## Related Github Issue

- Fixes #1288 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] ensure you are running the correct version of node as noted in `benefit-finder/package.json`
- [ ] ensure you have docker desktop running
- [ ] ensure you have latest database in the `usagov-2021` project, named `usagov.sql`

<!--- If there are steps for user testing list them here -->
- [ ] from the root of the directory, execute the script from the terminal `bash scripts/local/setup-usagov-benefit-finder.sh`


### Troubleshooting

if you are running into errors on the CMS build

`cms       | 2024/05/15 15:27:35 [emerg] 254#254: open() "/etc/nginx/partials/cms.conf" failed (2: No such file or directory) in /etc/nginx/conf.d/default.conf:3`

add `CF_SYSTEM_CERT_PATH=` to your `usagov-2021/.env.local` file

if successful, try these...
There are two flags available to pass with the exec command

`--dev` -  checks out dev code from usagov project
`--rebuild` - removes all docker services and containers and then runs the rest of the script