### PR TITLE
1482 structure data layer

### DIFF
--- a/benefit-finder/cypress/e2e/storybook/dataLayer.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/dataLayer.cy.js
@@ -1,130 +1,139 @@
 /// <reference types="cypress" />
 import * as utils from '../../support/utils.js'
+import { dataLayerUtils } from '../../../src/shared/utils'
 import { pageObjects } from '../../support/pageObjects'
 import * as EN_LOCALE_DATA from '../../../../benefit-finder/src/shared/locales/en/en.json'
 import * as BENEFITS_ELIBILITY_DATA from '../../fixtures/benefits-eligibility.json'
 
+const { intro, lifeEventSection, resultsView, benefitCount } =
+  dataLayerUtils.dataLayerStructure
+
 const dataLayerValues = [
   {
-    "event": "bf_page_change",
-    "bfData": {
-        "pageView": "bf-intro",
-        "viewTitle": "Benefit finder: death of a loved one"
+    event: intro.event,
+    bfData: {
+      pageView: intro.bfData.pageView,
+      viewTitle: 'Benefit finder: death of a loved one',
     },
   },
   {
-    "event": "bf_page_change",
-    "bfData": {
-        "pageView": "bf-form",
-        "viewTitle": "About the applicant"
+    event: lifeEventSection.event,
+    bfData: {
+      pageView: `${lifeEventSection.bfData.pageView}-1`,
+      viewTitle: 'About the applicant',
     },
   },
   {
-    "event": "bf_page_change",
-    "bfData": {
-        "pageView": "bf-result-view",
-        "viewTitle": "Your potential benefits",
-        "viewState": "bf-eligible-view"
+    event: resultsView.event,
+    bfData: {
+      pageView: resultsView.bfData.pageView,
+      viewTitle: 'Your potential benefits',
+      viewState: resultsView.bfData.viewState[1],
     },
   },
   {
-    "event": "bf_count",
-    "bfData": {
-        "eligible": 4,
-        "moreInfo": 1,
-        "notEligible": 25
+    event: benefitCount.event,
+    bfData: {
+      eligible: 4,
+      moreInfo: 1,
+      notEligible: 25,
     },
-  }
-
+  },
 ]
 
 describe('Basic Data Layer Checks', () => {
   it('has a dataLayer and loads GTM', () => {
     cy.visit(utils.storybookUri)
-    cy.window().then((window) => {
-      assert.isDefined(window.dataLayer,
-        'window.dataLayer is defined');
+    cy.window().then(window => {
+      assert.isDefined(window.dataLayer, 'window.dataLayer is defined')
 
       assert.isDefined(
-        window.dataLayer.find(x => x.event === "gtm.js"),
-        "GTM is loaded");
+        window.dataLayer.find(x => x.event === 'gtm.js'),
+        'GTM is loaded'
+      )
     })
-  });
-});
+  })
+})
 
