### PR TITLE
1318 data layer push

### DIFF
--- a/benefit-finder/index.html
+++ b/benefit-finder/index.html
@@ -8,6 +8,17 @@
     <style>
       @import url('https://fonts.googleapis.com/css2?family=Public+Sans:wght@200;400;600;700;800&family=Tilt+Warp&display=swap');
     </style>
+    <script type="text/javascript">
+      window.dataLayer = window.dataLayer || [
+        {
+          nodeID: '1984',
+          contentType: 'basic_page',
+          language: 'en',
+          homepageTest: 'not_homepage',
+          basicPagesubType: 'Navigation Page',
+        },
+      ]
+    </script>
   </head>
   <body>
     <script type="module" src="./src/index.jsx"></script>

--- a/benefit-finder/src/shared/components/Form/index.jsx
+++ b/benefit-finder/src/shared/components/Form/index.jsx
@@ -1,3 +1,4 @@
+import { dataLayerPush } from '../../utils'
 import PropTypes from 'prop-types'
 
 import './_index.scss'
@@ -8,6 +9,7 @@ import './_index.scss'
  * @return {html} returns a semantic html form element, with all its children
  */
 function Form({ children }) {
+  window.dataLayer && dataLayerPush({ pageView: 'bf-form' })
   return (
     <form className="bf-usa-form">
       <div className="bf-grid-contianer grid-container">{children}</div>

--- a/benefit-finder/src/shared/components/Intro/index.jsx
+++ b/benefit-finder/src/shared/components/Intro/index.jsx
@@ -1,3 +1,4 @@
+import { dataLayerPush } from '../../utils'
 import { useResetElement } from '../../hooks'
 import PropTypes from 'prop-types'
 import {
@@ -30,6 +31,8 @@ const Intro = ({ data, ui, setStep, step }) => {
     setStep(step + 1)
     resetElement.current.focus()
   }
+
+  window.dataLayer && dataLayerPush({ pageView: 'bf-intro', viewTitle: title })
 
   return (
     data && (

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, Fragment } from 'react'
 import PropTypes from 'prop-types'
-import { dateInputValidation, createMarkup } from '../../utils'
+import { dateInputValidation, createMarkup, dataLayerPush } from '../../utils'
 import { useHandleUnload, useResetElement } from '../../hooks'
 import * as apiCalls from '../../api/apiCalls'
 import {
@@ -258,6 +258,12 @@ const LifeEventSection = ({
     window.scrollTo(0, 0)
     getRequiredFields()
   }, [])
+
+  window.dataLayer &&
+    dataLayerPush({
+      pageView: 'bf-form',
+      viewTitle: currentData.section.heading,
+    })
 
   return (
     data && (

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -13,7 +13,7 @@ import {
   RelativeBenefitList,
   Summary,
 } from '../index'
-import { createMarkup } from '../../utils'
+import { createMarkup, dataLayerPush } from '../../utils'
 import './_index.scss'
 
 /**
@@ -101,6 +101,22 @@ const ResultsView = ({
       ),
     })
   }, [])
+
+  window.dataLayer &&
+    dataLayerPush({
+      pageView: 'bf-result-view',
+      viewTitle:
+        notEligibleView === false
+          ? eligible.chevron.heading
+          : notEligible.chevron.heading,
+      viewState:
+        notEligibleView === true ? 'bf-not-eligible-view' : 'bf-eligible-view',
+      criteriaValues,
+      benefits: benefitsLength,
+      eligible: eligibilityCount.eligible,
+      notEligible: eligibilityCount.notEligible,
+      moreInfo: eligibilityCount.moreInfo,
+    })
 
   // compare the selected criteria array with benefits
   return (

--- a/benefit-finder/src/shared/components/VerifySelectionsView/index.jsx
+++ b/benefit-finder/src/shared/components/VerifySelectionsView/index.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import PropTypes from 'prop-types'
-import { parseDate } from '../../utils'
+import { parseDate, dataLayerPush } from '../../utils'
 import * as apiCalls from '../../api/apiCalls'
 import { Heading, Button } from '../index'
 
@@ -106,6 +106,12 @@ const VerifySelectionsView = ({
   useEffect(() => {
     window.scrollTo(0, 0)
   }, [])
+
+  window.dataLayer &&
+    dataLayerPush({
+      pageView: 'bf-verify-selections',
+      viewTitle: verifySelectionsView?.heading,
+    })
 
   return (
     <div className="bf-verify-selections-view">

--- a/benefit-finder/src/shared/utils/dataLayer/index.js
+++ b/benefit-finder/src/shared/utils/dataLayer/index.js
@@ -1,0 +1,29 @@
+const defaultDataLayerObj = {
+  pageView: null,
+  viewTitle: null,
+  viewState: null,
+  benefits: null,
+  eligible: null,
+  notEligible: null,
+  moreInfo: null,
+}
+
+const dataLayerPush = newData => {
+  // merge values into default obj
+  const newObj = { ...defaultDataLayerObj, ...newData }
+
+  // merge values into window object
+  const newDataObj = { ...window.dataLayer[0], ...newObj }
+
+  // remove null values
+  for (const key in newDataObj) {
+    if (newDataObj[key] === null) {
+      delete newDataObj[key]
+    }
+  }
+
+  // replaace window object
+  window.dataLayer[0] = newDataObj
+}
+
+export default dataLayerPush

--- a/benefit-finder/src/shared/utils/index.js
+++ b/benefit-finder/src/shared/utils/index.js
@@ -1,5 +1,6 @@
 export { default as buildURIParameter } from './buildURIParameter'
 export { default as createMarkup } from './createMarkup'
 export { default as dateInputValidation } from './dateInputValidation'
+export { default as dataLayerPush } from './dataLayer'
 export { default as parseDate } from './parseDate'
 export { default as scrollLock } from './scrollLock'


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This works to manage the dataLayer object for easier access to critical data on GA analytic tools.

## Related Github Issue

- Fixes #1318 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] include latest usagov database
- [ ] `bash scripts/local/setup-usagov-benefit-finder.sh`
- [ ] login with the provided `uli`

<!--- If there are steps for user testing list them here -->
- [ ] visit `/benefit-finder/death`
- [ ] open inspector console
- [ ] run console.log(window.dataLayer)
- [ ] ensure, the following keys are included in the the [0] index object of the dataLayer array,

```
pageView: "bf-intro"
viewTitle: "Benefit finder: death of a loved one"
```

- [ ] complete the form
- [ ] view not eligible items
- [ ] open inspector console
- [ ] run console.log(window.dataLayer)
- [ ] ensure, the following keys are included in the the [0] index object of the dataLayer array,

```
pageView: "bf-result-view"
viewState: "bf-not-eligible-view"
viewTitle: "Benefits you did not qualify for"
moreInfo: 1
criteriaValues: 14
eligible: 5
benefits: 31
```


