### PR TITLE
1516 update benefit event values

### DIFF
--- a/benefit-finder/src/shared/components/Accordion/index.jsx
+++ b/benefit-finder/src/shared/components/Accordion/index.jsx
@@ -45,12 +45,16 @@ const Accordion = ({
   const handleOpenClose = isOpen => {
     setOpen(isOpen)
     isOpen === true &&
-      dataLayerUtils.dataLayerPush(window, {
-        event: benefitAccordion.event,
-        bfData: {
-          benefitTitle: heading,
+      dataLayerUtils.dataLayerPush(
+        window,
+        {
+          event: benefitAccordion.event,
+          bfData: {
+            benefitTitle: heading,
+          },
         },
-      })
+        false
+      )
   }
 
   // handle expand all

--- a/benefit-finder/src/shared/components/Accordion/index.jsx
+++ b/benefit-finder/src/shared/components/Accordion/index.jsx
@@ -39,14 +39,14 @@ const Accordion = ({
    */
   const [isOpen, setOpen] = useState(false)
 
-  const { benefitClick } = dataLayerUtils.dataLayerStructure
+  const { benefitAccordion } = dataLayerUtils.dataLayerStructure
 
   // handle dataLayer
   const handleOpenClose = isOpen => {
     setOpen(isOpen)
     isOpen === true &&
       dataLayerUtils.dataLayerPush(window, {
-        event: benefitClick.event,
+        event: benefitAccordion.event,
         bfData: {
           benefitTitle: heading,
         },

--- a/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerPush.js
+++ b/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerPush.js
@@ -1,4 +1,4 @@
-const dataLayerPush = (w, dataLayerObj, dedup) => {
+const dataLayerPush = (w, dataLayerObj, dedup = true) => {
   const isObject = object => {
     return object != null && typeof object === 'object'
   }
@@ -31,12 +31,15 @@ const dataLayerPush = (w, dataLayerObj, dedup) => {
   if (w.dataLayer) {
     // get the last index of the dataLayer array
     const lastItem = { ...window.dataLayer[window.dataLayer.length - 1] }
-
     delete lastItem['gtm.uniqueEventId']
 
-    // to prevent pushing duplicate objects unecessarily, as long as our last item doesn't match our current data obj, we push
-    isDeepEqual(lastItem, dataLayerObj) === false &&
+    if (dedup === true) {
+      // to prevent pushing duplicate objects unecessarily, as long as our last item doesn't match our current data obj, we push
+      isDeepEqual(lastItem, dataLayerObj) === false &&
+        w.dataLayer.push(dataLayerObj)
+    } else {
       w.dataLayer.push(dataLayerObj)
+    }
   }
 }
 

--- a/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
+++ b/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
@@ -36,8 +36,8 @@ const dataLayerStructure = {
       ],
     },
   },
-  benefitClick: {
-    event: 'bf_benefit_click',
+  benefitAccordion: {
+    event: 'bf-accordion-open',
     bfData: {
       benefitTitle: null,
     },

--- a/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
+++ b/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
@@ -37,7 +37,7 @@ const dataLayerStructure = {
     },
   },
   benefitAccordion: {
-    event: 'bf-accordion-open',
+    event: 'bf_accordion_open',
     bfData: {
       benefitTitle: null,
     },


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This works to 

1. ensure that users click top open an accordion, the data layer event that fires will be called `"bf_accordion_open"`
2. Accordion open event will only fire when the accordion is opened, not when it is closed
3. Accordion open event will fire on both eligible and ineligible results pages

## Related Github Issue

- Fixes #1516 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [x] pull changes locally
- [x] `cd benefit-finder`
- [x] `npm install`
- [x] `npm run start`

<!--- If there are steps for user testing list them here -->
- [x] complete required fields, answer YES for all radio fields
- [x] on the results view, CLICK open an accordion
- [x] console.log(window.dataLayer)
- [x] ensure the event value is `bf_accordion_open`

<img width="1512" alt="Screenshot 2024-07-01 at 11 23 39 AM" src="https://github.com/GSA/px-benefit-finder/assets/37077057/482edbee-7384-4d5b-90fc-6affcd750fc5">

- [x] close the same accordion
- [x] console.log(window.dataLayer)
- [x] ensure that a _new_ event _was not_ fired
- [x] CLICK open the accordion again, ensure that a _new_ event _was_ fired

- [x] toggle to not-eligible view
- [x] on the not-eligible results view, CLICK open an accordion
- [x] console.log(window.dataLayer)
- [x] ensure the event value is `bf_accordion_open`

