### PR TITLE
1370 new icon a11y snapshot

### DIFF
--- a/benefit-finder/src/shared/components/Icon/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/Icon/__tests__/__snapshots__/index.spec.jsx.snap
@@ -1,5 +1,31 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Icon > provides a label and graphic role when provided in attributes 1`] = `
+<DocumentFragment>
+  <i
+    aria-label="important"
+    data-testid="icon-info"
+    role="img"
+  >
+    <svg
+      class="bf-info"
+      fill="none"
+      height="14"
+      viewBox="0 0 14 14"
+      width="14"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clip-rule="evenodd"
+        d="M6.33594 3.66732H7.66927V5.00065H6.33594V3.66732ZM6.33594 6.33398H7.66927V10.334H6.33594V6.33398ZM7.0026 0.333984C3.3226 0.333984 0.335938 3.32065 0.335938 7.00065C0.335938 10.6807 3.3226 13.6673 7.0026 13.6673C10.6826 13.6673 13.6693 10.6807 13.6693 7.00065C13.6693 3.32065 10.6826 0.333984 7.0026 0.333984ZM7.0026 12.334C4.0626 12.334 1.66927 9.94065 1.66927 7.00065C1.66927 4.06065 4.0626 1.66732 7.0026 1.66732C9.9426 1.66732 12.3359 4.06065 12.3359 7.00065C12.3359 9.94065 9.9426 12.334 7.0026 12.334Z"
+        fill="#1B1B1B"
+        fill-rule="evenodd"
+      />
+    </svg>
+  </i>
+</DocumentFragment>
+`;
+
 exports[`Icon > renders a match to the previous snapshot 1`] = `
 <DocumentFragment>
   <i

--- a/benefit-finder/src/shared/components/Icon/__tests__/index.spec.jsx
+++ b/benefit-finder/src/shared/components/Icon/__tests__/index.spec.jsx
@@ -6,4 +6,11 @@ describe('Icon', () => {
     const { asFragment } = render(<Icon type="close" aria-hidden="true" />)
     expect(asFragment()).toMatchSnapshot()
   })
+
+  it('provides a label and graphic role when provided in attributes', () => {
+    const { asFragment } = render(
+      <Icon type="info" aria-label="important" role="img" />
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
updates snapshots to include coverage for a11y props on `<Icon />` `<i />` elements

## Related Github Issue

- Fixes #1370 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] Front End test are passing
