### PR TITLE
1270 a11y modal buttons

### DIFF
--- a/benefit-finder/src/shared/components/Button/index.jsx
+++ b/benefit-finder/src/shared/components/Button/index.jsx
@@ -85,6 +85,7 @@ function Button({
       onMouseOver={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       data-testid={props['data-testid']}
+      id={props.id}
     >
       {icon && <Icon type={icon} color={hoverColor} />}
       {children}

--- a/benefit-finder/src/shared/components/Modal/_index.scss
+++ b/benefit-finder/src/shared/components/Modal/_index.scss
@@ -15,8 +15,8 @@
     cursor: pointer;
   }
 
-  a.bf-nav-item-one,
-  a.bf-nav-item-two {
+  .bf-nav-item-one,
+  .bf-nav-item-two {
     @include important-bold;
 
     &.bf-usa-button {

--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import NavModal from 'react-modal'
 import PropTypes from 'prop-types'
-import { ObfuscatedLink, Icon, Heading } from '../index'
+import { Button, ObfuscatedLink, Icon, Heading } from '../index'
 import { scrollLock } from '../../utils'
 
 import './_index.scss'
@@ -151,7 +151,7 @@ const Modal = ({
           className="bf-usa-button-group__item usa-button-group__item width-full"
           key="bf-nav-item-one"
         >
-          <ObfuscatedLink
+          <Button
             id="bf-navItemOneBtn"
             className="bf-nav-item-one width-full"
             onClick={() => handleClick(navItemOneFunction)}
@@ -160,13 +160,13 @@ const Modal = ({
             tabIndex="0"
           >
             {navItemOneLabel}
-          </ObfuscatedLink>
+          </Button>
         </li>
         <li
           className="bf-usa-button-group__item usa-button-group__item width-full"
           key="nav-item-two"
         >
-          <ObfuscatedLink
+          <Button
             id="bf-navItemTwoBtn"
             className="bf-nav-item-two width-full"
             onClick={() => handleClick(navItemTwoFunction)}
@@ -175,7 +175,7 @@ const Modal = ({
             tabIndex="0"
           >
             {navItemTwoLabel}
-          </ObfuscatedLink>
+          </Button>
         </li>
       </ul>
     )


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This works to update our modal link buttons to HTML buttons.

## Related Github Issue

- Fixes #1270 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] `cd benefit-finder`
- [ ] `npm install`
- [ ] `npm run dev:storybook`
- [ ] visit `/iframe.html?args=&id=shared-components-modal--primary&viewMode=story` or, 

<!--- If there are steps for user testing list them here -->
- [ ] navigate form filling out required fields
- [ ] click modal trigger button "continue"
- [ ] inspect DOM
- [ ] search for `bf-modal bf-usa-button-group`
- [ ] ensure that inside this group contains an un-orderd list of html buttons

expected markup

![Screenshot 2024-05-17 122718](https://github.com/GSA/px-benefit-finder/assets/37077057/9723003c-4d2c-4426-8b74-4ea1bdf3bbdf)

