### PR TITLE
1514 update result view value

### DIFF
--- a/benefit-finder/cypress/e2e/storybook/dataLayer.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/dataLayer.cy.js
@@ -26,7 +26,7 @@ const dataLayerValues = [
   {
     event: resultsView.event,
     bfData: {
-      pageView: resultsView.bfData.pageView,
+      pageView: resultsView.bfData.pageView[1],
       viewTitle: 'Your potential benefits',
       viewState: resultsView.bfData.viewState[1],
     },

--- a/benefit-finder/cypress/e2e/storybook/dataLayer.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/dataLayer.cy.js
@@ -26,7 +26,7 @@ const dataLayerValues = [
   {
     event: resultsView.event,
     bfData: {
-      pageView: resultsView.bfData.pageView[1],
+      pageView: resultsView.bfData.pageView[0],
       viewTitle: 'Your potential benefits',
       viewState: resultsView.bfData.viewState[1],
     },
@@ -111,7 +111,7 @@ describe('Calls to Google Analytics Object', function () {
         .then(() => {
           // we wait for the last event to fire
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          cy.wait(100).then(() => {
+          cy.wait(1000).then(() => {
             // check last page change event
             const ev = {
               ...window.dataLayer.filter(
@@ -119,6 +119,9 @@ describe('Calls to Google Analytics Object', function () {
               ),
             }
             delete ev[0]['gtm.uniqueEventId']
+
+            cy.log(resultsView.bfData.pageView[1])
+            cy.log(dataLayerValues[2])
 
             expect(dataLayerValues[2]).to.deep.equal(ev[0])
 

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -114,7 +114,10 @@ const ResultsView = ({
       dataLayerUtils.dataLayerPush(window, {
         event: resultsView.event,
         bfData: {
-          pageView: resultsView.bfData.pageView,
+          pageView:
+            notEligibleView === true
+              ? resultsView.bfData.pageView[1]
+              : resultsView.bfData.pageView[0],
           viewTitle:
             notEligibleView === false
               ? (zeroBenefitsResult && zeroBenefits.chevron.heading) ||

--- a/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
+++ b/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
@@ -26,7 +26,7 @@ const dataLayerStructure = {
   resultsView: {
     event: 'bf_page_change',
     bfData: {
-      pageView: 'bf-result-view',
+      pageView: ['bf-result-eligible-view', 'bf-result-not-eligible-view'],
       viewTitle: null,
       viewState: [
         'bf-not-eligible-view',


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
in our `dataLayer.bfData.pageView` value, toggle `bf-result` view based on view state `eligible` and `not-eligible`

## Related Github Issue

- Fixes #1514 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [x] pull changes locally
- [x] `cd benefit-finder`
- [x] `npm install`
- [x] `npm run start`

<!--- If there are steps for user testing list them here -->
- [x] visit `/death`
- [x] complete required fields, answering YES to all radios
- [x] console.log(window.dataLayer)
- [x] confirm `bf_page_change` event object has `bfData.pageView` value of `"bf-result-eligible-view"`
- [x] CLICK `See benefits you did not qualify for` button
- [x] console.log(window.dataLayer)
- [x] confirm `bf_page_change` event object has `bfData.pageView` value of `"bf-result-not-eligible-view"`

expected:
<img width="1512" alt="Screenshot 2024-07-01 at 9 45 44 AM" src="https://github.com/GSA/px-benefit-finder/assets/37077057/794ce076-ccd1-461a-a5ce-abfd99e975fb">

