### PR TITLE
exclude blocks from storybook optimized dependencies array

### DIFF
--- a/benefit-finder/vite.config.mjs
+++ b/benefit-finder/vite.config.mjs
@@ -44,6 +44,9 @@ const server = test ? testServer : devServer
 export default defineConfig({
   base: './',
   plugins: [react(), eslint(), copy(copyConfig)],
+  optimizeDeps: {
+    exclude: ['@storybook/blocks'],
+  },
   css: {
     postcss: poscssConfig,
   },


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
some storybook dependencies are not updated for optimization, need to exclude

## Related Github Issue

- Fixes #1480 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
run this before checkout
- [x] `npm run cy:dev:storybook`

<!--- If there are steps for user testing list them here -->
- [x] navigate to colors
- [ ] confirm error in window
- [ ] confirm error in log

```
5:27:12 PM [vite] ✨ new dependencies optimized: @storybook/blocks
5:27:12 PM [vite] ✨ optimized dependencies changed. reloading
The file does not exist at "/Users/geoffreyqueen/Projects/px-benefit-finder/benefit-finder/node_modules/.cache/storybook/c618660f80827dd35effa1ef04c05c3306b9fc456ba25c89973e4ce15789da24/sb-vite/deps/chunk-F3JXEN2X.js?v=d2308db7" which is in the optimize deps directory. The dependency might be incompatible with the dep optimizer. Try adding it to optimizeDeps.exclude.
```

- [ ] stop node server
- [ ] checkout changes from this feature branch
- [ ] `npm run cy:dev:storybook`
- [ ] confirm error is gone

