### PR TITLE
1393 stop tome

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -150,8 +150,7 @@ jobs:
           sed -i 's/80/8080/g' Dockerfile-cms
           sed -i 's/ENTRYPOINT/CMD/' Dockerfile-cms
           sed -i 's/\["s3"\]\[\]?/s3\[\]/g' scripts/tome-run.sh scripts/tome-sync.sh
-          echo "#!/bin/bash" > scripts/tome-run.sh
-          echo "#!/bin/bash" > scripts/tome-sync.sh
+          sed -i "s,/var/www/scripts/tome-run.sh $URI $@,," > .docker/src-cms/etc/periodic/1min/generate-static-site
           sed -i 's/80/8080/g' .docker/src-cms/etc/nginx/partials/cms.conf.tmpl
           sed -i "s/\$service\['name'\] === 'database'/stristr(\$service\['name'\], 'mysql')/"  web/sites/default/settings.php
           sed -i "s/\$settings\['hash_salt'\] = \$service\['credentials'\]\['HASH_SALT'\]/\$settings\['hash_salt'\] = \$service\['credentials'\]\['hash_salt'\]/"  web/sites/default/settings.php

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - dev
       - main
-      - 1393-stop-tome
 
 jobs:
   php-lint:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -2,9 +2,10 @@ name: Build and deploy
 
 on:
   push:
-    branches: 
+    branches:
       - dev
       - main
+      - 1393-stop-tome
 
 jobs:
   php-lint:
@@ -19,7 +20,8 @@ jobs:
           node-version-file: "./benefit-finder/package.json"
       - name: Set env.BRANCH
         run: |
-          echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV
+          # echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV
+          echo "BRANCH=dev" >> $GITHUB_ENV
       - name: Install PHP
         run: bash ./scripts/pipeline/deb-php-install.sh
       # - name: Install Node.js
@@ -57,10 +59,10 @@ jobs:
     if: github.ref == 'refs/heads/dev'
     secrets: inherit
   backup-database-main:
-      needs: php-lint
-      uses: ./.github/workflows/database-backup-main.yml
-      if: github.ref == 'refs/heads/main'
-      secrets: inherit
+    needs: php-lint
+    uses: ./.github/workflows/database-backup-main.yml
+    if: github.ref == 'refs/heads/main'
+    secrets: inherit
   component-library:
     needs: [backup-database-dev, backup-database-main]
     if: always() && contains(needs.*.result, 'success') && !contains(needs.*.result, 'failure')
@@ -90,10 +92,10 @@ jobs:
           cd ..
       - name: Deploy Storybook
         env:
-          CF_USER: '${{ secrets.CF_USER }}'
-          CF_PASSWORD: '${{ secrets.CF_PASSWORD }}'
-          CF_ORG: '${{ secrets.CF_ORG }}'
-          PROJECT: '${{ secrets.PROJECT }}'
+          CF_USER: "${{ secrets.CF_USER }}"
+          CF_PASSWORD: "${{ secrets.CF_PASSWORD }}"
+          CF_ORG: "${{ secrets.CF_ORG }}"
+          PROJECT: "${{ secrets.PROJECT }}"
         run: |
           source ./scripts/pipeline/cloud-gov-login.sh
           cd benefit-finder
@@ -146,6 +148,8 @@ jobs:
           sed -i 's/80/8080/g' Dockerfile-cms
           sed -i 's/ENTRYPOINT/CMD/' Dockerfile-cms
           sed -i 's/\["s3"\]\[\]?/s3\[\]/g' scripts/tome-run.sh scripts/tome-sync.sh
+          echo "#!/bin/bash" > scripts/tome-run.sh
+          echo "#!/bin/bash" > scripts/tome-sync.sh
           sed -i 's/80/8080/g' .docker/src-cms/etc/nginx/partials/cms.conf.tmpl
           sed -i "s/\$service\['name'\] === 'database'/stristr(\$service\['name'\], 'mysql')/"  web/sites/default/settings.php
           sed -i "s/\$settings\['hash_salt'\] = \$service\['credentials'\]\['HASH_SALT'\]/\$settings\['hash_salt'\] = \$service\['credentials'\]\['hash_salt'\]/"  web/sites/default/settings.php
@@ -171,10 +175,10 @@ jobs:
           file: ./usagov-2021/Dockerfile-cms
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }} 
+          labels: ${{ steps.meta.outputs.labels }}
       - name: Configure manifest.yml
         env:
-          PROJECT: '${{ secrets.PROJECT }}'
+          PROJECT: "${{ secrets.PROJECT }}"
         run: |
           declare MEMORY
           [ "${BRANCH}" = "dev" ] && MEMORY=${{ vars.CMS_MEMORY_DEV }}
@@ -191,12 +195,12 @@ jobs:
           sed -i '16i\  command: /var/www/scripts/entrypoint.sh' manifest.yml
       - name: Deploy application
         env:
