### PR TITLE
Create backup bastion for more stable backup/restore pipelines

### DIFF
--- a/.github/workflows/database-backup-dev.yml
+++ b/.github/workflows/database-backup-dev.yml
@@ -53,6 +53,7 @@ jobs:
           CF_PASSWORD: "${{ secrets.CF_PASSWORD }}"
           CF_ORG: "${{ secrets.CF_ORG }}"
           PROJECT: "${{ secrets.PROJECT }}"
+          DATABASE_BACKUP_BASTION_NAME: '${{ secrets.DATABASE_BACKUP_BASTION_NAME }}'
         run: |
           export TIMESTAMP=$(date --utc +%FT%TZ | tr ':', '-')
           source ./scripts/pipeline/database-backup.sh

--- a/.github/workflows/database-backup-main.yml
+++ b/.github/workflows/database-backup-main.yml
@@ -53,6 +53,7 @@ jobs:
           CF_PASSWORD: "${{ secrets.CF_PASSWORD }}"
           CF_ORG: "${{ secrets.CF_ORG }}"
           PROJECT: "${{ secrets.PROJECT }}"
+          DATABASE_BACKUP_BASTION_NAME: '${{ secrets.DATABASE_BACKUP_BASTION_NAME }}'
         run: |
           export TIMESTAMP=$(date --utc +%FT%TZ | tr ':', '-')
           source ./scripts/pipeline/database-backup.sh

--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -44,6 +44,7 @@ jobs:
           CF_PASSWORD: '${{ secrets.CF_PASSWORD }}'
           CF_ORG: '${{ secrets.CF_ORG }}'
           PROJECT: '${{ secrets.PROJECT }}'
+          DATABASE_BACKUP_BASTION_NAME: '${{ secrets.DATABASE_BACKUP_BASTION_NAME }}'
         run: |
           export S3_FILE_PATH=${{ github.event.inputs.database_file_override }}
           source ./scripts/pipeline/s3-backup-download.sh

--- a/scripts/pipeline/database-backup.sh
+++ b/scripts/pipeline/database-backup.sh
@@ -22,7 +22,7 @@ wait_for_tunnel() {
 
 ## Create a tunnel through the application to pull the database.
 echo "Creating tunnel to database..."
-cf connect-to-service --no-client "${PROJECT}-cms-${BRANCH}" "${PROJECT}-mysql-${BRANCH}" > backup.txt &
+cf connect-to-service --no-client "${PROJECT}-${DATABASE_BACKUP_BASTION_NAME}-${BRANCH}" "${PROJECT}-mysql-${BRANCH}" > backup.txt &
 
 wait_for_tunnel
 

--- a/scripts/pipeline/database-restore.sh
+++ b/scripts/pipeline/database-restore.sh
@@ -22,7 +22,7 @@ gunzip database_restore.sql.gz
 
 ## Create a tunnel through the application to restore the database.
 echo "Creating tunnel to database..."
-cf connect-to-service --no-client "${PROJECT}-cms-${BRANCH}" "${PROJECT}-mysql-${BRANCH}" > restore.txt &
+cf connect-to-service --no-client "${PROJECT}-${DATABASE_BACKUP_BASTION_NAME}-${BRANCH}" "${PROJECT}-mysql-${BRANCH}" > restore.txt &
 
 wait_for_tunnel
 


### PR DESCRIPTION
## PR Summary

The current backup action tunnels through the CMS server to connect to the database. This update adds an independent application that is used for backups without the CMS server dependency. This will improve reliability, such as when the CMS is having issues and isn't available to tunnel through.

## Related Github Issue
[
#1330 Create backup bastion for more stable backup/restore pipelines](https://github.com/GSA/px-benefit-finder/issues/1330
)