### PR TITLE
Release v0.4.1.beta.1

### DIFF
--- a/benefit-finder/package-lock.json
+++ b/benefit-finder/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "benefit-finder",
-  "version": "0.4.0.beta.1",
+  "version": "0.4.1.beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "benefit-finder",
-      "version": "0.4.0.beta.1",
+      "version": "0.4.1.beta.1",
       "hasInstallScript": true,
       "dependencies": {
         "@uswds/uswds": "^3.8.1",

--- a/benefit-finder/package.json
+++ b/benefit-finder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "benefit-finder",
-  "version": "0.4.0.beta.1",
+  "version": "0.4.1.beta.1",
   "private": true,
   "engines": {
     "node": "20.x.x"

--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
@@ -12,7 +12,7 @@ exports[`loads intro 1`] = `
     <div
       class="benefit-finder "
       data-testid="app"
-      data-version="0.4.0.beta.1"
+      data-version="0.4.1.beta.1"
     >
       <div
         class="bf-intro"
@@ -270,7 +270,7 @@ exports[`loads window query scenario 1 1`] = `
     <div
       class="benefit-finder "
       data-testid="app"
-      data-version="0.4.0.beta.1"
+      data-version="0.4.1.beta.1"
     >
       <div
         class="bf-result-view"
@@ -7026,7 +7026,7 @@ exports[`loads window query scenario 2 1`] = `
     <div
       class="benefit-finder "
       data-testid="app"
-      data-version="0.4.0.beta.1"
+      data-version="0.4.1.beta.1"
     >
       <div
         class="bf-result-view"

--- a/restore.txt
+++ b/restore.txt
@@ -1,0 +1,12 @@
+Finding the service instance details...
+Setting up SSH tunnel...
+SSH tunnel created.
+Skipping call to client CLI. Connection information:
+
+Host: localhost
+Port: 44265
+Username: u1pqgr5amf7bbsm3
+Password: o95jv0wxlkynbk5qx7fxbmc6o
+Name: cgawsbrokerprodoly1e52tnaanm56
+
+Leave this terminal open while you want to use the SSH tunnel. Press Control-C to stop.

--- a/usagov_benefit_finder/configuration/core.entity_form_display.node.bears_life_event.default.yml
+++ b/usagov_benefit_finder/configuration/core.entity_form_display.node.bears_life_event.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.bears_life_event.field_b_id
+    - field.field.node.bears_life_event.field_b_search_title
     - field.field.node.bears_life_event.field_draft_json_data_file
     - field.field.node.bears_life_event.field_draft_json_data_file_path
     - field.field.node.bears_life_event.field_header_html
@@ -28,7 +29,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 9
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -40,16 +41,24 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_b_search_title:
+    type: string_textfield
+    weight: 7
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_draft_json_data_file:
     type: file_generic
-    weight: 20
+    weight: 21
     region: content
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
   field_draft_json_data_file_path:
     type: string_textfield
-    weight: 18
+    weight: 19
     region: content
     settings:
       size: 60
@@ -57,7 +66,7 @@ content:
     third_party_settings: {  }
   field_header_html:
     type: text_textarea
-    weight: 21
+    weight: 22
     region: content
     settings:
       rows: 5
@@ -68,14 +77,14 @@ content:
         hide_guidelines: '0'
   field_json_data_file:
     type: file_generic
-    weight: 19
+    weight: 20
     region: content
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
   field_json_data_file_path:
     type: string_textfield
-    weight: 17
+    weight: 18
     region: content
     settings:
       size: 60
@@ -117,7 +126,7 @@ content:
     third_party_settings: {  }
   field_summary:
     type: string_textarea
-    weight: 7
+    weight: 8
     region: content
     settings:
       rows: 5
@@ -132,38 +141,38 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 15
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 12
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 10
+    weight: 11
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   simple_sitemap:
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 16
+    weight: 17
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 11
+    weight: 12
     region: content
     settings:
       display_label: true
@@ -183,7 +192,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 8
+    weight: 9
     region: content
     settings:
       match_operator: CONTAINS
@@ -192,7 +201,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_life_event.default.yml
+++ b/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_life_event.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.bears_life_event.field_b_id
+    - field.field.node.bears_life_event.field_b_search_title
     - field.field.node.bears_life_event.field_draft_json_data_file
     - field.field.node.bears_life_event.field_draft_json_data_file_path
     - field.field.node.bears_life_event.field_header_html
@@ -36,6 +37,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 2
+    region: content
+  field_b_search_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 12
     region: content
   field_draft_json_data_file:
     type: file_default

--- a/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_life_event.teaser.yml
+++ b/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_life_event.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.bears_life_event.field_b_id
+    - field.field.node.bears_life_event.field_b_search_title
     - field.field.node.bears_life_event.field_draft_json_data_file
     - field.field.node.bears_life_event.field_draft_json_data_file_path
     - field.field.node.bears_life_event.field_header_html
@@ -35,6 +36,7 @@ content:
     region: content
 hidden:
   field_b_id: true
+  field_b_search_title: true
   field_draft_json_data_file: true
   field_draft_json_data_file_path: true
   field_header_html: true

--- a/usagov_benefit_finder/configuration/field.field.node.bears_life_event.field_b_search_title.yml
+++ b/usagov_benefit_finder/configuration/field.field.node.bears_life_event.field_b_search_title.yml
@@ -1,0 +1,19 @@
+uuid: 4cfe5edb-4b13-42ac-98b0-3cd6416cd289
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_search_title
+    - node.type.bears_life_event
+id: node.bears_life_event.field_b_search_title
+field_name: field_b_search_title
+entity_type: node
+bundle: bears_life_event
+label: 'Search Title'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_benefit_finder/configuration/field.storage.node.field_b_search_title.yml
+++ b/usagov_benefit_finder/configuration/field.storage.node.field_b_search_title.yml
@@ -1,0 +1,25 @@
+uuid: ee685fe0-3e6b-4b9a-8c8a-d1733cd1dabd
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_b_search_title
+field_name: field_b_search_title
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
@@ -300,3 +300,92 @@ function _usagov_benefit_finder_content_check_criteria_usage_in_benefit(int $nid
 
   return $return;
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * @param array $form
+ *   Form array.
+ * @param FormStateInterface $form_state
+ *   Form state object.
+ */
+function usagov_benefit_finder_content_form_node_bears_criteria_edit_form_alter(array &$form, FormStateInterface $form_state) {
+  $form['#validate'][] = '_usagov_benefit_finder_content_node_bears_criteria_edit_form_validate';
+}
+
+/**
+ * Validates criteria edit form hasChild field.
+ *
+ * @param array $form
+ *   Form array.
+ * @param FormStateInterface $form_state
+ *   Form state object.
+ */
+function _usagov_benefit_finder_content_node_bears_criteria_edit_form_validate(array $form, FormStateInterface $form_state) {
+  $errors = [];
+  $error_count = 0;
+
+  $has_child = $form_state->getValue('field_b_has_child');
+
+  if ($has_child['value']) {
+    return;
+  }
+
+  $node = \Drupal::routeMatch()->getParameter('node');
+  $nid = $node->id();
+
+  $result = _usagov_benefit_finder_content_check_criteria_has_child($nid);
+  if (!empty($result)) {
+    foreach ($result as $row) {
+      $errors[] = t("Can not uncheck \"Has Child\" field. There are related child values in the Life event form: $row[title] ($row[nid])");
+    }
+  }
+
+  if (!empty($errors)) {
+    foreach ($errors as $error) {
+      $form_state->setErrorByName((string) ++$error_count, $error);
+    }
+  }
+}
+
+/**
+ * It checks if criteria has child.
+ *
+ * @param int $nid
+ *   Node ID of given criteria.
+ */
+function _usagov_benefit_finder_content_check_criteria_has_child(int $nid) {
+  $return = [];
+
+  $connection = Database::getConnection();
+
+  $query = $connection->select('paragraph__field_b_children', 't');
+  $query->fields('t', ['entity_id']);
+  $query->condition('t.bundle', 'b_levent_elg_criteria');
+  $result = $query->execute();
+
+  $entity_ids = [];
+  foreach ($result as $row) {
+    $entity_ids[] = $row->entity_id;
+  }
+
+  if (empty($entity_ids)) {
+    return $return;
+  }
+
+  $query = $connection->select('node_field_data', 't1');
+  $query->join('node__field_b_sections_elg_criteria', 't2', 't1.nid = t2.entity_id');
+  $query->join('paragraph__field_b_criterias', 't3', 't2.field_b_sections_elg_criteria_target_id =  t3.entity_id');
+  $query->join('paragraph__field_b_criteria_key', 't4', 't3.field_b_criterias_target_id =  t4.entity_id');
+  $query->fields('t1', ['title', 'nid']);
+  $query->condition('t4.field_b_criteria_key_target_id', $nid);
+  $query->condition('t3.field_b_criterias_target_id', $entity_ids, 'IN');
+  $query->orderBy('title');
+  $result = $query->execute();
+
+  foreach ($result as $row) {
+    $return[] = ['nid' => $row->nid, 'title' => $row->title];
+  }
+
+  return $return;
+}


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
Patch release includes new search field value in benefit finder form content type

## Releated Github Issues

https://github.com/GSA/px-benefit-finder/milestone/8?closed=1

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->





### Custom Module Improvements

[Add search title in life event](https://github.com/GSA/px-benefit-finder/issues/1427)	https://github.com/GSA/px-benefit-finder/issues/1427

To test in local development site or in dev site.

- [ ] pull changes locally
- [ ] make local development site up at http://localhost
- [ ] if in local, `bin/drush cim --partial --source=modules/custom/usagov_benefit_finder/configuration -y`
- [ ] navigate to `admin/content?combine=&type=bears_life_event&status=All&langcode=All`
- [ ] go to life event "Benefit finder: death of a loved one" edit page
- [ ] verify that it has search title field

<img width="800" src="https://github.com/GSA/px-benefit-finder/assets/88853916/4a558ba4-6afe-4f94-a079-c8a7c490b639">

[Criteria uncheck has-child validation](https://github.com/GSA/px-benefit-finder/issues/870)	https://github.com/GSA/px-benefit-finder/issues/870

Test in local development site or in dev.

<!--- If there are steps for local setup list them here -->
- [ ] Pull changes locally
- [ ] Make local development site up at http://localhost
- [ ] Navigate to `/admin/content?combine=military&type=bears_criteria&status=All&langcode=All`
- [ ] Go to criteria "Deceased served in active military" Edit page
- [ ] Uncheck "Has Child" field
- [ ] Click `Save`
- [ ] Get error message of "Can not uncheck has-child field
![image](https://github.com/GSA/px-benefit-finder/assets/88853916/39e5a9f1-002f-41ef-bad2-935acc851871)

