### PR TITLE
1269 a11y alt text icons

### DIFF
--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
@@ -132,7 +132,7 @@ exports[`loads intro 1`] = `
                     class="bf-notice"
                   >
                     <i
-                      aria-hidden="true"
+                      alt="Important"
                       data-testid="icon-info"
                     >
                       <svg
@@ -165,7 +165,7 @@ exports[`loads intro 1`] = `
                     class="bf-notice"
                   >
                     <i
-                      aria-hidden="true"
+                      alt="Important"
                       data-testid="icon-info"
                     >
                       <svg
@@ -197,7 +197,7 @@ exports[`loads intro 1`] = `
                     class="bf-notice"
                   >
                     <i
-                      aria-hidden="true"
+                      alt="Important"
                       data-testid="icon-info"
                     >
                       <svg
@@ -416,7 +416,6 @@ exports[`loads window query scenario 1 1`] = `
                         Likely eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -696,7 +695,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -874,7 +872,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -1075,7 +1072,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -1311,7 +1307,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -1537,7 +1532,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -1743,7 +1737,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -1944,7 +1937,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -2145,7 +2137,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -2341,7 +2332,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -2542,7 +2532,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -2773,7 +2762,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -2974,7 +2962,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -3212,7 +3199,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -3358,7 +3344,6 @@ exports[`loads window query scenario 1 1`] = `
                         Likely eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -3608,7 +3593,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -3809,7 +3793,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -4010,7 +3993,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -4227,7 +4209,6 @@ exports[`loads window query scenario 1 1`] = `
                         Likely eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -4507,7 +4488,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -4685,7 +4665,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -4863,7 +4842,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -5059,7 +5037,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -5290,7 +5267,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -5508,7 +5484,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -5709,7 +5684,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -5879,7 +5853,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -6080,7 +6053,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -6260,7 +6232,6 @@ exports[`loads window query scenario 1 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -6497,7 +6468,6 @@ exports[`loads window query scenario 1 1`] = `
                         Likely eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -7203,7 +7173,6 @@ exports[`loads window query scenario 2 1`] = `
                         Likely eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -7482,7 +7451,6 @@ exports[`loads window query scenario 2 1`] = `
                         Likely eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -7672,7 +7640,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -7873,7 +7840,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -8134,7 +8100,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -8360,7 +8325,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -8566,7 +8530,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -8767,7 +8730,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -8968,7 +8930,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -9164,7 +9125,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -9365,7 +9325,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -9596,7 +9555,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -9796,7 +9754,6 @@ exports[`loads window query scenario 2 1`] = `
                         Likely eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -10045,7 +10002,6 @@ exports[`loads window query scenario 2 1`] = `
                         Likely eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -10204,7 +10160,6 @@ exports[`loads window query scenario 2 1`] = `
                         Likely eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -10454,7 +10409,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -10655,7 +10609,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -10856,7 +10809,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -11074,7 +11026,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -11342,7 +11293,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -11520,7 +11470,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -11698,7 +11647,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -11894,7 +11842,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -12125,7 +12072,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -12343,7 +12289,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -12544,7 +12489,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -12714,7 +12658,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -12915,7 +12858,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -13095,7 +13037,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >
@@ -13308,7 +13249,6 @@ exports[`loads window query scenario 2 1`] = `
                         Not eligible
                       </span>
                       <i
-                        alt="a plus icon"
                         aria-hidden="true"
                         data-testid="icon-open"
                       >

--- a/benefit-finder/src/shared/components/Accordion/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/Accordion/__tests__/__snapshots__/index.spec.jsx.snap
@@ -26,7 +26,6 @@ exports[`Accordion > renders a match to the previous snapshot 1`] = `
           Likely Eligible
         </span>
         <i
-          alt="a plus icon"
           aria-hidden="true"
           data-testid="icon-open"
         >

--- a/benefit-finder/src/shared/components/Accordion/index.jsx
+++ b/benefit-finder/src/shared/components/Accordion/index.jsx
@@ -50,9 +50,9 @@ const Accordion = ({
    */
   const handleIcon = () =>
     !isOpen ? (
-      <Icon type="open" alt="a plus icon" />
+      <Icon type="open" aria-hidden="true" />
     ) : (
-      <Icon type="close" alt="a minus icon" />
+      <Icon type="close" aria-hidden="true" />
     )
 
   const handleAriaControl = id => {

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/__snapshots__/index.spec.jsx.snap
@@ -32,7 +32,6 @@ exports[`BenefitAccordionGroup > renders a match to the previous snapshot 1`] = 
             More information needed
           </span>
           <i
-            alt="a plus icon"
             aria-hidden="true"
             data-testid="icon-open"
           >

--- a/benefit-finder/src/shared/components/Button/index.jsx
+++ b/benefit-finder/src/shared/components/Button/index.jsx
@@ -86,7 +86,7 @@ function Button({
       onMouseLeave={() => setIsHovered(false)}
       data-testid={props['data-testid']}
     >
-      {icon && <Icon type={icon} color={hoverColor} />}
+      {icon && <Icon type={icon} color={hoverColor} aria-hidden="true" />}
       {children}
     </button>
   )

--- a/benefit-finder/src/shared/components/Card/index.jsx
+++ b/benefit-finder/src/shared/components/Card/index.jsx
@@ -31,10 +31,12 @@ const Card = ({
   const defaultClasses = icon !== undefined ? ['bf-card-icon'] : ''
   const utilityClasses = ['add-list-reset']
   const handleCarrot =
-    noCarrot === true ? null : <Icon type={carrotType} color="#162E51" />
+    noCarrot === true ? null : (
+      <Icon type={carrotType} color="#162E51" aria-hidden="true" />
+    )
   const handleIcon =
     icon === undefined ? null : (
-      <Icon type={icon} className="bf-relative-icon" />
+      <Icon type={icon} className="bf-relative-icon" aria-hidden="true" />
     )
 
   return (

--- a/benefit-finder/src/shared/components/Icon/__tests__/index.spec.jsx
+++ b/benefit-finder/src/shared/components/Icon/__tests__/index.spec.jsx
@@ -3,7 +3,7 @@ import Icon from '../index.jsx'
 
 describe('Icon', () => {
   it('renders a match to the previous snapshot', () => {
-    const { asFragment } = render(<Icon type="close" />)
+    const { asFragment } = render(<Icon type="close" aria-hidden="true" />)
     expect(asFragment()).toMatchSnapshot()
   })
 })

--- a/benefit-finder/src/shared/components/Icon/index.jsx
+++ b/benefit-finder/src/shared/components/Icon/index.jsx
@@ -54,7 +54,7 @@ const Icon = ({ type, color, ...props }) => {
       icon = null
   }
   return (
-    <i {...props} aria-hidden="true" data-testid={`icon-${type}`}>
+    <i {...props} data-testid={`icon-${type}`}>
       {icon}
     </i>
   )

--- a/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.jsx.snap
@@ -118,7 +118,7 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                 class="bf-notice"
               >
                 <i
-                  aria-hidden="true"
+                  alt="Important"
                   data-testid="icon-info"
                 >
                   <svg
@@ -151,7 +151,7 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                 class="bf-notice"
               >
                 <i
-                  aria-hidden="true"
+                  alt="Important"
                   data-testid="icon-info"
                 >
                   <svg
@@ -183,7 +183,7 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                 class="bf-notice"
               >
                 <i
-                  aria-hidden="true"
+                  alt="Important"
                   data-testid="icon-info"
                 >
                   <svg

--- a/benefit-finder/src/shared/components/Intro/index.jsx
+++ b/benefit-finder/src/shared/components/Intro/index.jsx
@@ -58,6 +58,7 @@ const Intro = ({ data, ui, setStep, step }) => {
               <NoticesList
                 className="bf-intro-process-notices-list"
                 data={notices.list}
+                iconAlt={notices.iconAlt}
               />
             </div>
           </div>

--- a/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/index.jsx
+++ b/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/index.jsx
@@ -43,7 +43,7 @@ const KeyElegibilityCrieriaList = ({
                   data-testid={`${criteriaKey}`}
                 >
                   <div aria-hidden="true">
-                    <Icon type="green-check" />
+                    <Icon type="green-check" aria-hidden="true" />
                   </div>
                   {label}
                 </li>

--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -203,7 +203,7 @@ const Modal = ({
           className="bf-modal-button"
           onClick={() => handleCloseModal(triggerRef)}
         >
-          <Icon type="modal-close" color="black" alt="a close out icon" />
+          <Icon type="modal-close" color="black" aria-hidden="true" />
         </button>
         <Heading headingLevel={1} className="bf-modal-heading">
           {modalHeading}

--- a/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.jsx.snap
@@ -12,7 +12,7 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
         class="bf-notice"
       >
         <i
-          aria-hidden="true"
+          alt="Important"
           data-testid="icon-info"
         >
           <svg
@@ -45,7 +45,7 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
         class="bf-notice"
       >
         <i
-          aria-hidden="true"
+          alt="Important"
           data-testid="icon-info"
         >
           <svg
@@ -77,7 +77,7 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
         class="bf-notice"
       >
         <i
-          aria-hidden="true"
+          alt="Important"
           data-testid="icon-info"
         >
           <svg

--- a/benefit-finder/src/shared/components/NoticesList/__tests__/index.spec.jsx
+++ b/benefit-finder/src/shared/components/NoticesList/__tests__/index.spec.jsx
@@ -5,7 +5,12 @@ import * as en from '../../../locales/en/en.json'
 describe('NoticesList', () => {
   const t = en
   it('renders a match to the previous snapshot', () => {
-    const { asFragment } = render(<NoticesList data={t.intro.notices.list} />)
+    const { asFragment } = render(
+      <NoticesList
+        data={t.intro.notices.list}
+        iconAlt={t.intro.notices.iconAlt}
+      />
+    )
     expect(asFragment()).toMatchSnapshot()
   })
 })

--- a/benefit-finder/src/shared/components/NoticesList/index.jsx
+++ b/benefit-finder/src/shared/components/NoticesList/index.jsx
@@ -10,7 +10,7 @@ import './_index.scss'
  * @param {array} data inherited ui translations
  * @return {html} returns a semantic ul
  */
-const NoticesList = ({ data }) => {
+const NoticesList = ({ data, iconAlt }) => {
   /**
    * a functional component that renders a link as a button
    * @component
@@ -23,7 +23,7 @@ const NoticesList = ({ data }) => {
       data.data.map((item, i) => {
         return (
           <li className="bf-notice" key={`notice-${i}`}>
-            <Icon type="info" />
+            <Icon type="info" alt={iconAlt} />
             <div
               className="bf-notice-item"
               dangerouslySetInnerHTML={createMarkup(item.notice)}

--- a/benefit-finder/src/shared/components/ObfuscatedLink/index.jsx
+++ b/benefit-finder/src/shared/components/ObfuscatedLink/index.jsx
@@ -38,7 +38,9 @@ const ObfuscatedLink = ({
     : ['bf-usa-button', 'usa-button', 'bf-obfuscated-link']
 
   const handleCarrot =
-    noCarrot === true ? null : <Icon type="carrot-small" color="white" />
+    noCarrot === true ? null : (
+      <Icon type="carrot-small" color="white" aria-hidden="true" />
+    )
 
   return (
     <a

--- a/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
@@ -156,7 +156,6 @@ exports[`loads view 1`] = `
                       Likely eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -436,7 +435,6 @@ exports[`loads view 1`] = `
                       More information needed
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -614,7 +612,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -815,7 +812,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -1076,7 +1072,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -1302,7 +1297,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -1508,7 +1502,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -1709,7 +1702,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -1910,7 +1902,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -2106,7 +2097,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -2307,7 +2297,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -2538,7 +2527,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -2738,7 +2726,6 @@ exports[`loads view 1`] = `
                       Likely eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -2988,7 +2975,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -3134,7 +3120,6 @@ exports[`loads view 1`] = `
                       Likely eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -3384,7 +3369,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -3585,7 +3569,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -3786,7 +3769,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -4003,7 +3985,6 @@ exports[`loads view 1`] = `
                       Likely eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -4283,7 +4264,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -4461,7 +4441,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -4639,7 +4618,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -4835,7 +4813,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -5066,7 +5043,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -5284,7 +5260,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -5485,7 +5460,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -5655,7 +5629,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -5856,7 +5829,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -6036,7 +6008,6 @@ exports[`loads view 1`] = `
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -6273,7 +6244,6 @@ exports[`loads view 1`] = `
                       Likely eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -6786,7 +6756,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Likely eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -7066,7 +7035,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       More information needed
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -7244,7 +7212,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -7445,7 +7412,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -7706,7 +7672,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -7932,7 +7897,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -8138,7 +8102,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -8339,7 +8302,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -8540,7 +8502,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -8736,7 +8697,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -8937,7 +8897,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -9168,7 +9127,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -9368,7 +9326,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Likely eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -9618,7 +9575,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -9764,7 +9720,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Likely eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -10014,7 +9969,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -10215,7 +10169,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -10416,7 +10369,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -10633,7 +10585,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Likely eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -10913,7 +10864,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -11091,7 +11041,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -11269,7 +11218,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -11465,7 +11413,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -11696,7 +11643,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -11914,7 +11860,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -12115,7 +12060,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -12285,7 +12229,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -12486,7 +12429,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -12666,7 +12608,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Not eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >
@@ -12903,7 +12844,6 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                       Likely eligible
                     </span>
                     <i
-                      alt="a plus icon"
                       aria-hidden="true"
                       data-testid="icon-open"
                     >

--- a/benefit-finder/src/shared/locales/en/en.json
+++ b/benefit-finder/src/shared/locales/en/en.json
@@ -17,6 +17,7 @@
     },
     "notices": {
       "heading": "Before you start:",
+      "iconAlt": "Important",
       "list": [
         {
           "notice": "<div><strong>This is not an application.</strong></div>"

--- a/benefit-finder/src/shared/locales/es/es.json
+++ b/benefit-finder/src/shared/locales/es/es.json
@@ -17,6 +17,7 @@
     },
     "notices": {
       "heading": "Antes de empezar:",
+      "iconAlt": "Importante",
       "list": [
         {
           "notice": "<div><strong>Esto no es una aplicación.</strong></div>"


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This works to update the info icon component to include an alt text value

## Related Github Issue

- Fixes #1269

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] `cd benefit finder`
- [ ] `npm install`
- [ ] `npm run start`

<!--- If there are steps for user testing list them here -->
- [ ] visit `/death`
- [ ] inspect DOM, ensure that information icon in notices list has the following values;

1.  en locale === `alt="Important"`

expected:
![Screenshot 2024-05-17 145811](https://github.com/GSA/px-benefit-finder/assets/37077057/e4b815a2-e017-4a4f-ad7d-d705dc768175)

2.  es locale === `alt="Importante"`