### PR TITLE
1453 content translations zero ben

### DIFF
--- a/benefit-finder/src/shared/locales/en/en.json
+++ b/benefit-finder/src/shared/locales/en/en.json
@@ -107,10 +107,10 @@
     },
     "zeroBenefits": {
       "chevron": {
-        "heading": "You are likely not eligible for benefits",
-        "description": "<div><p>If you  reached these results by mistake, please go back to review your answers.</p></div>"
+        "heading": "You are likely not eligible for these benefits.",
+        "description": "<div><p>If you reached these results by mistake, please go back to review your answers.</p></div>"
       },
-      "heading": "No eligible results",
+      "heading": "No eligible results.",
       "description": "Based on your answers you are likely not eligible for benefits. You may become eligible if you enter more information or your situation changes.",
       "cta": "See all benefits"
     },

--- a/benefit-finder/src/shared/locales/es/es.json
+++ b/benefit-finder/src/shared/locales/es/es.json
@@ -105,6 +105,15 @@
       "heading": "Resultados",
       "description": "<strong>Según sus respuestas no es elegible para estos beneficios.<strong/> Podría calificar si tiene información adicional o si su situación cambia."
     },
+    "zeroBenefits": {
+      "chevron": {
+        "heading": "Usted parece no ser elegible para estos beneficios.",
+        "description": "<div><p>Si cree que cometió un error, por favor regrese para corregir sus respuestas.</p></div>"
+      },
+      "heading": "No tiene resultados elegibles.",
+      "description": "Basado en sus respuestas usted no es elegible para estos beneficios. Podría ser elegible si ingresa más información o si su situación cambia.",
+      "cta": "Ver todos los beneficios"
+    },
     "stepBackLink": "Volver",
     "eligibleResults": {
       "heading": "Resultados",


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This updates and includes translations for the new zero benefits view content

## Related Github Issue

- Fixes #1453 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [x] pull changes locally
- [x] `cd benefit-finder`
- [x] `npm install`
- [x] `npm run start`

<!--- If there are steps for user testing list them here -->

- [x] navigate through application completing the required fields and answering "NO" to radio fields
- [x] ensure that the spanish content below is appearing as expected 

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-64998143-7fff-c464-f1bc-d85ce9a7c054"><div dir="ltr" style="margin-left:-39.75pt;" align="left">
key | English | Spanish
-- | -- | --
chevron.heading | You are likely not eligible for these benefits. | Usted parece no ser elegible para estos beneficios.
chevron.description | If you reached these results by mistake, please go back to review your answers. | Si cree que cometió un error, por favor regrese para corregir sus respuestas.
heading | No eligible results. | No tiene resultados elegibles.
description | Based on your answers you are likely not eligible for benefits. You may become eligible if you enter more information or your situation changes. | Basado en sus respuestas usted no es elegible para estos beneficios. Podría ser elegible si ingresa más información o si su situación cambia.
cta | See all benefits | Ver todos los beneficios

</div></b>

expected view

<img width="1440" alt="Screenshot 2024-06-27 at 12 29 51 PM" src="https://github.com/GSA/px-benefit-finder/assets/37077057/a980a422-a1e6-4841-a012-71ae34b75054">