+describe('Calls to Google Analytics Object', function () {
+  it('homepage has a bf_page_change event', function () {
+    cy.visit(utils.storybookUri)
 
-describe('Calls to Google Analytics Object', function() {
+    cy.window().then(window => {
+      assert.isDefined(window.dataLayer, 'window.dataLayer is defined')
 
+      pageObjects
+        .button()
+        .contains(EN_LOCALE_DATA.intro.button)
+        .then(() => {
+          // get the last pushed event
+          const ev = { ...window.dataLayer[window.dataLayer.length - 1] }
+          delete ev['gtm.uniqueEventId']
 
-    it('homepage has a bf_page_change event', function() {
-        cy.visit(utils.storybookUri)
-
-        cy.window().then((window) => {
-          assert.isDefined(window.dataLayer,
-            'window.dataLayer is defined');
-
-            pageObjects.button().contains(EN_LOCALE_DATA.intro.button).then(() => {
-                // get the last pushed event
-                const ev = window.dataLayer[window.dataLayer.length - 1]
-
-                delete ev["gtm.uniqueEventId"]
-                expect(dataLayerValues[0]).to.deep.equal(ev)
-            })
+          expect(ev).to.deep.equal(dataLayerValues[0])
         })
-    });
+    })
+  })
 
-    it('homepage has a bf_page_change event', function() {
-        cy.visit(utils.storybookUri)
-        pageObjects.button().contains(EN_LOCALE_DATA.intro.button).click()
+  it('homepage has a bf_page_change event', function () {
+    cy.visit(utils.storybookUri)
+    pageObjects.button().contains(EN_LOCALE_DATA.intro.button).click()
 
-        cy.window().then((window) => {
-          assert.isDefined(window.dataLayer,
-            'window.dataLayer is defined');
+    cy.window().then(window => {
+      assert.isDefined(window.dataLayer, 'window.dataLayer is defined')
 
-            pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).then(() => {
-                // get the last pushed event
-                const ev = window.dataLayer[window.dataLayer.length - 1]
+      pageObjects
+        .button()
+        .contains(EN_LOCALE_DATA.buttonGroup[1].value)
+        .then(() => {
+          // get the last pushed event
+          const ev = { ...window.dataLayer[window.dataLayer.length - 1] }
+          delete ev['gtm.uniqueEventId']
 
-                delete ev["gtm.uniqueEventId"]
-                expect(dataLayerValues[1]).to.deep.equal(ev)
-            })
+          expect(dataLayerValues[1]).to.deep.equal(ev)
         })
-    });
+    })
+  })
 
+  it('results page has a bf_page_change and bf_count events', function () {
+    const selectedData = BENEFITS_ELIBILITY_DATA.scenario_1_covid.en.param
+    const enResults = BENEFITS_ELIBILITY_DATA.scenario_1_covid.en.results
+    const scenario = utils.encodeURIFromObject(selectedData)
+    cy.visit(`${utils.storybookUri}${scenario}`)
 
-    it('results page has a bf_page_change and bf_count events', function() {
-        const selectedData = BENEFITS_ELIBILITY_DATA.scenario_1_covid.en.param
-        const enResults = BENEFITS_ELIBILITY_DATA.scenario_1_covid.en.results
-        const scenario = utils.encodeURIFromObject(selectedData)
-        cy.visit(`${utils.storybookUri}${scenario}`)
+    cy.window().then(window => {
+      assert.isDefined(window.dataLayer, 'window.dataLayer is defined')
 
-        cy.window().then((window) => {
-          assert.isDefined(window.dataLayer,
-            'window.dataLayer is defined');
+      pageObjects
+        .benefitsAccordion()
+        .filter(':visible')
+        .should('have.length', enResults.eligible.length)
+        .then(() => {
+          // we wait for the last event to fire
+          // eslint-disable-next-line cypress/no-unnecessary-waiting
+          cy.wait(100).then(() => {
+            // check last page change event
+            const ev = {
+              ...window.dataLayer.filter(
+                x => x?.event === dataLayerValues[2].event
+              ),
+            }
+            delete ev[0]['gtm.uniqueEventId']
 
-          pageObjects
-            .benefitsAccordion()
-            .filter(':visible')
-            .should('have.length', enResults.eligible.length)
-            .then(() => {
+            expect(dataLayerValues[2]).to.deep.equal(ev[0])
 
-                // we wait for the last event to fire
-                // eslint-disable-next-line cypress/no-unnecessary-waiting
-                cy.wait(100).then(() => {
+            // // check count event
+            const evCount = {
+              ...window.dataLayer.filter(
+                x => x.event === dataLayerValues[3].event
+              ),
+            }
 
-                // check last page change event
-                const ev = window.dataLayer.filter(x => x?.bfData?.pageView === dataLayerValues[2].bfData.pageView)
+            delete evCount[0]['gtm.uniqueEventId']
 
-                delete ev[0]["gtm.uniqueEventId"]
-                expect(dataLayerValues[2]).to.deep.equal(ev[0])
-
-                // check count event
-                const evCount = window.dataLayer.filter(x => x.event === dataLayerValues[3].event)
-
-                delete evCount[0]["gtm.uniqueEventId"]
-                expect(dataLayerValues[3]).to.deep.equal(evCount[0])
-                })
-            })
+            expect(dataLayerValues[3]).to.deep.equal(evCount[0])
+          })
         })
-    });
+    })
+  })
 })

--- a/benefit-finder/src/shared/components/Intro/index.jsx
+++ b/benefit-finder/src/shared/components/Intro/index.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import { dataLayerUtils } from '../../utils'
 import { useResetElement } from '../../hooks'
 import PropTypes from 'prop-types'
 import {
@@ -24,7 +25,6 @@ import './_index.scss'
 const Intro = ({ data, ui, setStep, step }) => {
   const { timeEstimate, title, summary } = data
   const { heading, timeIndicator, steps, notices, button } = ui
-  // const resetElements = document.querySelectorAll('[tabindex="-1"]')
   const resetElement = useResetElement()
 
   const handleStep = () => {
@@ -34,11 +34,11 @@ const Intro = ({ data, ui, setStep, step }) => {
 
   // handle dataLayer
   useEffect(() => {
-    window.dataLayer &&
-      window.dataLayer.push({
-        event: 'bf_page_change',
-        bfData: { pageView: 'bf-intro', viewTitle: title },
-      })
+    const { intro } = dataLayerUtils.dataLayerStructure
+    dataLayerUtils.dataLayerPush(window, {
+      event: intro.event,
+      bfData: { pageView: intro.bfData.pageView, viewTitle: title },
+    })
   }, [])
 
   return (

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, Fragment } from 'react'
 import PropTypes from 'prop-types'
-import { dateInputValidation, createMarkup } from '../../utils'
+import { dateInputValidation, createMarkup, dataLayerUtils } from '../../utils'
 import { useHandleUnload, useResetElement } from '../../hooks'
 import * as apiCalls from '../../api/apiCalls'
 import {
@@ -261,25 +261,13 @@ const LifeEventSection = ({
 
   // handle dataLayer
   useEffect(() => {
-    window.dataLayer &&
-      window.dataLayer.push({
-        event: 'bf_page_change',
+    const { lifeEventSection } = dataLayerUtils.dataLayerStructure
+    modalOpen === false &&
+      dataLayerUtils.dataLayerPush(window, {
+        event: lifeEventSection.event,
         bfData: {
-          pageView: 'bf-form',
+          pageView: `${lifeEventSection.bfData.pageView}-${step}`,
           viewTitle: currentData.section.heading,
-        },
-      })
-  }, [])
-
-  useEffect(() => {
-    modalOpen === true &&
-      window.dataLayer &&
-      window.dataLayer.push({
-        event: 'bf_modal_open',
-        bfData: {
-          pageView: 'bf-form',
-          viewTitle: currentData.section.heading,
-          modalOpen,
         },
       })
   }, [])

--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react'
 import NavModal from 'react-modal'
 import PropTypes from 'prop-types'
 import { Button, ObfuscatedLink, Icon, Heading } from '../index'
-import { scrollLock } from '../../utils'
+import { scrollLock, dataLayerUtils } from '../../utils'
 
 import './_index.scss'
 
@@ -98,6 +98,18 @@ const Modal = ({
     // set our application root id here
     NavModal.setAppElement('#benefit-finder')
     return cleanUp()
+  }, [])
+
+  // handle dataLayer
+  useEffect(() => {
+    const { modal } = dataLayerUtils.dataLayerStructure
+    modalOpen === true &&
+      dataLayerUtils.dataLayerPush(window, {
+        event: modal.event,
+        bfData: {
+          modalOpen,
+        },
+      })
   }, [])
 
   /**

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -110,31 +110,32 @@ const ResultsView = ({
   // handle dataLayer
   useEffect(() => {
     const { resultsView } = dataLayerUtils.dataLayerStructure
-    dataLayerUtils.dataLayerPush(window, {
-      event: resultsView.event,
-      bfData: {
-        pageView: resultsView.bfData.pageView,
-        viewTitle:
-          notEligibleView === false
-            ? (zeroBenefitsResult && zeroBenefits.chevron.heading) ||
-              eligible.chevron.heading
-            : (zeroBenefitsResult && zeroBenefits.chevron.heading) ||
-              notEligible.chevron.heading,
-        viewState:
-          notEligibleView === true
-            ? (zeroBenefitsResult && resultsView.bfData.viewState[2]) ||
-              resultsView.bfData.viewState[0]
-            : (zeroBenefitsResult && resultsView.bfData.viewState[3]) ||
-              resultsView.bfData.viewState[1],
-      },
-    })
-  }, [notEligibleView])
+    eligibilityCount.notEligible >= 0 &&
+      dataLayerUtils.dataLayerPush(window, {
+        event: resultsView.event,
+        bfData: {
+          pageView: resultsView.bfData.pageView,
+          viewTitle:
+            notEligibleView === false
+              ? (zeroBenefitsResult && zeroBenefits.chevron.heading) ||
+                eligible.chevron.heading
+              : (zeroBenefitsResult && zeroBenefits.chevron.heading) ||
+                notEligible.chevron.heading,
+          viewState:
+            notEligibleView === true
+              ? (zeroBenefitsResult && resultsView.bfData.viewState[2]) ||
+                resultsView.bfData.viewState[0]
+              : (zeroBenefitsResult && resultsView.bfData.viewState[3]) ||
+                resultsView.bfData.viewState[1],
+        },
+      })
+  }, [notEligibleView, eligibilityCount])
 
   // handle dataLayer
   useEffect(() => {
     const { benefitCount } = dataLayerUtils.dataLayerStructure
     eligibilityCount.notEligible >= 0 &&
-      dataLayerUtils.dataLayerPush({
+      dataLayerUtils.dataLayerPush(window, {
         event: benefitCount.event,
         bfData: eligibilityCount,
       })

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -116,12 +116,16 @@ const ResultsView = ({
         pageView: resultsView.bfData.pageView,
         viewTitle:
           notEligibleView === false
-            ? eligible.chevron.heading
-            : notEligible.chevron.heading,
+            ? (zeroBenefitsResult && zeroBenefits.chevron.heading) ||
+              eligible.chevron.heading
+            : (zeroBenefitsResult && zeroBenefits.chevron.heading) ||
+              notEligible.chevron.heading,
         viewState:
           notEligibleView === true
-            ? resultsView.bfData.viewState[0]
-            : resultsView.bfData.viewState[1],
+            ? (zeroBenefitsResult && resultsView.bfData.viewState[2]) ||
+              resultsView.bfData.viewState[0]
+            : (zeroBenefitsResult && resultsView.bfData.viewState[3]) ||
+              resultsView.bfData.viewState[1],
       },
     })
   }, [notEligibleView])

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -13,7 +13,7 @@ import {
   RelativeBenefitList,
   Summary,
 } from '../index'
-import { createMarkup } from '../../utils'
+import { createMarkup, dataLayerUtils } from '../../utils'
 import './_index.scss'
 
 /**
@@ -104,27 +104,31 @@ const ResultsView = ({
 
   // handle dataLayer
   useEffect(() => {
-    window.dataLayer &&
-      window.dataLayer.push({
-        event: 'bf_page_change',
-        bfData: {
-          pageView: 'bf-result-view',
-          viewTitle:
-            notEligibleView === false
-              ? eligible.chevron.heading
-              : notEligible.chevron.heading,
-          viewState:
-            notEligibleView === true
-              ? 'bf-not-eligible-view'
-              : 'bf-eligible-view',
-        },
-      })
+    const { resultsView } = dataLayerUtils.dataLayerStructure
+    dataLayerUtils.dataLayerPush(window, {
+      event: resultsView.event,
+      bfData: {
+        pageView: resultsView.bfData.pageView,
+        viewTitle:
+          notEligibleView === false
+            ? eligible.chevron.heading
+            : notEligible.chevron.heading,
+        viewState:
+          notEligibleView === true
+            ? resultsView.bfData.viewState[0]
+            : resultsView.bfData.viewState[1],
+      },
+    })
   }, [notEligibleView])
 
+  // handle dataLayer
   useEffect(() => {
+    const { benefitCount } = dataLayerUtils.dataLayerStructure
     eligibilityCount.notEligible >= 0 &&
-      window.dataLayer &&
-      window.dataLayer.push({ event: 'bf_count', bfData: eligibilityCount })
+      dataLayerUtils.dataLayerPush({
+        event: benefitCount.event,
+        bfData: eligibilityCount,
+      })
   }, [eligibilityCount])
 
   // compare the selected criteria array with benefits

--- a/benefit-finder/src/shared/components/VerifySelectionsView/index.jsx
+++ b/benefit-finder/src/shared/components/VerifySelectionsView/index.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import PropTypes from 'prop-types'
-import { parseDate } from '../../utils'
+import { parseDate, dataLayerUtils } from '../../utils'
 import * as apiCalls from '../../api/apiCalls'
 import { Heading, Button } from '../index'
 
@@ -109,14 +109,14 @@ const VerifySelectionsView = ({
 
   // handle dataLayer
   useEffect(() => {
-    window.dataLayer &&
-      window.dataLayer.push({
-        event: 'bf_page_change',
-        bfData: {
-          pageView: 'bf-verify-selections',
-          viewTitle: verifySelectionsView?.heading,
-        },
-      })
+    const { verifySelections } = dataLayerUtils.dataLayerStructure
+    dataLayerUtils.dataLayerPush(window, {
+      event: verifySelections.event,
+      bfData: {
+        pageView: verifySelections.bfData.pageView,
+        viewTitle: verifySelectionsView?.heading,
+      },
+    })
   }, [])
 
   return (

--- a/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerPush.js
+++ b/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerPush.js
@@ -30,7 +30,9 @@ const dataLayerPush = (w, dataLayerObj, dedup) => {
 
   if (w.dataLayer) {
     // get the last index of the dataLayer array
-    const lastItem = window.dataLayer[window.dataLayer.length - 1]
+    const lastItem = { ...window.dataLayer[window.dataLayer.length - 1] }
+
+    delete lastItem['gtm.uniqueEventId']
 
     // to prevent pushing duplicate objects unecessarily, as long as our last item doesn't match our current data obj, we push
     isDeepEqual(lastItem, dataLayerObj) === false &&

--- a/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerPush.js
+++ b/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerPush.js
@@ -1,0 +1,41 @@
+const dataLayerPush = (w, dataLayerObj, dedup) => {
+  const isObject = object => {
+    return object != null && typeof object === 'object'
+  }
+
+  const isDeepEqual = (object1, object2) => {
+    // get the keys of our two objects
+    const objKeys1 = Object.keys(object1)
+    const objKeys2 = Object.keys(object2)
+
+    // if they have a different length we can return early
+    if (objKeys1.length !== objKeys2.length) return false
+
+    // compare each key
+    for (const key of objKeys1) {
+      const value1 = object1[key]
+      const value2 = object2[key]
+
+      const isObjects = isObject(value1) && isObject(value2)
+
+      if (
+        (isObjects && !isDeepEqual(value1, value2)) ||
+        (!isObjects && value1 !== value2)
+      ) {
+        return false
+      }
+    }
+    return true
+  }
+
+  if (w.dataLayer) {
+    // get the last index of the dataLayer array
+    const lastItem = window.dataLayer[window.dataLayer.length - 1]
+
+    // to prevent pushing duplicate objects unecessarily, as long as our last item doesn't match our current data obj, we push
+    isDeepEqual(lastItem, dataLayerObj) === false &&
+      w.dataLayer.push(dataLayerObj)
+  }
+}
+
+export default dataLayerPush

--- a/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
+++ b/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
@@ -1,0 +1,37 @@
+const dataLayerStructure = {
+  intro: {
+    event: 'bf_page_change',
+    bfData: { pageView: 'bf-intro', viewTitle: null },
+  },
+  lifeEventSection: {
+    event: 'bf_page_change',
+    bfData: {
+      pageView: 'bf-form',
+      viewTitle: null,
+    },
+  },
+  modal: {
+    event: 'bf_modal_open',
+    bfData: {
+      modalOpen: false,
+    },
+  },
+  verifySelections: {
+    event: 'bf_page_change',
+    bfData: {
+      pageView: 'bf-verify-selections',
+      viewTitle: null,
+    },
+  },
+  resultsView: {
+    event: 'bf_page_change',
+    bfData: {
+      pageView: 'bf-result-view',
+      viewTitle: null,
+      viewState: ['bf-not-eligible-view', 'bf-eligible-view'],
+    },
+  },
+  benefitCount: { event: 'bf_count', bfData: null },
+}
+
+export default dataLayerStructure

--- a/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
+++ b/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
@@ -40,21 +40,3 @@ const dataLayerStructure = {
 }
 
 export default dataLayerStructure
-
-// {
-// event: 'bf_page_change',
-// bfData: {
-//   pageView: 'bf-result-view',
-//   viewTitle:
-//     notEligibleView === false
-//       ? (zeroBenefitsResult && zeroBenefits.chevron.heading) ||
-//         eligible.chevron.heading
-//       : (zeroBenefitsResult && zeroBenefits.chevron.heading) ||
-//         notEligible.chevron.heading,
-//   viewState:
-//     notEligibleView === true
-//       ? (zeroBenefitsResult && 'bf-not-eligible-view-zero-benefits') ||
-//         'bf-not-eligible-view'
-//       : (zeroBenefitsResult && 'bf-eligible-view-zero-benefits') ||
-//         'bf-eligible-view',
-// }

--- a/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
+++ b/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
@@ -28,10 +28,33 @@ const dataLayerStructure = {
     bfData: {
       pageView: 'bf-result-view',
       viewTitle: null,
-      viewState: ['bf-not-eligible-view', 'bf-eligible-view'],
+      viewState: [
+        'bf-not-eligible-view',
+        'bf-eligible-view',
+        'bf-not-eligible-view-zero-benefits',
+        'bf-eligible-view-zero-benefits',
+      ],
     },
   },
   benefitCount: { event: 'bf_count', bfData: null },
 }
 
 export default dataLayerStructure
+
+// {
+// event: 'bf_page_change',
+// bfData: {
+//   pageView: 'bf-result-view',
+//   viewTitle:
+//     notEligibleView === false
+//       ? (zeroBenefitsResult && zeroBenefits.chevron.heading) ||
+//         eligible.chevron.heading
+//       : (zeroBenefitsResult && zeroBenefits.chevron.heading) ||
+//         notEligible.chevron.heading,
+//   viewState:
+//     notEligibleView === true
+//       ? (zeroBenefitsResult && 'bf-not-eligible-view-zero-benefits') ||
+//         'bf-not-eligible-view'
+//       : (zeroBenefitsResult && 'bf-eligible-view-zero-benefits') ||
+//         'bf-eligible-view',
+// }

--- a/benefit-finder/src/shared/utils/dataLayerUtils/index.js
+++ b/benefit-finder/src/shared/utils/dataLayerUtils/index.js
@@ -1,0 +1,4 @@
+import dataLayerPush from './dataLayerPush.js'
+import dataLayerStructure from './dataLayerStructure.js'
+
+export default { dataLayerPush, dataLayerStructure }

--- a/benefit-finder/src/shared/utils/index.js
+++ b/benefit-finder/src/shared/utils/index.js
@@ -1,5 +1,6 @@
 export { default as buildURIParameter } from './buildURIParameter'
 export { default as createMarkup } from './createMarkup'
+export { default as dataLayerUtils } from './dataLayerUtils'
 export { default as dateInputValidation } from './dateInputValidation'
 export { default as parseDate } from './parseDate'
 export { default as scrollLock } from './scrollLock'


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This works to move our dataLayer structure into an export object so the values can be maintained from an organized location

## Related Github Issue

- Fixes #1482 

When the work was restructured additional updates were made to resolve the following items

- Fixes #1478 
- Fixes #1468 
- Fixes #1477 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [x] pull changes locally
- [x] `cd benefit-finder`
- [x] `npm install`
- [x] `npm run start`


User Testing
<!--- If there are steps for user testing list them here -->
- [x] navigate to `/death`
- [x] apply values to all required fields
- [x] for all radio inputs, select `NO` ( this ensures no benefits view)
- [x] console.log(window.dataLayer)

you should end up with an array of objects that follow this format

```
[
    {
        "nodeID": "1984",
        "contentType": "basic_page",
        "language": "en",
        "homepageTest": "not_homepage",
        "basicPagesubType": "Navigation Page"
    },
    {
        "event": "bf_page_change",
        "bfData": {
            "pageView": "bf-intro",
            "viewTitle": "Benefit finder: death of a loved one"
        }
    },
    {
        "event": "bf_page_change",
        "bfData": {
            "pageView": "bf-form-1",
            "viewTitle": "About the applicant"
        }
    },
    {
        "event": "bf_page_change",
        "bfData": {
            "pageView": "bf-form-2",
            "viewTitle": "About the deceased"
        }
    },
    {
        "event": "bf_modal_open",
        "bfData": {
            "modalOpen": true
        }
    },
    {
        "event": "bf_page_change",
        "bfData": {
            "pageView": "bf-verify-selections",
            "viewTitle": "Review and confirm"
        }
    },
    {
        "event": "bf_page_change",
        "bfData": {
            "pageView": "bf-result-view",
            "viewTitle": "You are likely not eligible for benefits",
            "viewState": "bf-eligible-view-zero-benefits"
        }
    },
    {
        "event": "bf_count",
        "bfData": {
            "eligible": 0,
            "moreInfo": 0,
            "notEligible": 30
        }
    },
    {
        "event": "bf_page_change",
        "bfData": {
            "pageView": "bf-result-view",
            "viewTitle": "You are likely not eligible for benefits",
            "viewState": "bf-not-eligible-view-zero-benefits"
        }
    }
]
```

- [x] confirm that our `bf_page_change` event is `bf-eligible-view-zero-benefits`

```
    {
        "event": "bf_page_change",
        "bfData": {
            "pageView": "bf-result-view",
            "viewTitle": "You are likely not eligible for benefits",
            "viewState": "bf-eligible-view-zero-benefits"
        }
    },
```

- [x] confirm that in the count we have `0` eligible benefits

```
    {
        "event": "bf_count",
        "bfData": {
            "eligible": 0,
            "moreInfo": 0,
            "notEligible": 30
        }
    },
```

- [x] confirm inital load dataLayer object that comes from USAGov node

 // Initial load from USAGov node page

```
    {
        "nodeID": "1984",
        "contentType": "basic_page",
        "language": "en",
        "homepageTest": "not_homepage",
        "basicPagesubType": "Navigation Page"
    },
```


 // Initial load from BF application intro view

- [x] To test for #1468 , please confirm here that only (1)`"event": "bf_page_change"` event has fired at this location in the array

```
    {
        "event": "bf_page_change",
        "bfData": {
            "pageView": "bf-intro",
            "viewTitle": "Benefit finder: death of a loved one"
        }
    },
```

// incrementing steps values as pageView numerics in the dataLayer 

- [ ]To test for #1477 , we should confirm that each step has incrmented in the `"pageView": "bf-form-{step}"` value, in this case we have two steps in the form

```
    {
        "event": "bf_page_change",
        "bfData": {
            "pageView": "bf-form-1",
            "viewTitle": "About the applicant"
        }
    },
    {
        "event": "bf_page_change",
        "bfData": {
            "pageView": "bf-form-2",
            "viewTitle": "About the deceased"
        }
    },
```

- [x] To test #1478, we should only see the `"event": "bf_modal_open"`, has been pushed by itself, we should not have additional pushes of `"event": "bf_page_change"` with the value of `"pageView": "bf-form-2"` having been pushed again

```
    {
        "event": "bf_modal_open",
        "bfData": {
            "modalOpen": true
        }
    },
```

- [x] navigate back to the beginning of the form by pressing the back link at the top of each view

<img width="701" alt="Screenshot 2024-06-25 at 1 55 07 PM" src="https://github.com/GSA/px-benefit-finder/assets/37077057/0375892c-086c-49ec-9c69-259c20e095d1">

- [x] for all radio inputs, select `YES` ( this ensures an eligible benefits view)
- [x] console.log(window.dataLayer)

you should end up with additional objects in the array that follow this format

```
[
  ...
    {
        "event": "bf_page_change",
        "bfData": {
            "pageView": "bf-form-2",
            "viewTitle": "About the deceased"
        }
    },
    {
        "event": "bf_page_change",
        "bfData": {
            "pageView": "bf-form-1",
            "viewTitle": "About the applicant"
        }
    },
    {
        "event": "bf_page_change",
        "bfData": {
            "pageView": "bf-form-2",
            "viewTitle": "About the deceased"
        }
    },
    {
        "event": "bf_modal_open",
        "bfData": {
            "modalOpen": true
        }
    },
    {
        "event": "bf_page_change",
        "bfData": {
            "pageView": "bf-verify-selections",
            "viewTitle": "Review and confirm"
        }
    },
    {
        "event": "bf_page_change",
        "bfData": {
            "pageView": "bf-result-view",
            "viewTitle": "Your potential benefits",
            "viewState": "bf-eligible-view"
        }
    },
    {
        "event": "bf_count",
        "bfData": {
            "eligible": 5,
            "moreInfo": 11,
            "notEligible": 14
        }
    },
    {
        "event": "bf_page_change",
        "bfData": {
            "pageView": "bf-result-view",
            "viewTitle": "Benefits you did not qualify for",
            "viewState": "bf-not-eligible-view"
        }
    }
]
```

- [x] confirm that our `bf_page_change` event is `bf-eligible-view`

```
    {
        "event": "bf_page_change",
        "bfData": {
            "pageView": "bf-result-view",
            "viewTitle": "Your potential benefits",
            "viewState": "bf-eligible-view"
        }
    },
```

- [x] confirm that in the count we have eligible benefits

```
    {
        "event": "bf_count",
        "bfData": {
            "eligible": 5,
            "moreInfo": 11,
            "notEligible": 14
        }
    },
```