-          CF_USER: '${{ secrets.CF_USER }}'
-          CF_PASSWORD: '${{ secrets.CF_PASSWORD }}'
-          CF_ORG: '${{ secrets.CF_ORG }}'
-          CR_PAT: '${{ secrets.CR_PAT }}'
-          CR_USERNAME: '${{ secrets.CR_USERNAME }}'
-          PROJECT: '${{ secrets.PROJECT }}'
+          CF_USER: "${{ secrets.CF_USER }}"
+          CF_PASSWORD: "${{ secrets.CF_PASSWORD }}"
+          CF_ORG: "${{ secrets.CF_ORG }}"
+          CR_PAT: "${{ secrets.CR_PAT }}"
+          CR_USERNAME: "${{ secrets.CR_USERNAME }}"
+          PROJECT: "${{ secrets.PROJECT }}"
         run: |
           source ./scripts/pipeline/cloud-gov-login.sh
           cd usagov-2021

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -77,7 +77,8 @@ jobs:
           node-version-file: "./benefit-finder/package.json"
       - name: Set env.BRANCH
         run: |
-          echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV
+          # echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV
+          echo "BRANCH=dev" >> $GITHUB_ENV
       - name: Install basic dependancies
         run: |
           ./scripts/pipeline/deb-basic-deps.sh
@@ -123,7 +124,8 @@ jobs:
           node-version-file: "./benefit-finder/package.json"
       - name: Set env.BRANCH
         run: |
-          echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV
+          # echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV
+          echo "BRANCH=dev" >> $GITHUB_ENV
       - name: Install basic dependancies
         run: ./scripts/pipeline/deb-basic-deps.sh
       - name: Install Cloudfoundry CLI

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -150,7 +150,7 @@ jobs:
           sed -i 's/80/8080/g' Dockerfile-cms
           sed -i 's/ENTRYPOINT/CMD/' Dockerfile-cms
           sed -i 's/\["s3"\]\[\]?/s3\[\]/g' scripts/tome-run.sh scripts/tome-sync.sh
-          sed -i "s,/var/www/scripts/tome-run.sh $URI $@,," > .docker/src-cms/etc/periodic/1min/generate-static-site
+          sed -i "s,/var/www/scripts/tome-run.sh $URI $@,," .docker/src-cms/etc/periodic/1min/generate-static-site
           sed -i 's/80/8080/g' .docker/src-cms/etc/nginx/partials/cms.conf.tmpl
           sed -i "s/\$service\['name'\] === 'database'/stristr(\$service\['name'\], 'mysql')/"  web/sites/default/settings.php
           sed -i "s/\$settings\['hash_salt'\] = \$service\['credentials'\]\['HASH_SALT'\]/\$settings\['hash_salt'\] = \$service\['credentials'\]\['hash_salt'\]/"  web/sites/default/settings.php

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -150,7 +150,7 @@ jobs:
           sed -i 's/80/8080/g' Dockerfile-cms
           sed -i 's/ENTRYPOINT/CMD/' Dockerfile-cms
           sed -i 's/\["s3"\]\[\]?/s3\[\]/g' scripts/tome-run.sh scripts/tome-sync.sh
-          sed -i "s,/var/www/scripts/tome-run.sh $URI $@,," .docker/src-cms/etc/periodic/1min/generate-static-site
+          sed -i "s|/var/www/scripts/tome-run.sh \$URI \$@||" .docker/src-cms/etc/periodic/1min/generate-static-site
           sed -i 's/80/8080/g' .docker/src-cms/etc/nginx/partials/cms.conf.tmpl
           sed -i "s/\$service\['name'\] === 'database'/stristr(\$service\['name'\], 'mysql')/"  web/sites/default/settings.php
           sed -i "s/\$settings\['hash_salt'\] = \$service\['credentials'\]\['HASH_SALT'\]/\$settings\['hash_salt'\] = \$service\['credentials'\]\['hash_salt'\]/"  web/sites/default/settings.php

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,8 +20,7 @@ jobs:
           node-version-file: "./benefit-finder/package.json"
       - name: Set env.BRANCH
         run: |
-          # echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV
-          echo "BRANCH=dev" >> $GITHUB_ENV
+          echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV
       - name: Install PHP
         run: bash ./scripts/pipeline/deb-php-install.sh
       # - name: Install Node.js
@@ -77,8 +76,7 @@ jobs:
           node-version-file: "./benefit-finder/package.json"
       - name: Set env.BRANCH
         run: |
-          # echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV
-          echo "BRANCH=dev" >> $GITHUB_ENV
+          echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV
       - name: Install basic dependancies
         run: |
           ./scripts/pipeline/deb-basic-deps.sh
@@ -124,8 +122,7 @@ jobs:
           node-version-file: "./benefit-finder/package.json"
       - name: Set env.BRANCH
         run: |
-          # echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV
-          echo "BRANCH=dev" >> $GITHUB_ENV
+          echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV
       - name: Install basic dependancies
         run: ./scripts/pipeline/deb-basic-deps.sh
       - name: Install Cloudfoundry CLI


### PR DESCRIPTION
## PR Summary

This PR adds a SED command to the Application configuration step that removes the entry to kick off a tome rebuild of a static site, this is all in an effort to reduce resource utilization as it is no longer required and hopefully stabilize the maintenance pipelines that intermittently fail.

## Related Github Issue
https://github.com/GSA/px-benefit-finder/issues/1393

- Fixes #(issue)
https://github.com/GSA/px-benefit-finder/issues/1393

## Detailed Testing steps

Review logs make sure TOME is not running post deploy.


