### PR TITLE
Vista change in Spanish benefit button

### DIFF
--- a/benefit-finder/src/shared/locales/es/es.json
+++ b/benefit-finder/src/shared/locales/es/es.json
@@ -124,7 +124,7 @@
       "benefitSummaryPrefix": "Cumple ",
       "benefitSummaryConjunction": "de",
       "unmetLabel": "No cumplió con",
-      "visitLabel": "Visita",
+      "visitLabel": "Visite",
       "sourceIsEnglish": "(en inglés)"
     },
     "notEligibleResults": {


### PR DESCRIPTION
## PR Summary

Changed Visita-->Visite in Spanish forms for button in benefit accordion.

I think this is the only place where the "Visita" in the button comes up.

## Related Github Issue

- Fixes #1313 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [x] QA
- [ ] Publish
- [ ] Manually QA live changes

<!--- If there are steps for user testing list them here -->
