### PR TITLE
Include Button Outline on Focus

### DIFF
--- a/benefit-finder/src/shared/components/Button/_index.scss
+++ b/benefit-finder/src/shared/components/Button/_index.scss
@@ -33,6 +33,10 @@
 
 .bf-usa-button--outline:hover {
   background-color: color.$white;
-  box-shadow: inset 0 0 0 2px color.$marine;
   color: color.$marine;
+  box-shadow: inset 0 0 0 2px color.$marine;
+}
+
+.bf-usa-button--outline:focus {
+  box-shadow: inset 0 0 0 2px color.$white;
 }


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This implements an adjustment to the focus state on secondary button styles so that there is a white inner stroke agains the darker focus stroke, which improves contrast for a11y.

## Related Github Issue

- Fixes #1214 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull change locally
- [ ] `cd benefit-finder`
- [ ] `npm install`
- [ ] `npm run start`

<!--- If there are steps for user testing list them here -->
- [ ] visit `/death`
- [ ] navigate to the first step in form
- [ ] open inspector in web console force "focus" state on all both buttons in the button group at the bottom of step 
- [ ] ensure that there is a white inner stroke against the focus outline

expected
<img width="1439" alt="Screenshot 2024-05-28 at 8 14 50 AM" src="https://github.com/GSA/px-benefit-finder/assets/37077057/3efbd695-07ee-4253-b5f3-fbdb295cc390">


