### PR TITLE
1307 replace type string TRUE

### DIFF
--- a/benefit-finder/src/shared/api/mock-data/current.js
+++ b/benefit-finder/src/shared/api/mock-data/current.js
@@ -36,7 +36,7 @@ const content = `{
                 "fieldset": {
                   "criteriaKey": "applicant_date_of_birth",
                   "legend": "Date of birth",
-                  "required": "TRUE",
+                  "required": true,
                   "hint": "For example: January 19 2000",
                   "inputs": [
                     {
@@ -45,7 +45,7 @@ const content = `{
                         "type": "Date",
                         "name": "applicant_date_of_birth",
                         "label": "Date of birth",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -63,7 +63,7 @@ const content = `{
                 "fieldset": {
                   "criteriaKey": "applicant_relationship_to_the_deceased",
                   "legend": "Relationship to the deceased",
-                  "required": "TRUE",
+                  "required": true,
                   "hint": "",
                   "inputs": [
                     {
@@ -72,7 +72,7 @@ const content = `{
                         "type": "Select",
                         "name": "applicant_relationship_to_the_deceased",
                         "label": "Applicant's relationship to the deceased",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -106,7 +106,7 @@ const content = `{
                 "fieldset": {
                   "criteriaKey": "applicant_marital_status",
                   "legend": "Marital status",
-                  "required": "TRUE",
+                  "required": true,
                   "hint": "",
                   "inputs": [
                     {
@@ -115,7 +115,7 @@ const content = `{
                         "type": "Select",
                         "name": "applicant_marital_status",
                         "label": "Marital status",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -145,7 +145,7 @@ const content = `{
                 "fieldset": {
                   "criteriaKey": "applicant_citizen_status",
                   "legend": "Are you a U.S. citizen or eligible non-citizen?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "",
                   "inputs": [
                     {
@@ -154,7 +154,7 @@ const content = `{
                         "type": "Radio",
                         "name": "applicant_citizen_status",
                         "label": "Are you a U.S. citizen or eligible non-citizen?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -176,7 +176,7 @@ const content = `{
                 "fieldset": {
                   "criteriaKey": "applicant_care_for_child",
                   "legend": "Are you caring for the deceased's child who is under age 16 or has a disability?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "",
                   "inputs": [
                     {
@@ -185,7 +185,7 @@ const content = `{
                         "type": "Radio",
                         "name": "applicant_care_for_child",
                         "label": "Are you caring for a child of someone who is retired, has a disability, or has died, and the child is disabled or under the age of 16?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -207,7 +207,7 @@ const content = `{
                 "fieldset": {
                   "criteriaKey": "applicant_paid_funeral_expenses",
                   "legend": "Did you pay for funeral or burial expenses?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "",
                   "inputs": [
                     {
@@ -216,7 +216,7 @@ const content = `{
                         "type": "Radio",
                         "name": "applicant_paid_funeral_expenses",
                         "label": "Did you pay for funeral or burial expenses?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -246,7 +246,7 @@ const content = `{
                 "fieldset": {
                   "criteriaKey": "deceased_date_of_death",
                   "legend": "Date of death",
-                  "required": "TRUE",
+                  "required": true,
                   "hint": "Date on the death certificate. For example: January 25 2024",
                   "inputs": [
                     {
@@ -255,7 +255,7 @@ const content = `{
                         "type": "Date",
                         "name": "deceased_date_of_death",
                         "label": "Date of death",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -273,7 +273,7 @@ const content = `{
                 "fieldset": {
                   "criteriaKey": "deceased_death_location_is_US",
                   "legend": "Did the death happen in the U.S.?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "Including the U.S. and its territories",
                   "inputs": [
                     {
@@ -282,7 +282,7 @@ const content = `{
                         "type": "Radio",
                         "name": "deceased_death_location_is_US",
                         "label": "Did the person die in the U.S.?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -304,7 +304,7 @@ const content = `{
                 "fieldset": {
                   "criteriaKey": "deceased_paid_into_SS",
                   "legend": "Did the deceased ever work and pay U.S. Social Security taxes?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "",
                   "inputs": [
                     {
@@ -313,7 +313,7 @@ const content = `{
                         "type": "Radio",
                         "name": "deceased_paid_into_SS",
                         "label": "Did the deceased ever work and pay Social Security taxes on their earnings?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -335,7 +335,7 @@ const content = `{
                 "fieldset": {
                   "criteriaKey": "deceased_public_safety_officer",
                   "legend": "Was the deceased a public safety officer who died in the line of duty?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "",
                   "inputs": [
                     {
@@ -344,7 +344,7 @@ const content = `{
                         "type": "Radio",
                         "name": "deceased_public_safety_officer",
                         "label": "Was the deceased a public safety officer who died in the line of duty?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -366,7 +366,7 @@ const content = `{
                 "fieldset": {
                   "criteriaKey": "deceased_miner",
                   "legend": "Did the deceased work in coal mines and die because of black lung disease?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "",
                   "inputs": [
                     {
@@ -375,7 +375,7 @@ const content = `{
                         "type": "Radio",
                         "name": "deceased_miner",
                         "label": "Did the person work in the coal mines and their death was due to black lung disease (pneumoconiosis)?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -397,7 +397,7 @@ const content = `{
                 "fieldset": {
                   "criteriaKey": "deceased_american_indian",
                   "legend": "Was the deceased an American Indian or Alaskan Native?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "A member of a federally recognized American Indian Tribe or Alaska Native.",
                   "inputs": [
                     {
@@ -406,7 +406,7 @@ const content = `{
                         "type": "Radio",
                         "name": "deceased_american_indian",
                         "label": "Was the deceased a member of a federally recognized American Indian Tribe or Alaska Native?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -428,7 +428,7 @@ const content = `{
                 "fieldset": {
                   "criteriaKey": "deceased_died_of_COVID",
                   "legend": "Was the death COVID-19 related?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "",
                   "inputs": [
                     {
@@ -437,7 +437,7 @@ const content = `{
                         "type": "Radio",
                         "name": "deceased_died_of_COVID",
                         "label": "Was the person’s death COVID-19 related?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -459,7 +459,7 @@ const content = `{
                 "fieldset": {
                   "criteriaKey": "deceased_served_in_active_military",
                   "legend": "Did the deceased actively serve in the U.S. military?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "",
                   "inputs": [
                     {
@@ -468,7 +468,7 @@ const content = `{
                         "type": "Radio",
                         "name": "deceased_served_in_active_military",
                         "label": "Did the deceased serve in active military service?",
-                        "hasChild": "TRUE",
+                        "hasChild": true,
                         "childDependencyOption": "Yes",
                         "values": [
                           {
@@ -490,7 +490,7 @@ const content = `{
                           "fieldset": {
                             "criteriaKey": "deceased_service_status",
                             "legend": "What was the military service status of the deceased?",
-                            "required": "FALSE",
+                            "required": false,
                             "hint": "",
                             "inputs": [
                               {
@@ -499,7 +499,7 @@ const content = `{
                                   "type": "Select",
                                   "name": "deceased_service_status",
                                   "label": "What was the service status of the deceased?",
-                                  "hasChild": "FALSE",
+                                  "hasChild": false,
                                   "childDependencyOption": "",
                                   "values": [
                                     {
@@ -533,7 +533,7 @@ const content = `{
                           "fieldset": {
                             "criteriaKey": "deceased_military_death_circumstance",
                             "legend": "Which option best applies to the death of the deceased?",
-                            "required": "FALSE",
+                            "required": false,
                             "hint": "",
                             "inputs": [
                               {
@@ -542,7 +542,7 @@ const content = `{
                                   "type": "Select",
                                   "name": "deceased_military_death_circumstance",
                                   "label": "Which option applies to the deceased?",
-                                  "hasChild": "FALSE",
+                                  "hasChild": false,
                                   "childDependencyOption": "",
                                   "values": [
                                     {
@@ -580,7 +580,7 @@ const content = `{
                           "fieldset": {
                             "criteriaKey": "deceased_grave_headstone",
                             "legend": "Is the deceased buried in an unmarked grave or with a privately purchased headstone?",
-                            "required": "FALSE",
+                            "required": false,
                             "hint": "",
                             "inputs": [
                               {
@@ -589,7 +589,7 @@ const content = `{
                                   "type": "Radio",
                                   "name": "deceased_grave_headstone",
                                   "label": "Is the person buried in a grave with a privately purchased headstone or in an unmarked grave?",
-                                  "hasChild": "FALSE",
+                                  "hasChild": false,
                                   "childDependencyOption": "",
                                   "values": [
                                     {
@@ -623,7 +623,7 @@ const content = `{
           "title": "COVID-19 funeral assistance",
           "summary": "<p>Financial assistance for burial and funeral costs for someone who died of COVID-19. To be eligible, you have not been reimbursed from an organization or agency.</p>",
           "SourceLink": "https://www.fema.gov/disasters/coronavirus/economic/funeral-assistance",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": " Federal Emergency Management Agency (FEMA)",
             "summary": "<p>Federal Emergency Management Agency (FEMA) offers support to people during natural disasters and national emergencies, including housing and funeral assistance.</p>",
@@ -676,7 +676,7 @@ const content = `{
           "title": "Coal mine workers' compensation (black lung benefits) for surviving spouse",
           "summary": "<p>Compensation to surviving spouses of coal minerstotally disabled by or whose deaths are attributable to pneumoconiosis.</p>",
           "SourceLink": "https://www.dol.gov/agencies/owcp/dcmwc/filing_guide_survivor",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Department of Labor (DOL)",
             "summary": "<p>Promotes and improves the welfare, working conditions, opportunities, benefits and rights of wage earners, job seekers, and retirees of the United States.</p>",
@@ -708,7 +708,7 @@ const content = `{
           "title": "Presidential Memorial Certificate",
           "summary": "<p>An engraved Presidential Memorial Certificate (PMC) signed by the current president honoring the military service of a veteran or reservist.</p>",
           "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/presidential-memorial-certificates/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
@@ -762,7 +762,7 @@ const content = `{
           "title": "Veterans burial allowance",
           "summary": "<p>Assistance with burial, funeral, and transportation costs of a deceased veteran.</p>",
           "SourceLink": "https://www.va.gov/burials-memorials/veterans-burial-allowance/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
@@ -827,7 +827,7 @@ const content = `{
           "title": "Survivors pension for spouse",
           "summary": "<p>Monthly payments to surviving spouses of wartime veterans with certain income and net worth limits.</p>",
           "SourceLink": "https://www.va.gov/pension/survivors-pension/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
@@ -874,7 +874,7 @@ const content = `{
           "title": "Survivors pension for child with disabilities",
           "summary": "<p>Monthly payments to qualified unmarried dependent children with disabilities of wartime veterans with certain income and net worth limits.</p>",
           "SourceLink": "https://www.va.gov/pension/survivors-pension/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
@@ -927,7 +927,7 @@ const content = `{
           "title": "Veterans medallions",
           "summary": "<p>A headstone medallion, grave marker, and Presidential Memorial Certificate for eligible veterans buried in a private cemetery.</p>",
           "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/headstones-markers-medallions/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
@@ -978,7 +978,7 @@ const content = `{
           "title": "Veterans headstone and grave marker",
           "summary": "<p>A headstone, grave or niche marker, or medallion to honor a veteran, service member, or eligible family member.</p>",
           "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/headstones-markers-medallions/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
@@ -1029,7 +1029,7 @@ const content = `{
           "title": "Life insurance for survivors of veterans",
           "summary": "<p>Payment from a veteran's or service member's life insurance policy.</p>",
           "SourceLink": "https://www.benefits.va.gov/INSURANCE/sglivgli.asp",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
@@ -1074,7 +1074,7 @@ const content = `{
           "title": "Dependency and Indemnity Compensation (DIC)",
           "summary": "<p>Tax-free financial assistance to eligible dependents, spouses, or parents of service members and veterans.</p>",
           "SourceLink": "https://www.va.gov/disability/dependency-indemnity-compensation/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
@@ -1125,7 +1125,7 @@ const content = `{
           "title": "Civilian Health and Medical Program of the VA (CHAMPVA)",
           "summary": "<p>Health insurance for dependents and surviving spouses covering some health care services and supplies.</p>",
           "SourceLink": "https://www.va.gov/health-care/family-caregiver-benefits/champva/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
@@ -1182,7 +1182,7 @@ const content = `{
           "title": "Burial benefits",
           "summary": "<p>Burial and transport assistance for the deceased, and travel support for the spouse, children, and immediate family members of the service member.</p>",
           "SourceLink": "https://www.militaryonesource.mil/benefits/funeral-and-burial-benefits-for-service-members/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Department of Defense (DOD)",
             "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
@@ -1231,7 +1231,7 @@ const content = `{
           "title": "Lump-sum death benefit",
           "summary": "<p>Financial assistance of $255 to surviving spouses of a deceased person who qualified for Social Security benefits.</p>",
           "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h7",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": "Social Security Administration (SSA)",
             "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
@@ -1278,7 +1278,7 @@ const content = `{
           "title": "Financial Assistance and Social Services (FASS) for deceased",
           "summary": "<p>Assistance with burial expenses of deceased American Indians who do not have resources for funeral expenses or with certain income and net worth limits.</p>",
           "SourceLink": "https://www.bia.gov/bia/ois/dhs/financial-assistance",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": "Department of Interior (DOI) - Indian Affairs",
             "summary": "<p>The Bureau of Indian Affairs enhances the quality of life and protects and improves the trust assets of American Indians, Indian tribes, and Alaska Natives.</p>",
@@ -1303,7 +1303,7 @@ const content = `{
           "title": "Survivors benefits for mothers/fathers with a child",
           "summary": "<p>Social Security survivors benefits to the person providing care for the child of a deceased worker.</p>",
           "SourceLink": "https://www.ssa.gov/forms/ssa-5.html",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Social Security Administration (SSA)",
             "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
@@ -1347,7 +1347,7 @@ const content = `{
           "title": "Annuity for certain military surviving spouses",
           "summary": "<p>Financial support for surviving spouses of members of the uniformed services.</p>",
           "SourceLink": "https://militarypay.defense.gov/Benefits/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Department of Defense (DOD)",
             "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
@@ -1393,7 +1393,7 @@ const content = `{
           "title": "Education benefits (GI Bill) for survivors",
           "summary": "<p>VA education benefits or job training for dependents and survivors of a veteran. You must have a high school or GED diploma to be eligible.</p>",
           "SourceLink": "https://www.va.gov/education/survivor-dependent-benefits/",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
@@ -1442,7 +1442,7 @@ const content = `{
           "title": "Survivors benefits for child with disabilities",
           "summary": "<p>Social Security survivors benefits to a child, stepchild, grandchild, or adopted child with disabilities of eligible workers. You only need one application to apply for all SSA benefits.</p>",
           "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h4",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": "Social Security Administration (SSA)",
             "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
@@ -1495,7 +1495,7 @@ const content = `{
           "title": "Survivors benefits for spouse with disabilities",
           "summary": "<p>Benefits for surviving spouses and certain divorced spouses with disabilities. Eligible survivors must have a disability that prevents them from working for more than a year. You only need one application to apply for all SSA benefits.</p>",
           "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h2",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": "Social Security Administration (SSA)",
             "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
@@ -1549,7 +1549,7 @@ const content = `{
           "title": "Public safety officers' Educational Assistance Program",
           "summary": "<p>Financial assistance for higher education to spouses and children of police, fire, and emergency public safety officers killed in the line of duty.</p>",
           "SourceLink": "https://psob.bja.ojp.gov/PSOB_Education2018.pdf",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Department of Justice (DOJ)",
             "summary": "<p>Offers financial and educational support to help families of fallen public safety officers.</p>",
@@ -1582,7 +1582,7 @@ const content = `{
           "title": "Public safety officers' death benefits",
           "summary": "<p>A one-time benefit for survivors of law enforcement officers, firefighters, and other first responders whose deaths were related to an injury sustained during the line of duty.</p>",
           "SourceLink": "https://bja.ojp.gov/program/psob/benefits",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Department of Justice (DOJ)",
             "summary": "<p>Offers financial and educational support to help families of fallen public safety officers.</p>",
@@ -1617,7 +1617,7 @@ const content = `{
           "title": "Burial flag",
           "summary": "<p>A United States flag for the coffin or urn in honor of the military service member.</p>",
           "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/burial-flags/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
@@ -1658,7 +1658,7 @@ const content = `{
           "title": "Home loan program for survivors",
           "summary": "<p>A VA-backed home loan to surviving spouses of veterans.</p>",
           "SourceLink": "https://www.va.gov/housing-assistance/home-loans/surviving-spouse/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
@@ -1715,7 +1715,7 @@ const content = `{
           "title": "Survivors benefits for child",
           "summary": "<p>Offers Social Security survivors benefits to a child, stepchild, grandchild, or adopted child of eligible workers.</p>",
           "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h4",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": "Social Security Administration (SSA)",
             "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
@@ -1765,7 +1765,7 @@ const content = `{
           "title": "Survivor benefit plan",
           "summary": "<p>Offers up to 55% of a service member's retired pay for survivors of active duty service members and some retired and reserve members.</p>",
           "SourceLink": "https://bja.ojp.gov/program/psob/benefits",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Department of Defense (DOD)",
             "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
@@ -1812,7 +1812,7 @@ const content = `{
           "title": "Burial in VA national cemetery",
           "summary": "<p>Burial in VA national cemeteries for eligible veterans, service members, and some family members.</p>",
           "SourceLink": "https://www.va.gov/burials-memorials/eligibility/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
@@ -1853,7 +1853,7 @@ const content = `{
           "title": "Death gratuity",
           "summary": "<p>Tax free payment of $100,000 to eligible survivors of members of the Armed Forces who died while on active duty or while serving in certain reserve statuses.</p>",
           "SourceLink": "https://militarypay.defense.gov/Benefits/Death-Gratuity/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Department of Defense (DOD)",
             "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
@@ -1901,7 +1901,7 @@ const content = `{
           "title": "Survivors pension for child",
           "summary": "<p>Monthly payments to qualified unmarried dependent children of deceased wartime veterans.</p>",
           "SourceLink": "https://www.va.gov/pension/survivors-pension/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
@@ -1954,7 +1954,7 @@ const content = `{
           "title": "Survivors benefits for parents",
           "summary": "<p>Social Security survivors benefits to parents of eligible workers.</p>",
           "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h5",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": "Social Security Administration (SSA)",
             "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
@@ -1997,7 +1997,7 @@ const content = `{
           "title": "Survivors benefits for spouse",
           "summary": "<p>Social Security survivors benefits to surviving spouses and certain divorced spouses of eligible workers.</p>",
           "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h2",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": "Social Security Administration (SSA)",
             "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",

--- a/benefit-finder/src/shared/api/mock-data/current.json
+++ b/benefit-finder/src/shared/api/mock-data/current.json
@@ -36,7 +36,7 @@
                 "fieldset": {
                   "criteriaKey": "applicant_date_of_birth",
                   "legend": "Date of birth",
-                  "required": "TRUE",
+                  "required": true,
                   "hint": "For example: January 19 2000",
                   "inputs": [
                     {
@@ -45,7 +45,7 @@
                         "type": "Date",
                         "name": "applicant_date_of_birth",
                         "label": "Date of birth",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -63,7 +63,7 @@
                 "fieldset": {
                   "criteriaKey": "applicant_relationship_to_the_deceased",
                   "legend": "Relationship to the deceased",
-                  "required": "TRUE",
+                  "required": true,
                   "hint": "",
                   "inputs": [
                     {
@@ -72,7 +72,7 @@
                         "type": "Select",
                         "name": "applicant_relationship_to_the_deceased",
                         "label": "Applicant's relationship to the deceased",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -106,7 +106,7 @@
                 "fieldset": {
                   "criteriaKey": "applicant_marital_status",
                   "legend": "Marital status",
-                  "required": "TRUE",
+                  "required": true,
                   "hint": "",
                   "inputs": [
                     {
@@ -115,7 +115,7 @@
                         "type": "Select",
                         "name": "applicant_marital_status",
                         "label": "Marital status",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -145,7 +145,7 @@
                 "fieldset": {
                   "criteriaKey": "applicant_citizen_status",
                   "legend": "Are you a U.S. citizen or eligible non-citizen?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "",
                   "inputs": [
                     {
@@ -154,7 +154,7 @@
                         "type": "Radio",
                         "name": "applicant_citizen_status",
                         "label": "Are you a U.S. citizen or eligible non-citizen?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -176,7 +176,7 @@
                 "fieldset": {
                   "criteriaKey": "applicant_care_for_child",
                   "legend": "Are you caring for the deceased's child who is under age 16 or has a disability?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "",
                   "inputs": [
                     {
@@ -185,7 +185,7 @@
                         "type": "Radio",
                         "name": "applicant_care_for_child",
                         "label": "Are you caring for a child of someone who is retired, has a disability, or has died, and the child is disabled or under the age of 16?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -207,7 +207,7 @@
                 "fieldset": {
                   "criteriaKey": "applicant_paid_funeral_expenses",
                   "legend": "Did you pay for funeral or burial expenses?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "",
                   "inputs": [
                     {
@@ -216,7 +216,7 @@
                         "type": "Radio",
                         "name": "applicant_paid_funeral_expenses",
                         "label": "Did you pay for funeral or burial expenses?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -246,7 +246,7 @@
                 "fieldset": {
                   "criteriaKey": "deceased_date_of_death",
                   "legend": "Date of death",
-                  "required": "TRUE",
+                  "required": true,
                   "hint": "Date on the death certificate. For example: January 25 2024",
                   "inputs": [
                     {
@@ -255,7 +255,7 @@
                         "type": "Date",
                         "name": "deceased_date_of_death",
                         "label": "Date of death",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -273,7 +273,7 @@
                 "fieldset": {
                   "criteriaKey": "deceased_death_location_is_US",
                   "legend": "Did the death happen in the U.S.?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "Including the U.S. and its territories",
                   "inputs": [
                     {
@@ -282,7 +282,7 @@
                         "type": "Radio",
                         "name": "deceased_death_location_is_US",
                         "label": "Did the person die in the U.S.?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -304,7 +304,7 @@
                 "fieldset": {
                   "criteriaKey": "deceased_paid_into_SS",
                   "legend": "Did the deceased ever work and pay U.S. Social Security taxes?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "",
                   "inputs": [
                     {
@@ -313,7 +313,7 @@
                         "type": "Radio",
                         "name": "deceased_paid_into_SS",
                         "label": "Did the deceased ever work and pay Social Security taxes on their earnings?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -335,7 +335,7 @@
                 "fieldset": {
                   "criteriaKey": "deceased_public_safety_officer",
                   "legend": "Was the deceased a public safety officer who died in the line of duty?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "",
                   "inputs": [
                     {
@@ -344,7 +344,7 @@
                         "type": "Radio",
                         "name": "deceased_public_safety_officer",
                         "label": "Was the deceased a public safety officer who died in the line of duty?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -366,7 +366,7 @@
                 "fieldset": {
                   "criteriaKey": "deceased_miner",
                   "legend": "Did the deceased work in coal mines and die because of black lung disease?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "",
                   "inputs": [
                     {
@@ -375,7 +375,7 @@
                         "type": "Radio",
                         "name": "deceased_miner",
                         "label": "Did the person work in the coal mines and their death was due to black lung disease (pneumoconiosis)?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -397,7 +397,7 @@
                 "fieldset": {
                   "criteriaKey": "deceased_american_indian",
                   "legend": "Was the deceased an American Indian or Alaskan Native?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "A member of a federally recognized American Indian Tribe or Alaska Native.",
                   "inputs": [
                     {
@@ -406,7 +406,7 @@
                         "type": "Radio",
                         "name": "deceased_american_indian",
                         "label": "Was the deceased a member of a federally recognized American Indian Tribe or Alaska Native?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -428,7 +428,7 @@
                 "fieldset": {
                   "criteriaKey": "deceased_died_of_COVID",
                   "legend": "Was the death COVID-19 related?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "",
                   "inputs": [
                     {
@@ -437,7 +437,7 @@
                         "type": "Radio",
                         "name": "deceased_died_of_COVID",
                         "label": "Was the person’s death COVID-19 related?",
-                        "hasChild": "FALSE",
+                        "hasChild": false,
                         "childDependencyOption": "",
                         "values": [
                           {
@@ -459,7 +459,7 @@
                 "fieldset": {
                   "criteriaKey": "deceased_served_in_active_military",
                   "legend": "Did the deceased actively serve in the U.S. military?",
-                  "required": "FALSE",
+                  "required": false,
                   "hint": "",
                   "inputs": [
                     {
@@ -468,7 +468,7 @@
                         "type": "Radio",
                         "name": "deceased_served_in_active_military",
                         "label": "Did the deceased serve in active military service?",
-                        "hasChild": "TRUE",
+                        "hasChild": true,
                         "childDependencyOption": "Yes",
                         "values": [
                           {
@@ -490,7 +490,7 @@
                           "fieldset": {
                             "criteriaKey": "deceased_service_status",
                             "legend": "What was the military service status of the deceased?",
-                            "required": "FALSE",
+                            "required": false,
                             "hint": "",
                             "inputs": [
                               {
@@ -499,7 +499,7 @@
                                   "type": "Select",
                                   "name": "deceased_service_status",
                                   "label": "What was the service status of the deceased?",
-                                  "hasChild": "FALSE",
+                                  "hasChild": false,
                                   "childDependencyOption": "",
                                   "values": [
                                     {
@@ -533,7 +533,7 @@
                           "fieldset": {
                             "criteriaKey": "deceased_military_death_circumstance",
                             "legend": "Which option best applies to the death of the deceased?",
-                            "required": "FALSE",
+                            "required": false,
                             "hint": "",
                             "inputs": [
                               {
@@ -542,7 +542,7 @@
                                   "type": "Select",
                                   "name": "deceased_military_death_circumstance",
                                   "label": "Which option applies to the deceased?",
-                                  "hasChild": "FALSE",
+                                  "hasChild": false,
                                   "childDependencyOption": "",
                                   "values": [
                                     {
@@ -580,7 +580,7 @@
                           "fieldset": {
                             "criteriaKey": "deceased_grave_headstone",
                             "legend": "Is the deceased buried in an unmarked grave or with a privately purchased headstone?",
-                            "required": "FALSE",
+                            "required": false,
                             "hint": "",
                             "inputs": [
                               {
@@ -589,7 +589,7 @@
                                   "type": "Radio",
                                   "name": "deceased_grave_headstone",
                                   "label": "Is the person buried in a grave with a privately purchased headstone or in an unmarked grave?",
-                                  "hasChild": "FALSE",
+                                  "hasChild": false,
                                   "childDependencyOption": "",
                                   "values": [
                                     {
@@ -623,50 +623,38 @@
           "title": "COVID-19 funeral assistance",
           "summary": "<p>Financial assistance for burial and funeral costs for someone who died of COVID-19. To be eligible, you have not been reimbursed from an organization or agency.</p>",
           "SourceLink": "https://www.fema.gov/disasters/coronavirus/economic/funeral-assistance",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": " Federal Emergency Management Agency (FEMA)",
             "summary": "<p>Federal Emergency Management Agency (FEMA) offers support to people during natural disasters and national emergencies, including housing and funeral assistance.</p>",
             "lede": "<p>Federal Emergency Management Agency (FEMA) offers support to people during natural disasters and national emergencies, including housing and funeral assistance.</p>"
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_died_of_COVID",
               "label": "The deceased's death was COVID-19 related",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_death_location_is_US",
               "label": "The deceased died in the U.S.",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_date_of_death",
               "label": "The deceased died after May 20th, 2020",
-              "acceptableValues": [
-                ">=05-20-2020"
-              ]
+              "acceptableValues": [">=05-20-2020"]
             },
             {
               "criteriaKey": "applicant_citizen_status",
               "label": "You are a U.S. citizen or eligible non-citizen",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_paid_funeral_expenses",
               "label": "You paid for funeral or burial expenses and were not reimbursed",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             }
           ]
         }
@@ -676,29 +664,23 @@
           "title": "Coal mine workers' compensation (black lung benefits) for surviving spouse",
           "summary": "<p>Compensation to surviving spouses of coal minerstotally disabled by or whose deaths are attributable to pneumoconiosis.</p>",
           "SourceLink": "https://www.dol.gov/agencies/owcp/dcmwc/filing_guide_survivor",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Department of Labor (DOL)",
             "summary": "<p>Promotes and improves the welfare, working conditions, opportunities, benefits and rights of wage earners, job seekers, and retirees of the United States.</p>",
             "lede": "<p>Promotes and improves the welfare, working conditions, opportunities, benefits and rights of wage earners, job seekers, and retirees of the United States.</p>"
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_miner",
               "label": "The deceased worked in the coal mines and their death was due to black lung disease (pneumoconiosis)",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Your relationship to the deceased is: spouse",
-              "acceptableValues": [
-                "Spouse"
-              ]
+              "acceptableValues": ["Spouse"]
             }
           ]
         }
@@ -708,22 +690,18 @@
           "title": "Presidential Memorial Certificate",
           "summary": "<p>An engraved Presidential Memorial Certificate (PMC) signed by the current president honoring the military service of a veteran or reservist.</p>",
           "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/presidential-memorial-certificates/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
@@ -762,29 +740,23 @@
           "title": "Veterans burial allowance",
           "summary": "<p>Assistance with burial, funeral, and transportation costs of a deceased veteran.</p>",
           "SourceLink": "https://www.va.gov/burials-memorials/veterans-burial-allowance/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_date_of_death",
               "label": "The deceased died within the last two years",
-              "acceptableValues": [
-                "<2years"
-              ]
+              "acceptableValues": ["<2years"]
             },
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
@@ -815,9 +787,7 @@
             {
               "criteriaKey": "applicant_paid_funeral_expenses",
               "label": "You paid for funeral or burial expenses",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             }
           ]
         }
@@ -827,22 +797,18 @@
           "title": "Survivors pension for spouse",
           "summary": "<p>Monthly payments to surviving spouses of wartime veterans with certain income and net worth limits.</p>",
           "SourceLink": "https://www.va.gov/pension/survivors-pension/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
@@ -854,17 +820,12 @@
             {
               "criteriaKey": "applicant_marital_status",
               "label": "Your marital status is unmarried or widowed",
-              "acceptableValues": [
-                "Unmarried",
-                "Widowed"
-              ]
+              "acceptableValues": ["Unmarried", "Widowed"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Your relationship to the deceased is: spouse",
-              "acceptableValues": [
-                "Spouse"
-              ]
+              "acceptableValues": ["Spouse"]
             }
           ]
         }
@@ -874,22 +835,18 @@
           "title": "Survivors pension for child with disabilities",
           "summary": "<p>Monthly payments to qualified unmarried dependent children with disabilities of wartime veterans with certain income and net worth limits.</p>",
           "SourceLink": "https://www.va.gov/pension/survivors-pension/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
@@ -901,23 +858,17 @@
             {
               "criteriaKey": "applicant_date_of_birth",
               "label": "You are under 18 years",
-              "acceptableValues": [
-                ">18years"
-              ]
+              "acceptableValues": [">18years"]
             },
             {
               "criteriaKey": "applicant_marital_status",
               "label": "Your marital status is unmarried",
-              "acceptableValues": [
-                "Unmarried"
-              ]
+              "acceptableValues": ["Unmarried"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Your relationship to the deceased is: child",
-              "acceptableValues": [
-                "Child"
-              ]
+              "acceptableValues": ["Child"]
             }
           ]
         }
@@ -927,22 +878,18 @@
           "title": "Veterans medallions",
           "summary": "<p>A headstone medallion, grave marker, and Presidential Memorial Certificate for eligible veterans buried in a private cemetery.</p>",
           "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/headstones-markers-medallions/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
@@ -956,9 +903,7 @@
             {
               "criteriaKey": "deceased_grave_headstone",
               "label": "The person is buried in a grave with a privately purchased headstone or an unmarked grave",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
@@ -978,22 +923,18 @@
           "title": "Veterans headstone and grave marker",
           "summary": "<p>A headstone, grave or niche marker, or medallion to honor a veteran, service member, or eligible family member.</p>",
           "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/headstones-markers-medallions/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
@@ -1007,9 +948,7 @@
             {
               "criteriaKey": "deceased_grave_headstone",
               "label": "The person is buried in a grave with a privately purchased headstone or an unmarked grave",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
@@ -1029,22 +968,18 @@
           "title": "Life insurance for survivors of veterans",
           "summary": "<p>Payment from a veteran's or service member's life insurance policy.</p>",
           "SourceLink": "https://www.benefits.va.gov/INSURANCE/sglivgli.asp",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
@@ -1074,22 +1009,18 @@
           "title": "Dependency and Indemnity Compensation (DIC)",
           "summary": "<p>Tax-free financial assistance to eligible dependents, spouses, or parents of service members and veterans.</p>",
           "SourceLink": "https://www.va.gov/disability/dependency-indemnity-compensation/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
@@ -1111,11 +1042,7 @@
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Your relationship to the deceased is: child, parent, or spouse",
-              "acceptableValues": [
-                "Child",
-                "Parent",
-                "Spouse"
-              ]
+              "acceptableValues": ["Child", "Parent", "Spouse"]
             }
           ]
         }
@@ -1125,22 +1052,18 @@
           "title": "Civilian Health and Medical Program of the VA (CHAMPVA)",
           "summary": "<p>Health insurance for dependents and surviving spouses covering some health care services and supplies.</p>",
           "SourceLink": "https://www.va.gov/health-care/family-caregiver-benefits/champva/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
@@ -1161,18 +1084,12 @@
             {
               "criteriaKey": "applicant_marital_status",
               "label": "Your marital status is: unmarried or widowed",
-              "acceptableValues": [
-                "Unmarried",
-                "Widowed"
-              ]
+              "acceptableValues": ["Unmarried", "Widowed"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Your relationship to the deceased is: child or spouse",
-              "acceptableValues": [
-                "Child",
-                "Spouse"
-              ]
+              "acceptableValues": ["Child", "Spouse"]
             }
           ]
         }
@@ -1182,36 +1099,28 @@
           "title": "Burial benefits",
           "summary": "<p>Burial and transport assistance for the deceased, and travel support for the spouse, children, and immediate family members of the service member.</p>",
           "SourceLink": "https://www.militaryonesource.mil/benefits/funeral-and-burial-benefits-for-service-members/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Department of Defense (DOD)",
             "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
               "label": "The service status of the deceased is: active-duty member",
-              "acceptableValues": [
-                "Active-duty service member"
-              ]
+              "acceptableValues": ["Active-duty service member"]
             },
             {
               "criteriaKey": "deceased_military_death_circumstance",
               "label": "One of the following applies to the deceased: died on active duty",
-              "acceptableValues": [
-                "Died while on active duty"
-              ]
+              "acceptableValues": ["Died while on active duty"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
@@ -1231,44 +1140,33 @@
           "title": "Lump-sum death benefit",
           "summary": "<p>Financial assistance of $255 to surviving spouses of a deceased person who qualified for Social Security benefits.</p>",
           "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h7",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": "Social Security Administration (SSA)",
             "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_paid_into_SS",
               "label": "The deceased worked and paid Social Security taxes",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_date_of_death",
               "label": "The deceased died within the last two years",
-              "acceptableValues": [
-                "<2years"
-              ]
+              "acceptableValues": ["<2years"]
             },
             {
               "criteriaKey": "applicant_citizen_status",
               "label": "You are a U.S. citizen or eligible non-citizen",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Your relationship to the deceased is: spouse or child",
-              "acceptableValues": [
-                "Spouse",
-                "Child"
-              ]
+              "acceptableValues": ["Spouse", "Child"]
             }
           ]
         }
@@ -1278,22 +1176,18 @@
           "title": "Financial Assistance and Social Services (FASS) for deceased",
           "summary": "<p>Assistance with burial expenses of deceased American Indians who do not have resources for funeral expenses or with certain income and net worth limits.</p>",
           "SourceLink": "https://www.bia.gov/bia/ois/dhs/financial-assistance",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": "Department of Interior (DOI) - Indian Affairs",
             "summary": "<p>The Bureau of Indian Affairs enhances the quality of life and protects and improves the trust assets of American Indians, Indian tribes, and Alaska Natives.</p>",
             "lede": "<p>The Bureau of Indian Affairs enhances the quality of life and protects and improves the trust assets of American Indians, Indian tribes, and Alaska Natives.</p>"
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_american_indian",
               "label": "The deceased was a member of a federally recognized American Indian Tribe or an Alaska Native.",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             }
           ]
         }
@@ -1303,7 +1197,7 @@
           "title": "Survivors benefits for mothers/fathers with a child",
           "summary": "<p>Social Security survivors benefits to the person providing care for the child of a deceased worker.</p>",
           "SourceLink": "https://www.ssa.gov/forms/ssa-5.html",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Social Security Administration (SSA)",
             "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
@@ -1313,31 +1207,22 @@
             {
               "criteriaKey": "deceased_paid_into_SS",
               "label": "The deceased worked and paid Social Security taxes",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_marital_status",
               "label": "Your marital status is unmarried or widowed",
-              "acceptableValues": [
-                "Unmarried",
-                "Widowed"
-              ]
+              "acceptableValues": ["Unmarried", "Widowed"]
             },
             {
               "criteriaKey": "applicant_citizen_status",
               "label": "You are a US citizen or eligible non-citizen",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_care_for_child",
               "label": "You are caring for a child of someone who is retired, has a disability, or has died, and the child is disabled or under the age of 16",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             }
           ]
         }
@@ -1347,43 +1232,33 @@
           "title": "Annuity for certain military surviving spouses",
           "summary": "<p>Financial support for surviving spouses of members of the uniformed services.</p>",
           "SourceLink": "https://militarypay.defense.gov/Benefits/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Department of Defense (DOD)",
             "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_date_of_death",
               "label": "Deceased died before 1978",
-              "acceptableValues": [
-                "<01-01-1978"
-              ]
+              "acceptableValues": ["<01-01-1978"]
             },
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "You served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
               "label": "The service status of the deceased is: retired from the service",
-              "acceptableValues": [
-                "Retired from the service"
-              ]
+              "acceptableValues": ["Retired from the service"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Your relationship to the deceased is: spouse",
-              "acceptableValues": [
-                "Spouse"
-              ]
+              "acceptableValues": ["Spouse"]
             }
           ]
         }
@@ -1393,22 +1268,18 @@
           "title": "Education benefits (GI Bill) for survivors",
           "summary": "<p>VA education benefits or job training for dependents and survivors of a veteran. You must have a high school or GED diploma to be eligible.</p>",
           "SourceLink": "https://www.va.gov/education/survivor-dependent-benefits/",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
@@ -1429,10 +1300,7 @@
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Your relationship to the deceased is: spouse or child",
-              "acceptableValues": [
-                "Spouse",
-                "Child"
-              ]
+              "acceptableValues": ["Spouse", "Child"]
             }
           ]
         }
@@ -1442,50 +1310,38 @@
           "title": "Survivors benefits for child with disabilities",
           "summary": "<p>Social Security survivors benefits to a child, stepchild, grandchild, or adopted child with disabilities of eligible workers. You only need one application to apply for all SSA benefits.</p>",
           "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h4",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": "Social Security Administration (SSA)",
             "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_paid_into_SS",
               "label": "The deceased worked and paid Social Security taxes",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_date_of_birth",
               "label": "You are under 18 years",
-              "acceptableValues": [
-                "<18years"
-              ]
+              "acceptableValues": ["<18years"]
             },
             {
               "criteriaKey": "applicant_marital_status",
               "label": "Your marital status is unmarried",
-              "acceptableValues": [
-                "Unmarried"
-              ]
+              "acceptableValues": ["Unmarried"]
             },
             {
               "criteriaKey": "applicant_citizen_status",
               "label": "You are a U.S. citizen or eligible non-citizen",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Your relationship to the deceased is: child",
-              "acceptableValues": [
-                "Child"
-              ]
+              "acceptableValues": ["Child"]
             }
           ]
         }
@@ -1495,51 +1351,38 @@
           "title": "Survivors benefits for spouse with disabilities",
           "summary": "<p>Benefits for surviving spouses and certain divorced spouses with disabilities. Eligible survivors must have a disability that prevents them from working for more than a year. You only need one application to apply for all SSA benefits.</p>",
           "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h2",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": "Social Security Administration (SSA)",
             "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_paid_into_SS",
               "label": "The deceased worked and paid Social Security taxes",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_date_of_birth",
               "label": "You are over 50 years",
-              "acceptableValues": [
-                ">=50years"
-              ]
+              "acceptableValues": [">=50years"]
             },
             {
               "criteriaKey": "applicant_marital_status",
               "label": "Your marital status is widowed or divorced",
-              "acceptableValues": [
-                "Widowed",
-                "Divorced"
-              ]
+              "acceptableValues": ["Widowed", "Divorced"]
             },
             {
               "criteriaKey": "applicant_citizen_status",
               "label": "You are a US citizen or eligible non-citizen",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Your relationship to the deceased is: spouse",
-              "acceptableValues": [
-                "Spouse"
-              ]
+              "acceptableValues": ["Spouse"]
             }
           ]
         }
@@ -1549,30 +1392,23 @@
           "title": "Public safety officers' Educational Assistance Program",
           "summary": "<p>Financial assistance for higher education to spouses and children of police, fire, and emergency public safety officers killed in the line of duty.</p>",
           "SourceLink": "https://psob.bja.ojp.gov/PSOB_Education2018.pdf",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Department of Justice (DOJ)",
             "summary": "<p>Offers financial and educational support to help families of fallen public safety officers.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_public_safety_officer",
               "label": "The deceased was a public safety officer who died in the line of duty",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Your relationship to the deceased is: spouse or child",
-              "acceptableValues": [
-                "Spouse",
-                "Child"
-              ]
+              "acceptableValues": ["Spouse", "Child"]
             }
           ]
         }
@@ -1582,22 +1418,18 @@
           "title": "Public safety officers' death benefits",
           "summary": "<p>A one-time benefit for survivors of law enforcement officers, firefighters, and other first responders whose deaths were related to an injury sustained during the line of duty.</p>",
           "SourceLink": "https://bja.ojp.gov/program/psob/benefits",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Department of Justice (DOJ)",
             "summary": "<p>Offers financial and educational support to help families of fallen public safety officers.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_public_safety_officer",
               "label": "The deceased was a public safety officer who died in the line of duty",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
@@ -1617,7 +1449,7 @@
           "title": "Burial flag",
           "summary": "<p>A United States flag for the coffin or urn in honor of the military service member.</p>",
           "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/burial-flags/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
@@ -1627,9 +1459,7 @@
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
@@ -1658,22 +1488,18 @@
           "title": "Home loan program for survivors",
           "summary": "<p>A VA-backed home loan to surviving spouses of veterans.</p>",
           "SourceLink": "https://www.va.gov/housing-assistance/home-loans/surviving-spouse/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
@@ -1696,16 +1522,12 @@
             {
               "criteriaKey": "applicant_marital_status",
               "label": "Your marital status is widowed",
-              "acceptableValues": [
-                "Widowed"
-              ]
+              "acceptableValues": ["Widowed"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Your relationship to the deceased is: spouse",
-              "acceptableValues": [
-                "Spouse"
-              ]
+              "acceptableValues": ["Spouse"]
             }
           ]
         }
@@ -1715,7 +1537,7 @@
           "title": "Survivors benefits for child",
           "summary": "<p>Offers Social Security survivors benefits to a child, stepchild, grandchild, or adopted child of eligible workers.</p>",
           "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h4",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": "Social Security Administration (SSA)",
             "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
@@ -1725,37 +1547,27 @@
             {
               "criteriaKey": "deceased_paid_into_SS",
               "label": "The deceased worked and paid Social Security taxes",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_date_of_birth",
               "label": "You are under 18 years",
-              "acceptableValues": [
-                "<18years"
-              ]
+              "acceptableValues": ["<18years"]
             },
             {
               "criteriaKey": "applicant_marital_status",
               "label": "Your marital status is unmarried",
-              "acceptableValues": [
-                "Unmarried"
-              ]
+              "acceptableValues": ["Unmarried"]
             },
             {
               "criteriaKey": "applicant_citizen_status",
               "label": "You are a U.S. citizen or eligible non-citizen",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Applicant's relationship to the deceased is: child",
-              "acceptableValues": [
-                "Child"
-              ]
+              "acceptableValues": ["Child"]
             }
           ]
         }
@@ -1765,7 +1577,7 @@
           "title": "Survivor benefit plan",
           "summary": "<p>Offers up to 55% of a service member's retired pay for survivors of active duty service members and some retired and reserve members.</p>",
           "SourceLink": "https://bja.ojp.gov/program/psob/benefits",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Department of Defense (DOD)",
             "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
@@ -1775,9 +1587,7 @@
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
@@ -1799,10 +1609,7 @@
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Your relationship to the deceased is: spouse or child",
-              "acceptableValues": [
-                "Spouse",
-                "Child"
-              ]
+              "acceptableValues": ["Spouse", "Child"]
             }
           ]
         }
@@ -1812,7 +1619,7 @@
           "title": "Burial in VA national cemetery",
           "summary": "<p>Burial in VA national cemeteries for eligible veterans, service members, and some family members.</p>",
           "SourceLink": "https://www.va.gov/burials-memorials/eligibility/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
@@ -1822,9 +1629,7 @@
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
@@ -1853,7 +1658,7 @@
           "title": "Death gratuity",
           "summary": "<p>Tax free payment of $100,000 to eligible survivors of members of the Armed Forces who died while on active duty or while serving in certain reserve statuses.</p>",
           "SourceLink": "https://militarypay.defense.gov/Benefits/Death-Gratuity/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Department of Defense (DOD)",
             "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
@@ -1863,9 +1668,7 @@
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "The deceased served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
@@ -1901,22 +1704,18 @@
           "title": "Survivors pension for child",
           "summary": "<p>Monthly payments to qualified unmarried dependent children of deceased wartime veterans.</p>",
           "SourceLink": "https://www.va.gov/pension/survivors-pension/",
-          "SourceIsEnglish": "TRUE",
+          "SourceIsEnglish": true,
           "agency": {
             "title": "Veterans Affairs Department (VA)",
             "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
             "lede": ""
           },
-          "lifeEvents": [
-            "Benefit finder: death of a loved one"
-          ],
+          "lifeEvents": ["Benefit finder: death of a loved one"],
           "eligibility": [
             {
               "criteriaKey": "deceased_served_in_active_military",
               "label": "You served in the active military",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "deceased_service_status",
@@ -1928,23 +1727,17 @@
             {
               "criteriaKey": "applicant_date_of_birth",
               "label": "You are under 18 years",
-              "acceptableValues": [
-                "<18years"
-              ]
+              "acceptableValues": ["<18years"]
             },
             {
               "criteriaKey": "applicant_marital_status",
               "label": "Your marital status is unmarried",
-              "acceptableValues": [
-                "Unmarried"
-              ]
+              "acceptableValues": ["Unmarried"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Your relationship to the deceased is: child",
-              "acceptableValues": [
-                "Child"
-              ]
+              "acceptableValues": ["Child"]
             }
           ]
         }
@@ -1954,7 +1747,7 @@
           "title": "Survivors benefits for parents",
           "summary": "<p>Social Security survivors benefits to parents of eligible workers.</p>",
           "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h5",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": "Social Security Administration (SSA)",
             "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
@@ -1964,30 +1757,22 @@
             {
               "criteriaKey": "deceased_paid_into_SS",
               "label": "The deceased worked and paid Social Security taxes",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_date_of_birth",
               "label": "You are over 62 years",
-              "acceptableValues": [
-                ">=62years"
-              ]
+              "acceptableValues": [">=62years"]
             },
             {
               "criteriaKey": "applicant_citizen_status",
               "label": "You are a US citizen or eligible non-citizen",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Your relationship to the deceased is: parent",
-              "acceptableValues": [
-                "Parent"
-              ]
+              "acceptableValues": ["Parent"]
             }
           ]
         }
@@ -1997,7 +1782,7 @@
           "title": "Survivors benefits for spouse",
           "summary": "<p>Social Security survivors benefits to surviving spouses and certain divorced spouses of eligible workers.</p>",
           "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h2",
-          "SourceIsEnglish": "FALSE",
+          "SourceIsEnglish": false,
           "agency": {
             "title": "Social Security Administration (SSA)",
             "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
@@ -2007,38 +1792,27 @@
             {
               "criteriaKey": "deceased_paid_into_SS",
               "label": "The deceased worked and paid Social Security taxes",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_date_of_birth",
               "label": "You are over 60 years",
-              "acceptableValues": [
-                ">=60years"
-              ]
+              "acceptableValues": [">=60years"]
             },
             {
               "criteriaKey": "applicant_marital_status",
               "label": "Your marital status is widowed or divorced",
-              "acceptableValues": [
-                "Widowed",
-                "Divorced"
-              ]
+              "acceptableValues": ["Widowed", "Divorced"]
             },
             {
               "criteriaKey": "applicant_citizen_status",
               "label": "You are a US citizen or eligible non-citizen",
-              "acceptableValues": [
-                "Yes"
-              ]
+              "acceptableValues": ["Yes"]
             },
             {
               "criteriaKey": "applicant_relationship_to_the_deceased",
               "label": "Your relationship to the deceased is: spouse",
-              "acceptableValues": [
-                "Spouse"
-              ]
+              "acceptableValues": ["Spouse"]
             }
           ]
         }

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/index.spec.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/index.spec.jsx
@@ -22,7 +22,7 @@ describe('BenefitAccordionGroup', () => {
   })
 
   it('renders (en inglés) when flagged as TRUE', () => {
-    b.benefit.SourceIsEnglish = 'TRUE' // ensure true
+    b.benefit.SourceIsEnglish = true // ensure true
     render(
       <BenefitAccordionGroup
         ui={es.resultsView}
@@ -35,7 +35,7 @@ describe('BenefitAccordionGroup', () => {
   })
 
   it('does not render (en inglés) when flagged as FALSE', () => {
-    b.benefit.SourceIsEnglish = 'FALSE' // ensure false
+    b.benefit.SourceIsEnglish = false // ensure false
     render(
       <BenefitAccordionGroup
         ui={es.resultsView}

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/index.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/index.jsx
@@ -210,7 +210,7 @@ const BenefitAccordionGroup = ({
                 rel="noopener noreferrer"
               >
                 {visitLabel} {agency.title}{' '}
-                {sourceIsEnglish && SourceIsEnglish === 'TRUE'
+                {sourceIsEnglish && SourceIsEnglish === true
                   ? sourceIsEnglish
                   : ''}
               </ObfuscatedLink>

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/index.stories.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/index.stories.jsx
@@ -10,8 +10,8 @@ const entryKey = Object.keys(b[0])
 const { resultsView } = en
 
 const SourceIsEnglishBenefits = b.slice(5, 7)
-SourceIsEnglishBenefits[0].benefit.SourceIsEnglish = 'TRUE' // ensure true
-SourceIsEnglishBenefits[1].benefit.SourceIsEnglish = 'FALSE' // ensure false
+SourceIsEnglishBenefits[0].benefit.SourceIsEnglish = true // ensure true
+SourceIsEnglishBenefits[1].benefit.SourceIsEnglish = false // ensure false
 
 export default {
   component: BenefitAccordionGroup,

--- a/benefit-finder/src/shared/components/Date/index.jsx
+++ b/benefit-finder/src/shared/components/Date/index.jsx
@@ -6,7 +6,7 @@ import './_index.scss'
  * a parse our date object
  * @component
  * @param {func} onChange - inherited change handler
- * @param {string} required - inherited string value to manage required state
+ * @param {boolean} required - inherited boolean value to manage required state
  * @param {object} value - inherited state values
  * @return {Date} returns a tandard format Date ie 1995-12-17T03:24:00
  */
@@ -43,12 +43,12 @@ const Date = ({ onChange, value, required, ui, id, invalid }) => {
         </div>
         <select
           className={`bf-usa-select usa-select ${
-            required === 'TRUE' ? 'required-field' : ''
+            required === true ? 'required-field' : ''
           }`}
           id={`date_of_birth_month-${id}`}
           name={`date_of_birth_month-${id}`}
           aria-describedby={`month-description-${id}`}
-          required={required === 'TRUE'}
+          required={required === true}
           value={(value && value.month) || ''}
           onChange={onChange}
           aria-invalid={invalid === true}
@@ -74,14 +74,14 @@ const Date = ({ onChange, value, required, ui, id, invalid }) => {
           Enter two numerals for day
         </div>
         <input
-          className={`bf-usa-input usa-input ${required === 'TRUE' ? 'required-field' : ''}`}
+          className={`bf-usa-input usa-input ${required === true ? 'required-field' : ''}`}
           aria-describedby={`day-description-${id}`}
           id={`date_of_birth_day-${id}`}
           name={`date_of_birth_day-${id}`}
           inputMode="numeric"
           value={(value && value.day) || ''}
           onChange={onChange}
-          required={required === 'TRUE'}
+          required={required === true}
           aria-invalid={invalid === true}
         />
       </div>
@@ -96,14 +96,14 @@ const Date = ({ onChange, value, required, ui, id, invalid }) => {
           Enter four numerals for year
         </div>
         <input
-          className={`bf-usa-input usa-input ${required === 'TRUE' ? 'required-field' : ''}`}
+          className={`bf-usa-input usa-input ${required === true ? 'required-field' : ''}`}
           aria-describedby={`year-description-${id}`}
           id={`date_of_birth_year-${id}`}
           name={`date_of_birth_year-${id}`}
           inputMode="numeric"
           value={(value && value.year) || ''}
           onChange={onChange}
-          required={required === 'TRUE'}
+          required={required === true}
           aria-invalid={invalid === true}
         />
       </div>
@@ -113,7 +113,7 @@ const Date = ({ onChange, value, required, ui, id, invalid }) => {
 
 Date.propTypes = {
   onChange: PropTypes.func,
-  required: PropTypes.string,
+  required: PropTypes.bool,
   value: PropTypes.object,
 }
 

--- a/benefit-finder/src/shared/components/Fieldset/index.jsx
+++ b/benefit-finder/src/shared/components/Fieldset/index.jsx
@@ -46,7 +46,7 @@ const Fieldset = ({
 
   // determine if we need to include a reqired hint
   const handleRequired =
-    required === 'FALSE' ? <Legend>{legend}</Legend> : RequiredFlag()
+    required === false ? <Legend>{legend}</Legend> : RequiredFlag()
 
   return (
     <fieldset

--- a/benefit-finder/src/shared/components/Fieldset/index.stories.jsx
+++ b/benefit-finder/src/shared/components/Fieldset/index.stories.jsx
@@ -8,7 +8,7 @@ export default {
     children: <TextInput label="Text input label" />,
     legend: 'Legend',
     hint: 'Hint',
-    required: 'FALSE',
+    required: false,
   },
 }
 
@@ -16,6 +16,6 @@ export const Primary = {}
 export const Required = {
   args: {
     ...Primary.args,
-    required: 'TRUE',
+    required: true,
   },
 }

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -244,7 +244,7 @@ const LifeEventSection = ({
   const handleDateRequired = (values, item) => {
     return Object.keys(values?.value).length === 3 &&
       values?.value?.year?.length === 4
-      ? 'FALSE'
+      ? false
       : item.fieldset.required
   }
 

--- a/benefit-finder/src/shared/components/Radio/index.jsx
+++ b/benefit-finder/src/shared/components/Radio/index.jsx
@@ -25,7 +25,7 @@ const Radio = ({
   className,
   name,
 }) => {
-  const handleRequired = required === 'TRUE' ? ['required-field'] : ''
+  const handleRequired = required === true ? ['required-field'] : ''
   const defaultClasses = ['bf-usa-radio__input usa-radio__input']
   const utilityClasses = handleRequired
   return (

--- a/benefit-finder/src/shared/components/Select/index.jsx
+++ b/benefit-finder/src/shared/components/Select/index.jsx
@@ -28,7 +28,7 @@ function Select({
   invalid,
 }) {
   const { labelSelect, defaultValue } = ui
-  const handleRequired = required === 'TRUE' ? ['required-field'] : ''
+  const handleRequired = required === true ? ['required-field'] : ''
   const defaultClasses = ['bf-usa-select usa-select']
   const utilityClasses = handleRequired
   /**
@@ -60,7 +60,7 @@ function Select({
         id={htmlFor}
         onChange={onChange}
         value={selected || ''}
-        required={required === 'TRUE'}
+        required={required === true}
         aria-invalid={invalid}
       >
         <option value="" key="default" disabled>

--- a/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
@@ -374,7 +374,7 @@ class LifeEventController {
     $criteria_fieldset = [
       "criteriaKey" => current($criteria->get('field_b_criteria_key')->referencedEntities())->get('field_b_id')->value,
       "legend" => $criteria->get('field_b_legend')->value ?? "",
-      "required" => $criteria->get('field_b_required')->value ? "true" : "false",
+      "required" => $criteria->get('field_b_required')->value ? true : false,
       "hint" => $criteria->get('field_b_hint')->value ?? "",
     ];
 
@@ -384,7 +384,7 @@ class LifeEventController {
       "type" => $criteria_node->get('field_b_type')->value,
       "name" => $criteria_node->get('field_b_name')->value ?? "",
       "label" => $criteria_node->get('field_b_label')->value ?? "",
-      "hasChild" => $criteria_node->get('field_b_has_child')->value ? "true" : "false",
+      "hasChild" => $criteria_node->get('field_b_has_child')->value ? true : false,
       "childDependencyOption" => $criteria_node->get('field_b_child_dependency_option')->value ?? "",
     ];
 
@@ -442,7 +442,7 @@ class LifeEventController {
       "title" => $node->get('title')->value,
       "summary" => $node->get('field_b_summary')->value ?? "",
       "SourceLink" => $node->get('field_b_source_link')->value ?? "",
-      "SourceIsEnglish" => $node->get('field_b_source_is_english')->value ? "true" : "false",
+      "SourceIsEnglish" => $node->get('field_b_source_is_english')->value ? true : false,
     ];
 
     // Get agency node and build benefit agency.

--- a/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
@@ -374,7 +374,7 @@ class LifeEventController {
     $criteria_fieldset = [
       "criteriaKey" => current($criteria->get('field_b_criteria_key')->referencedEntities())->get('field_b_id')->value,
       "legend" => $criteria->get('field_b_legend')->value ?? "",
-      "required" => $criteria->get('field_b_required')->value ? "TRUE" : "FALSE",
+      "required" => $criteria->get('field_b_required')->value ? "true" : "false",
       "hint" => $criteria->get('field_b_hint')->value ?? "",
     ];
 
@@ -384,7 +384,7 @@ class LifeEventController {
       "type" => $criteria_node->get('field_b_type')->value,
       "name" => $criteria_node->get('field_b_name')->value ?? "",
       "label" => $criteria_node->get('field_b_label')->value ?? "",
-      "hasChild" => $criteria_node->get('field_b_has_child')->value ? "TRUE" : "FALSE",
+      "hasChild" => $criteria_node->get('field_b_has_child')->value ? "true" : "false",
       "childDependencyOption" => $criteria_node->get('field_b_child_dependency_option')->value ?? "",
     ];
 
@@ -442,7 +442,7 @@ class LifeEventController {
       "title" => $node->get('title')->value,
       "summary" => $node->get('field_b_summary')->value ?? "",
       "SourceLink" => $node->get('field_b_source_link')->value ?? "",
-      "SourceIsEnglish" => $node->get('field_b_source_is_english')->value ? "TRUE" : "FALSE",
+      "SourceIsEnglish" => $node->get('field_b_source_is_english')->value ? "true" : "false",
     ];
 
     // Get agency node and build benefit agency.


### PR DESCRIPTION
## PR Summary

This work replaces type string TRUE.

## Related Github Issue

- Fixes #1307 

## Detailed Testing steps

- [x] Pull changes locally
- [x] Make local development site up at http://localhost/

JSON Response
- [x] Navigate to /benefit-finder/api/life-event/death
- [x] Verify that "required", "hasChild", and "SourceIsEnglish" have boolean value
- [x] Verify that `"required": true,`
- [x] Verify that "`hasChild": true,`
- [x] Verify that "`SourceIsEnglish": true,`

Application
- [x] review code, ensure all conditionals on the string `'TRUE'` or `'FALSE'` have been replaced with the boolean equivelant of `true` or `false`
- [x] ensure all test are passing
- [x] navigate to first step of form
- [x] Verify that  when `"required": true,` is in the fieldset object, a `required` flag is associated with the fieldset label
- [x] Click `continue` without filling out any field values
- [x] Verify that any field marked with reqired is flagged with an error state
- [x] complete required fields
- [x] navigate to next step by clicking `continue`
- [x] Verify that  when "`hasChild": true,` is in the fieldset object, the related child fieldset is hidden. `"Did the deceased actively serve in the U.S. military?"`
- [x] Verify that  when "`hasChild": true,` is in the fieldset object, the related child fieldset is visible when the dependecy  option value is valid, `"True"]`
- [x] Verify that  when "`SourceIsEnglish": true,` the sourcelink in a benefit indicates `(en inglés)`
- [x] toggle ES locale, navigate through form and find `Visita Asuntos Indígenas, Departamento del Interior (DOI) (en inglés)` in the benefits