### PR TITLE
PXBF-1398 updated i element props in notices list

### DIFF
--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
@@ -132,8 +132,9 @@ exports[`loads intro 1`] = `
                     class="bf-notice"
                   >
                     <i
-                      alt="Important"
+                      aria-label="Important"
                       data-testid="icon-info"
+                      role="img"
                     >
                       <svg
                         class="bf-info"
@@ -165,8 +166,9 @@ exports[`loads intro 1`] = `
                     class="bf-notice"
                   >
                     <i
-                      alt="Important"
+                      aria-label="Important"
                       data-testid="icon-info"
+                      role="img"
                     >
                       <svg
                         class="bf-info"
@@ -197,8 +199,9 @@ exports[`loads intro 1`] = `
                     class="bf-notice"
                   >
                     <i
-                      alt="Important"
+                      aria-label="Important"
                       data-testid="icon-info"
+                      role="img"
                     >
                       <svg
                         class="bf-info"

--- a/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.jsx.snap
@@ -118,8 +118,9 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                 class="bf-notice"
               >
                 <i
-                  alt="Important"
+                  aria-label="Important"
                   data-testid="icon-info"
+                  role="img"
                 >
                   <svg
                     class="bf-info"
@@ -151,8 +152,9 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                 class="bf-notice"
               >
                 <i
-                  alt="Important"
+                  aria-label="Important"
                   data-testid="icon-info"
+                  role="img"
                 >
                   <svg
                     class="bf-info"
@@ -183,8 +185,9 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                 class="bf-notice"
               >
                 <i
-                  alt="Important"
+                  aria-label="Important"
                   data-testid="icon-info"
+                  role="img"
                 >
                   <svg
                     class="bf-info"

--- a/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.jsx.snap
@@ -12,8 +12,9 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
         class="bf-notice"
       >
         <i
-          alt="Important"
+          aria-label="Important"
           data-testid="icon-info"
+          role="img"
         >
           <svg
             class="bf-info"
@@ -45,8 +46,9 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
         class="bf-notice"
       >
         <i
-          alt="Important"
+          aria-label="Important"
           data-testid="icon-info"
+          role="img"
         >
           <svg
             class="bf-info"
@@ -77,8 +79,9 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
         class="bf-notice"
       >
         <i
-          alt="Important"
+          aria-label="Important"
           data-testid="icon-info"
+          role="img"
         >
           <svg
             class="bf-info"

--- a/benefit-finder/src/shared/components/NoticesList/index.jsx
+++ b/benefit-finder/src/shared/components/NoticesList/index.jsx
@@ -23,7 +23,7 @@ const NoticesList = ({ data, iconAlt }) => {
       data.data.map((item, i) => {
         return (
           <li className="bf-notice" key={`notice-${i}`}>
-            <Icon type="info" alt={iconAlt} />
+            <Icon type="info" aria-label={iconAlt} role="img" />
             <div
               className="bf-notice-item"
               dangerouslySetInnerHTML={createMarkup(item.notice)}


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This works to update `< i />`  element props in notices list for a better a11y experience

## Related Github Issue

- Fixes #1398 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [x] pull changes locally
- [x] `cd benefit-finder`
- [x] `npm install`
- [x] `npm run start`

<!--- If there are steps for user testing list them here -->

- [x] visit /death
- [x] inspect informational notices list
- [x] ensure `<i />` element includes `aria-label` and `role=img`
- [x] turn on voice over/ NVDA
- [x] navigate notices list items
- [ ] ensure information icons are announced as  "important graphic" or "important image"
