### PR TITLE
PXBF-ensure-prod-checkout: ensure prod checkout when moved

### DIFF
--- a/scripts/pipeline/mv-usagov_benefit_finder.sh
+++ b/scripts/pipeline/mv-usagov_benefit_finder.sh
@@ -18,12 +18,16 @@ then
     # init submodule
     git submodule init
     git submodule update
-    cd "${BENEFIT_FINDER_MODULE_LOCATION}"
+    cd "${USAGOV_PROJECT_LOCATION}" || exit 1
     git fetch origin prod:prod
     git checkout prod
 else
     echo "usa.gov project directory exists, updating submodule"
     git pull --recurse-submodules
+    cd "${USAGOV_PROJECT_LOCATION}" || exit 1
+    pwd
+    git fetch origin prod:prod
+    git checkout prod
 fi
 
 # check if module directory exist


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This shouldn't change much on pipeline, but fixes some local workflow issues by ensuring `prod` branch checkout on submodules when moving applications around the project.

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [x] pull changes locally
- [x] bash `scripts/pipeline/mv-usagov_benefit_finder.sh`
- [x] cd `usagov-2021`

<!--- If there are steps for user testing list them here -->
- [x] git status
- [x] ensure current branch is `prod`
- [x] confirm project builds in pipeline
