### PR TITLE
Change project variable in service key  to uppercase

### DIFF
--- a/.github/workflows/cloudgov-cleanup-old-service-keys.yml
+++ b/.github/workflows/cloudgov-cleanup-old-service-keys.yml
@@ -2,7 +2,7 @@ name: Clean up service keys
 
 on:
   schedule:
-    - cron: '30 4 * * *'
+    - cron: "30 4 * * *"
 
 jobs:
   cleanup-service-keys-dev:
@@ -19,10 +19,10 @@ jobs:
       - name: Cleanup keys (dev)
         shell: bash
         env:
-          CF_USER: '${{ secrets.CF_USER }}'
-          CF_PASSWORD: '${{ secrets.CF_PASSWORD }}'
-          CF_ORG: '${{ secrets.CF_ORG }}'
-          PROJECT: '${{ secrets.project }}'
+          CF_USER: "${{ secrets.CF_USER }}"
+          CF_PASSWORD: "${{ secrets.CF_PASSWORD }}"
+          CF_ORG: "${{ secrets.CF_ORG }}"
+          PROJECT: "${{ secrets.PROJECT }}"
         run: |
           source ./scripts/pipeline/cloud-gov-login.sh
           source ./scripts/pipeline/cloud-gov-cleanup-service-keys.sh
@@ -40,10 +40,11 @@ jobs:
       - name: Cleanup keys (main)
         shell: bash
         env:
-          CF_USER: '${{ secrets.CF_USER }}'
-          CF_PASSWORD: '${{ secrets.CF_PASSWORD }}'
-          CF_ORG: '${{ secrets.CF_ORG }}'
-          PROJECT: '${{ secrets.project }}'
+          CF_USER: "${{ secrets.CF_USER }}"
+          CF_PASSWORD: "${{ secrets.CF_PASSWORD }}"
+          CF_ORG: "${{ secrets.CF_ORG }}"
+          PROJECT: "${{ secrets.PROJECT }}"
         run: |
           source ./scripts/pipeline/cloud-gov-login.sh
           source ./scripts/pipeline/cloud-gov-cleanup-service-keys.sh
+


### PR DESCRIPTION
## PR Summary

These pipelines were failing because the project variable is lower case, changing to upper.

## Related Github Issue

- Fixes #364 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- Monitor daily cron for dev and main make sure they complete sucessfully.
