### PR TITLE
1338 disable auto json file generation in multi-content action

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_api/usagov_benefit_finder_api.module
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_api/usagov_benefit_finder_api.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Batch\BatchBuilder;
+use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\usagov_benefit_finder_api\Controller\LifeEventController;
 
@@ -15,7 +16,13 @@ use Drupal\usagov_benefit_finder_api\Controller\LifeEventController;
  * @param Node $node
  */
 function usagov_benefit_finder_api_node_update(Node $node) {
-  _usagov_benefit_finder_api_batch_generate_json_data_files($node);
+  $url = _usagov_benefit_finder_api_get_current_page_url();
+  if (strpos($url, "/admin/content") === false) {
+    _usagov_benefit_finder_api_batch_generate_json_data_files($node);
+  }
+  else {
+    \Drupal::messenger()->addWarning(t('The system did not generate Benefit Finder JSON files in this action.'));
+  }
 }
 
 /**
@@ -127,4 +134,15 @@ function _usagov_benefit_finder_api_batch_generate_json_data_files(Node $node) {
       batch_set($batch_builder->toArray());
     }
   }
+}
+
+/**
+ * Gets the current page URL.
+ *
+ * @return string
+ *   The current page URL.
+ */
+function _usagov_benefit_finder_api_get_current_page_url() {
+  $current_url = Url::fromRoute('<current>')->toString();
+  return $current_url;
 }


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This work disables auto json file generation for multi-content action, for example Publish content, and displays a warning message.

## Related Github Issue

- Fixes #1338

## Detailed Testing steps

To test in local development site or in dev site.

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] make local development site up at http://localhost
- [ ] navigate to `admin/content?combine=&type=bears_criteria&status=All&langcode=All`
- [ ] select several criteria
- [ ] select "Publish content" in action list

<img width="800" src="https://github.com/GSA/px-benefit-finder/assets/88853916/cb4e9ee3-4b83-430e-8328-b299f8594293">

- [ ] click "Apply to selected items" button
- [ ] verify that the system not generating json files
- [ ] verify that the system displays warning message

<img width="800" src="https://github.com/GSA/px-benefit-finder/assets/88853916/a39b25bc-f9e5-44ea-8ac7-f1b5b2917b99">

<!--- If there are steps for user testing list them here -->