### PR TITLE
PXBF-1452-scale-based-fonts: update fixed size fonts to rem based fonts

### DIFF
--- a/benefit-finder/src/shared/styles/mixins/_index.scss
+++ b/benefit-finder/src/shared/styles/mixins/_index.scss
@@ -1,83 +1,96 @@
+// USAGov font ratio is based on 16px
+// for example h1 @ 2.44rem = 39.04px
+
+// Our conversions
+// 36px = 2.25rem
+// 32px = 2rem
+// 24px = 1.5rem
+// 22px = 1.375rem
+// 20px = 1.25rem
+// 17px = 1.063rem
+// 16px = 1rem
+// 15px = 0.938rem
+
 @mixin h0 {
   font-family: 'Public Sans', sans-serif;
-  font-size: 36px;
+  font-size: 2.25rem;
   font-weight: 800;
   line-height: 100%;
 }
 
 @mixin h1 {
   font-family: 'Public Sans', sans-serif;
-  font-size: 36px;
+  font-size: 2rem;
   font-weight: 800;
   line-height: 100%;
 }
 
 @mixin h2 {
   font-family: 'Public Sans', sans-serif;
-  font-size: 32px;
+  font-size: 1.5rem;
   font-weight: 800;
   line-height: 100%;
 }
 
 @mixin h3 {
   font-family: 'Public Sans', sans-serif;
-  font-size: 32px;
+  font-size: 1.375rem;
   font-weight: 700;
   line-height: 134.09%;
 }
 
 @mixin h4 {
   font-family: 'Public Sans', sans-serif;
-  font-size: 24px;
+  font-size: 1.25rem;
   font-weight: 800;
   line-height: 114.59%;
 }
 
 @mixin h5 {
   font-family: 'Public Sans', sans-serif;
-  font-size: 22px;
+  font-size: 1.375rem;
   font-weight: 700;
   line-height: 134.09%;
 }
 
 @mixin h6 {
   font-family: 'Public Sans', sans-serif;
-  font-size: 20px;
+  font-size: 1.25rem;
   font-weight: 700;
   line-height: 134.09%;
 }
 
 @mixin important-x-bold {
   font-family: 'Public Sans', sans-serif;
-  font-size: 16px;
+  font-size: 1rem;
   font-weight: 800;
   line-height: 134.09%;
 }
 
 @mixin important-bold {
   font-family: 'Public Sans', sans-serif;
-  font-size: 16px;
+  font-size: 1rem;
   font-weight: 700;
   line-height: 134.09%;
 }
 
 @mixin p {
   font-family: 'Public Sans', sans-serif;
-  font-size: 16px;
+  font-size: 1rem;
   font-weight: 400;
   line-height: 18.8px;
 }
 
 @mixin p1 {
   font-family: 'Public Sans', sans-serif;
-  font-size: 16px;
+  font-size: 1rem;
   font-weight: 400;
   line-height: 18.8px;
 }
 
 @mixin p2 {
   font-family: 'Public Sans', sans-serif;
-  font-size: 15px;
+  font-size: 0.938rem;
   font-weight: 400;
   line-height: 18.8px;
 }
@@ -90,7 +103,7 @@
 }
 
 @mixin list-items {
-  font-size: 17px;
+  font-size: 1.063rem;
   font-weight: 400;
   line-height: 26px;
 }


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

## Related Github Issue

- Fixes #1452 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [x] pull changes locally
- [x] build and run application in usagov container

<!--- If there are steps for user testing list them here -->
Chrome: Open Settings or Preferences and change the font size to Very large or Very small.

Previous
Example at "Very Large"
![Image](https://github.com/GSA/px-benefit-finder/assets/37077057/9cbf9623-9735-4e75-bcf9-ba5dd59d6151)

Expected
<img width="1439" alt="Screenshot 2024-06-24 at 12 14 18 PM" src="https://github.com/GSA/px-benefit-finder/assets/37077057/ac343c9d-d5a4-41b6-9404-fb1e72c16420">

