### PR TITLE
1222 a11y error state contrast

### DIFF
--- a/benefit-finder/src/shared/components/Date/index.jsx
+++ b/benefit-finder/src/shared/components/Date/index.jsx
@@ -6,8 +6,12 @@ import './_index.scss'
  * a parse our date object
  * @component
  * @param {func} onChange - inherited change handler
- * @param {boolean} required - inherited boolean value to manage required state
  * @param {object} value - inherited state values
+ * @param {boolean} required - inherited boolean value to manage required state
+  * @param {object} ui - inherited ui object values
+ * @param {string} id - inherited string value for id specificity
+ * @param {boolean} invalid - inherited boolean value to manage error state
+
  * @return {Date} returns a tandard format Date ie 1995-12-17T03:24:00
  */
 const Date = ({ onChange, value, required, ui, id, invalid }) => {
@@ -113,8 +117,11 @@ const Date = ({ onChange, value, required, ui, id, invalid }) => {
 
 Date.propTypes = {
   onChange: PropTypes.func,
-  required: PropTypes.bool,
   value: PropTypes.object,
+  required: PropTypes.bool,
+  ui: PropTypes.object,
+  id: PropTypes.string,
+  invalid: PropTypes.bool,
 }
 
 export default Date

--- a/benefit-finder/src/shared/components/Radio/_index.scss
+++ b/benefit-finder/src/shared/components/Radio/_index.scss
@@ -5,13 +5,18 @@
   padding-bottom: space.$padding-bottom-md-plus;
 }
 
-.usa-input--error + .bf-usa-radio__label::before {
-  box-shadow: 0 0 0 3px color.$alert-red;
-}
-
 .bf-usa-radio__input:checked + .bf-usa-radio__label::before {
   background-color: #005ea2;
   box-shadow:
     0 0 0 2px #005ea2,
     inset 0 0 0 2px white;
+  outline-offset: 4px;
+}
+
+.bf-usa-radio__input:checked.usa-input--error + .bf-usa-radio__label::before {
+  background-color: #005ea2;
+  box-shadow:
+    0 0 0 3px color.$alert-red,
+    inset 0 0 0 2px white;
+  outline-offset: 4px;
 }

--- a/benefit-finder/src/shared/components/Radio/index.jsx
+++ b/benefit-finder/src/shared/components/Radio/index.jsx
@@ -55,9 +55,13 @@ const Radio = ({
 }
 
 Radio.propTypes = {
+  id: PropTypes.string,
   label: PropTypes.string,
   value: PropTypes.string,
-  defaultChecked: PropTypes.bool,
+  checked: PropTypes.bool,
+  onChange: PropTypes.func,
+  className: PropTypes.string,
+  name: PropTypes.string,
 }
 
 export default Radio

--- a/benefit-finder/src/shared/components/Radio/index.stories.jsx
+++ b/benefit-finder/src/shared/components/Radio/index.stories.jsx
@@ -23,6 +23,7 @@ export const Error = {
     ...Primary.args,
     required: true,
     checked: true,
+    invalid: true,
     className: 'bf-usa-input--error usa-input--error',
   },
 }

--- a/benefit-finder/src/shared/components/Radio/index.stories.jsx
+++ b/benefit-finder/src/shared/components/Radio/index.stories.jsx
@@ -17,3 +17,12 @@ export const DefaultChecked = {
     checked: true,
   },
 }
+
+export const Error = {
+  args: {
+    ...Primary.args,
+    required: true,
+    checked: true,
+    className: 'bf-usa-input--error usa-input--error',
+  },
+}

--- a/benefit-finder/src/shared/components/Select/_index.scss
+++ b/benefit-finder/src/shared/components/Select/_index.scss
@@ -13,5 +13,9 @@
     height: auto;
     border-radius: 3px;
     border-color: color.$alert-red;
+
+    &:focus {
+      outline-offset: 2px;
+    }
   }
 }

--- a/benefit-finder/src/shared/components/Select/index.jsx
+++ b/benefit-finder/src/shared/components/Select/index.jsx
@@ -78,8 +78,10 @@ Select.propTypes = {
   options: PropTypes.array,
   selected: PropTypes.string,
   onChange: PropTypes.func,
+  required: PropTypes.bool,
   ui: PropTypes.object,
   className: PropTypes.string,
+  invalid: PropTypes.bool,
 }
 
 export default Select

--- a/benefit-finder/src/shared/components/Select/index.stories.jsx
+++ b/benefit-finder/src/shared/components/Select/index.stories.jsx
@@ -19,3 +19,12 @@ export default {
 }
 
 export const Primary = {}
+
+export const Error = {
+  args: {
+    ...Primary.args,
+    required: true,
+    invalid: true,
+    className: 'bf-usa-input--error usa-input--error',
+  },
+}

--- a/benefit-finder/src/shared/components/TextInput/_index.scss
+++ b/benefit-finder/src/shared/components/TextInput/_index.scss
@@ -1,0 +1,3 @@
+.bf-usa-input.usa-input--error {
+  outline-offset: 2px;
+}

--- a/benefit-finder/src/shared/components/TextInput/index.jsx
+++ b/benefit-finder/src/shared/components/TextInput/index.jsx
@@ -1,6 +1,7 @@
 import { useHandleClassName } from '../../hooks'
 import { Label } from '../index'
 import PropTypes from 'prop-types'
+import './_index.scss'
 
 /**
  * a functional component that renders a field for text input

--- a/benefit-finder/src/shared/components/TextInput/index.stories.jsx
+++ b/benefit-finder/src/shared/components/TextInput/index.stories.jsx
@@ -12,6 +12,16 @@ export default {
 
 export const Primary = {}
 
+export const Error = {
+  args: {
+    ...Primary.args,
+    required: true,
+    checked: true,
+    invalid: true,
+    className: 'bf-usa-input--error usa-input--error',
+  },
+}
+
 export const TextArea = {
   args: {
     ...Primary.args,


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This works to ensure our input and select elements have an outline offset so that there are not any contrast concerns when error state is set.

## Related Github Issue

- Fixes #1222 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] `cd benefit-finder`
- [ ] `npm install`
- [ ] `npm run start`

<!--- If there are steps for user testing list them here -->
- [ ] navigate to `/death`
- [ ] navigate to first step of form
- [ ] click continue button to trigger error state
- [ ] tab through form to view focus state of elements, or
- [ ] open inspector in web console force "focus" state on all the elements that have errors
- [ ] ensure that there is a 2px seperation between the focus and the red outline of the error state 

expected:
![focus state input elements](https://github.com/GSA/px-benefit-finder/assets/37077057/67d95ae4-1965-4db0-9e9e-af2bcb0342de)

