### PR TITLE
new gtm event to track open all interactions on results view

### DIFF
--- a/benefit-finder/cypress/e2e/storybook/dataLayer.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/dataLayer.cy.js
@@ -5,8 +5,13 @@ import { pageObjects } from '../../support/pageObjects'
 import * as EN_LOCALE_DATA from '../../../../benefit-finder/src/shared/locales/en/en.json'
 import * as BENEFITS_ELIBILITY_DATA from '../../fixtures/benefits-eligibility.json'
 
-const { intro, lifeEventSection, resultsView, benefitCount } =
-  dataLayerUtils.dataLayerStructure
+const {
+  intro,
+  lifeEventSection,
+  resultsView,
+  benefitCount,
+  openAllBenefitAccordions,
+} = dataLayerUtils.dataLayerStructure
 
 const dataLayerValues = [
   {
@@ -37,6 +42,12 @@ const dataLayerValues = [
       eligible: 4,
       moreInfo: 1,
       notEligible: 25,
+    },
+  },
+  {
+    event: openAllBenefitAccordions.event,
+    bfData: {
+      accordionsOpen: openAllBenefitAccordions.bfData.accordionsOpen,
     },
   },
 ]
@@ -132,6 +143,54 @@ describe('Calls to Google Analytics Object', function () {
             delete evCount[0]['gtm.uniqueEventId']
 
             expect(dataLayerValues[3]).to.deep.equal(evCount[0])
+          })
+        })
+    })
+  })
+
+  it('clicking open all on results page has a bf_open_all_accordions event', function () {
+    const selectedData = BENEFITS_ELIBILITY_DATA.scenario_1_covid.en.param
+    const scenario = utils.encodeURIFromObject(selectedData)
+    cy.visit(`${utils.storybookUri}${scenario}`)
+
+    cy.window().then(window => {
+      assert.isDefined(window.dataLayer, 'window.dataLayer is defined')
+
+      pageObjects
+        .expandAll()
+        .click()
+        .then(() => {
+          // we wait for the last event to fire
+          // eslint-disable-next-line cypress/no-unnecessary-waiting
+          cy.wait(100).then(() => {
+            // check last page change event
+            const ev = {
+              ...window.dataLayer.filter(
+                x => x?.event === dataLayerValues[4].event
+              ),
+            }
+            delete ev[0]['gtm.uniqueEventId']
+
+            expect(dataLayerValues[4]).to.deep.equal(ev[0])
+          })
+        })
+
+      pageObjects
+        .expandAll()
+        .click()
+        .then(() => {
+          // we wait for the last event to fire
+          // eslint-disable-next-line cypress/no-unnecessary-waiting
+          cy.wait(100).then(() => {
+            // check last page change event
+            const ev = {
+              ...window.dataLayer.filter(
+                x => x?.event === dataLayerValues[4].event
+              ),
+            }
+            delete ev[0]['gtm.uniqueEventId']
+
+            expect(dataLayerValues[4]).to.not.deep.equal(ev[0])
           })
         })
     })

--- a/benefit-finder/cypress/e2e/storybook/dataLayer.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/dataLayer.cy.js
@@ -163,38 +163,31 @@ describe('Calls to Google Analytics Object', function () {
         .expandAll()
         .click()
         .then(() => {
-          // we wait for the last event to fire
-          // eslint-disable-next-line cypress/no-unnecessary-waiting
-          cy.wait(100).then(() => {
-            // check last page change event
-            const ev = {
-              ...window.dataLayer.filter(
-                x => x?.event === dataLayerValues[4].event
-              ),
-            }
-            delete ev[0]['gtm.uniqueEventId']
+          // check last page change event
+          const ev = {
+            ...window.dataLayer.filter(
+              x => x?.event === dataLayerValues[4].event
+            ),
+          }
+          delete ev[0]['gtm.uniqueEventId']
 
-            expect(dataLayerValues[4]).to.deep.equal(ev[0])
-          })
+          expect(dataLayerValues[4]).to.deep.equal(ev[0])
         })
 
       pageObjects
         .expandAll()
         .click()
         .then(() => {
-          // we wait for the last event to fire
-          // eslint-disable-next-line cypress/no-unnecessary-waiting
-          cy.wait(100).then(() => {
-            // check last page change event
-            const ev = {
-              ...window.dataLayer.filter(
-                x => x?.event === dataLayerValues[4].event
-              ),
-            }
-            delete ev[0]['gtm.uniqueEventId']
+          // check last page change event
+          const ev = {
+            ...window.dataLayer.filter(
+              x => x?.event === dataLayerValues[4].event
+            ),
+          }
+          // we ignore dedup here so there can be multiple fires
+          delete ev[1]['gtm.uniqueEventId']
 
-            expect(dataLayerValues[4]).to.not.deep.equal(ev[0])
-          })
+          expect(dataLayerValues[4]).to.not.deep.equal(ev[1])
         })
     })
   })

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/index.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/index.jsx
@@ -34,7 +34,8 @@ const BenefitAccordionGroup = ({
     sourceIsEnglish,
   } = benefitAccordion
   const { closedState, openState } = benefitAccordionGroup
-  const { benefitLink } = dataLayerUtils.dataLayerStructure
+  const { benefitLink, openAllBenefitAccordions } =
+    dataLayerUtils.dataLayerStructure
   /**
    * a hook that hanldes our open state of the accordions in our group
    * @function
@@ -49,6 +50,7 @@ const BenefitAccordionGroup = ({
    */
   const handleExpandIcon = isExpandAll ? `${openState} -` : `${closedState} +`
 
+  // handle dataLayer
   /**
    * a function that pushes dataLayer events when the user clicks the link of that benefit
    * @function
@@ -63,6 +65,26 @@ const BenefitAccordionGroup = ({
   }
 
   /**
+   * a function that handles expanded state and pushes dataLayer events when the user clicks the "open all" action
+   * @function
+   * @prop {boolean} isExpandAll true or false
+   */
+  const handleExpandAll = isExpandAll => {
+    setExpandAll(!isExpandAll)
+    isExpandAll === false &&
+      dataLayerUtils.dataLayerPush(
+        window,
+        {
+          event: openAllBenefitAccordions.event,
+          bfData: {
+            accordionsOpen: isExpandAll,
+          },
+        },
+        false
+      )
+  }
+
+  /**
    * a functional component that renders a button and controls the expansion of our accordions
    * @component
    * @return {html} returns html
@@ -74,7 +96,7 @@ const BenefitAccordionGroup = ({
           className="bf-expand-all"
           aria-label={handleExpandIcon}
           unstyled
-          onClick={() => setExpandAll(!isExpandAll)}
+          onClick={() => handleExpandAll(isExpandAll)}
         >
           {handleExpandIcon}
         </Button>

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/index.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/index.jsx
@@ -71,17 +71,16 @@ const BenefitAccordionGroup = ({
    */
   const handleExpandAll = isExpandAll => {
     setExpandAll(!isExpandAll)
-    isExpandAll === false &&
-      dataLayerUtils.dataLayerPush(
-        window,
-        {
-          event: openAllBenefitAccordions.event,
-          bfData: {
-            accordionsOpen: isExpandAll,
-          },
+    dataLayerUtils.dataLayerPush(
+      window,
+      {
+        event: openAllBenefitAccordions.event,
+        bfData: {
+          accordionsOpen: !isExpandAll,
         },
-        false
-      )
+      },
+      false
+    )
   }
 
   /**

--- a/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerPush.js
+++ b/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerPush.js
@@ -1,4 +1,4 @@
-const dataLayerPush = (w, dataLayerObj, dedup) => {
+const dataLayerPush = (w, dataLayerObj, dedup = true) => {
   const isObject = object => {
     return object != null && typeof object === 'object'
   }
@@ -31,12 +31,15 @@ const dataLayerPush = (w, dataLayerObj, dedup) => {
   if (w.dataLayer) {
     // get the last index of the dataLayer array
     const lastItem = { ...window.dataLayer[window.dataLayer.length - 1] }
-
     delete lastItem['gtm.uniqueEventId']
 
-    // to prevent pushing duplicate objects unecessarily, as long as our last item doesn't match our current data obj, we push
-    isDeepEqual(lastItem, dataLayerObj) === false &&
+    if (dedup === true) {
+      // to prevent pushing duplicate objects unecessarily, as long as our last item doesn't match our current data obj, we push
+      isDeepEqual(lastItem, dataLayerObj) === false &&
+        w.dataLayer.push(dataLayerObj)
+    } else {
       w.dataLayer.push(dataLayerObj)
+    }
   }
 }
 

--- a/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
+++ b/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
@@ -39,7 +39,7 @@ const dataLayerStructure = {
   openAllBenefitAccordions: {
     event: 'bf_open_all_accordions',
     bfData: {
-      accordionsOpen: false,
+      accordionsOpen: true,
     },
   },
   benefitClick: {

--- a/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
+++ b/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
@@ -36,6 +36,12 @@ const dataLayerStructure = {
       ],
     },
   },
+  openAllBenefitAccordions: {
+    event: 'bf_open_all_accordions',
+    bfData: {
+      accordionsOpen: false,
+    },
+  },
   benefitClick: {
     event: 'bf_benefit_click',
     bfData: {


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This works to ensure,

1. Data layer event fires whenever someone clicks open all/close all
2. Event can distinguish between open and close, using a can use a data layer variable with value open value as `true` or `false`

## Related Github Issue

- Fixes #1516 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [x] pull changes locally
- [x] `cd benefit-finder`
- [x] `npm install`
- [x] `npm run start`

<!--- If there are steps for user testing list them here -->
- [x]  complete all required fields, select YES for all radio fields
- [x] on the results view, CLICK `Open all +`
- [ ] console.log(window.dataLayer)
- [ ] ensure that the `bf_open_all_accordions` event fires
- [ ] ensure that bfData.accordionsOpen is `true`
- [ ] on the results view, CLICK `Close all +`
- [ ] console.log(window.dataLayer)
- [ ] ensure that the `bf_open_all_accordions` event fires
- [ ] console.log(window.dataLayer)
- [ ] ensure that bfData.accordionsOpen is `false`

expected:

<img width="1509" alt="Screenshot 2024-07-01 at 12 24 35 PM" src="https://github.com/GSA/px-benefit-finder/assets/37077057/b6a81ae2-0c33-43e6-9156-cc5f838bade5">

