### PR TITLE
1511 error count

### DIFF
--- a/benefit-finder/src/shared/components/Alert/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/Alert/__tests__/__snapshots__/index.spec.jsx.snap
@@ -17,7 +17,9 @@ exports[`Alert > renders a match to the previous snapshot when it has an error 1
         class="bf-usa-alert__heading usa-alert__heading font-family-sans"
         id=""
         role="heading"
-      />
+      >
+          
+      </h2>
       <p
         class="bf-usa-alert__text usa-alert__text"
       />
@@ -43,7 +45,9 @@ exports[`Alert > renders a match to the previous snapshot, default 1`] = `
         class="bf-usa-alert__heading usa-alert__heading font-family-sans"
         id=""
         role="heading"
-      />
+      >
+          
+      </h2>
       <p
         class="bf-usa-alert__text usa-alert__text"
       />
@@ -69,7 +73,9 @@ exports[`Alert > renders a match to the previous snapshot, error type with no er
         class="bf-usa-alert__heading usa-alert__heading font-family-sans"
         id=""
         role="heading"
-      />
+      >
+          
+      </h2>
       <p
         class="bf-usa-alert__text usa-alert__text"
       />

--- a/benefit-finder/src/shared/components/Alert/index.jsx
+++ b/benefit-finder/src/shared/components/Alert/index.jsx
@@ -9,10 +9,11 @@ import './_index.scss'
  * @param {string} className - inherited classes
  * @param {string} children - inherited children
  * @param {any} alertFieldRef - inherited ref hook
- * @param {string} heading - inherited heading
+ * @param {obj} heading - inherited heading, contains prefix and suffix
  * @param {string} description - inherited description
  * @param {bool} type - string
  * @param {bool}  hasError - checks for current error state of parent value
+ * @param {number} errorCount - number of errors in the view
  * @param {bool} noBackground - style variant
  * @param {number} tabIndex - index value of tab order
  * @return {html} returns a wrapped paragraph styled as usa-alert
@@ -79,12 +80,13 @@ Alert.propTypes = {
   className: PropTypes.string,
   children: PropTypes.any,
   alertFieldRef: PropTypes.any,
-  heading: PropTypes.string,
+  heading: PropTypes.object,
   description: PropTypes.string,
   type: PropTypes.string,
   hasError: PropTypes.bool,
   noBackground: PropTypes.bool,
   tabIndex: PropTypes.number,
+  errorCount: PropTypes.number,
 }
 
 export default Alert

--- a/benefit-finder/src/shared/components/Alert/index.jsx
+++ b/benefit-finder/src/shared/components/Alert/index.jsx
@@ -28,6 +28,7 @@ const Alert = ({
   hasError,
   noBackground,
   tabIndex,
+  errorCount,
 }) => {
   const defaultClasses =
     type === 'error'
@@ -65,7 +66,7 @@ const Alert = ({
             headingLevel={2}
             className="bf-usa-alert__heading usa-alert__heading"
           >
-            {heading}
+            {heading?.prefix}&nbsp;{errorCount}&nbsp;{heading?.suffix}
           </Heading>
           <p className="bf-usa-alert__text usa-alert__text">{description}</p>
         </div>

--- a/benefit-finder/src/shared/components/Date/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/Date/__tests__/__snapshots__/index.spec.jsx.snap
@@ -23,7 +23,6 @@ exports[`Date > renders a match to the previous snapshot 1`] = `
       </div>
       <select
         aria-describedby="month-description-undefined"
-        aria-invalid="false"
         class="bf-usa-select usa-select "
         id="date_of_birth_month-undefined"
         name="date_of_birth_month-undefined"
@@ -113,7 +112,6 @@ exports[`Date > renders a match to the previous snapshot 1`] = `
       </div>
       <input
         aria-describedby="day-description-undefined"
-        aria-invalid="false"
         class="bf-usa-input usa-input "
         id="date_of_birth_day-undefined"
         inputmode="numeric"
@@ -138,7 +136,6 @@ exports[`Date > renders a match to the previous snapshot 1`] = `
       </div>
       <input
         aria-describedby="year-description-undefined"
-        aria-invalid="false"
         class="bf-usa-input usa-input "
         id="date_of_birth_year-undefined"
         inputmode="numeric"

--- a/benefit-finder/src/shared/components/Date/index.jsx
+++ b/benefit-finder/src/shared/components/Date/index.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types'
-import { Alert } from '../index'
 import './_index.scss'
 
 /**
@@ -7,34 +6,28 @@ import './_index.scss'
  * @component
  * @param {func} onChange - inherited change handler
  * @param {object} value - inherited state values
- * @param {boolean} required - inherited boolean value to manage required state
   * @param {object} ui - inherited ui object values
  * @param {string} id - inherited string value for id specificity
- * @param {boolean} invalid - inherited boolean value to manage error state
+ * @param {array} invalid - inherited boolean value to manage error state
 
  * @return {Date} returns a tandard format Date ie 1995-12-17T03:24:00
  */
-const Date = ({ onChange, value, required, ui, id, invalid }) => {
+const Date = ({ onChange, value, ui, id, invalid }) => {
   const { date, select } = ui
-  const { labelDay, labelMonth, labelYear, monthOptions, alert } = date
+  const { labelDay, labelMonth, labelYear, monthOptions } = date
   const { dateDefaultValue } = select
 
   // Note: when we break each input into functional components they trigger unwanted rerenders
+
+  const handleInvalid = (invalidArray, id) => {
+    return invalidArray && invalidArray.map(el => el.id === id).includes(true)
+  }
 
   return (
     <div
       id={`bf-usa-memorable-date-${id} usa-memorable-date-${id}`}
       className="bf-usa-memorable-date usa-memorable-date"
     >
-      {invalid === true && (
-        <Alert
-          className="bf-usa-date-alert"
-          heading={ui.alertBanner.heading}
-          description={alert}
-          type="error"
-          hasError={invalid}
-        ></Alert>
-      )}
       <div className="bf-usa-form-group usa-form-group bf-usa-form-group--month usa-form-group--month bf-usa-form-group--select usa-form-group--select">
         <label
           className="bf-usa-label usa-label"
@@ -46,16 +39,13 @@ const Date = ({ onChange, value, required, ui, id, invalid }) => {
           Select a month from the list
         </div>
         <select
-          className={`bf-usa-select usa-select ${
-            required === true ? 'required-field' : ''
-          }`}
+          className={`bf-usa-select usa-select ${handleInvalid(invalid, `date_of_birth_month-${id}`) ? 'usa-input--error' : ''}`}
           id={`date_of_birth_month-${id}`}
           name={`date_of_birth_month-${id}`}
           aria-describedby={`month-description-${id}`}
-          required={required === true}
           value={(value && value.month) || ''}
           onChange={onChange}
-          aria-invalid={invalid === true}
+          aria-invalid={handleInvalid(invalid, `date_of_birth_month-${id}`)}
         >
           <option value="" key="default" disabled>
             {dateDefaultValue}
@@ -78,15 +68,14 @@ const Date = ({ onChange, value, required, ui, id, invalid }) => {
           Enter two numerals for day
         </div>
         <input
-          className={`bf-usa-input usa-input ${required === true ? 'required-field' : ''}`}
+          className={`bf-usa-input usa-input ${handleInvalid(invalid, `date_of_birth_day-${id}`) ? 'usa-input--error' : ''}`}
           aria-describedby={`day-description-${id}`}
           id={`date_of_birth_day-${id}`}
           name={`date_of_birth_day-${id}`}
           inputMode="numeric"
           value={(value && value.day) || ''}
           onChange={onChange}
-          required={required === true}
-          aria-invalid={invalid === true}
+          aria-invalid={handleInvalid(invalid, `date_of_birth_day-${id}`)}
         />
       </div>
       <div className="bf-usa-form-group usa-form-group bf-usa-form-group--year usa-form-group--year">
@@ -100,15 +89,14 @@ const Date = ({ onChange, value, required, ui, id, invalid }) => {
           Enter four numerals for year
         </div>
         <input
-          className={`bf-usa-input usa-input ${required === true ? 'required-field' : ''}`}
+          className={`bf-usa-input usa-input ${handleInvalid(invalid, `date_of_birth_year-${id}`) ? 'usa-input--error' : ''}`}
           aria-describedby={`year-description-${id}`}
           id={`date_of_birth_year-${id}`}
           name={`date_of_birth_year-${id}`}
           inputMode="numeric"
           value={(value && value.year) || ''}
           onChange={onChange}
-          required={required === true}
-          aria-invalid={invalid === true}
+          aria-invalid={handleInvalid(invalid, `date_of_birth_year-${id}`)}
         />
       </div>
     </div>
@@ -118,10 +106,9 @@ const Date = ({ onChange, value, required, ui, id, invalid }) => {
 Date.propTypes = {
   onChange: PropTypes.func,
   value: PropTypes.object,
-  required: PropTypes.bool,
   ui: PropTypes.object,
   id: PropTypes.string,
-  invalid: PropTypes.bool,
+  invalid: PropTypes.array,
 }
 
 export default Date

--- a/benefit-finder/src/shared/components/Fieldset/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/Fieldset/__tests__/__snapshots__/index.spec.jsx.snap
@@ -3,7 +3,7 @@
 exports[`Fieldset > renders a match to the previous snapshot 1`] = `
 <DocumentFragment>
   <fieldset
-    class="bf-usa-fieldset usa-fieldset "
+    class="bf-usa-fieldset usa-fieldset   "
   />
 </DocumentFragment>
 `;

--- a/benefit-finder/src/shared/components/Fieldset/index.jsx
+++ b/benefit-finder/src/shared/components/Fieldset/index.jsx
@@ -9,8 +9,13 @@ import './_index.scss'
  * @component
  * @param {React.ReactNode} children - inherited children
  * @param {string} legend - passed to Legend component
+ * @param {bool} required - inherited from data
+ * @param {node} alertRef - inherited reference
+ * @param {object} requiredLabel - passed to Legend component
+ * @param {boolean} hidden - inherited from data
  * @param {string} hint - passed to Hint component
  * @param {string} className - inherited classes
+ * @param {string} id - inherited id value
  * @return {html} returns a div
  */
 const Fieldset = ({
@@ -22,9 +27,13 @@ const Fieldset = ({
   hidden,
   hint,
   className,
+  id,
+  invalid,
 }) => {
   const handleHidden = hidden !== undefined && hidden ? ['display-none'] : ''
-  const defaultClasses = ['bf-usa-fieldset usa-fieldset']
+  const defaultClasses = [
+    `bf-usa-fieldset usa-fieldset ${required === true ? 'required-field' : ''} ${invalid === true ? 'usa-input--error' : ''}`,
+  ]
   const utilityClasses = handleHidden
 
   /**
@@ -56,9 +65,11 @@ const Fieldset = ({
         utilityClasses,
       })}
       ref={alertRef}
+      required={required === true}
+      id={id}
     >
-      {hint && <div className="bf-hint">{hint}</div>}
       {legend && handleRequired}
+      {hint && <div className="bf-hint">{hint}</div>}
       {children}
     </fieldset>
   )

--- a/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.jsx.snap
@@ -83,7 +83,7 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
               id=""
               role="heading"
             >
-              Error
+              Your information contains  errors
             </h2>
             <p
               class="bf-usa-alert__text usa-alert__text"

--- a/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.jsx.snap
@@ -83,7 +83,7 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
               id=""
               role="heading"
             >
-              Your information contains  errors
+              Your information contains 0 errors
             </h2>
             <p
               class="bf-usa-alert__text usa-alert__text"
@@ -109,13 +109,10 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
           </p>
         </div>
         <fieldset
-          class="bf-usa-fieldset usa-fieldset "
+          class="bf-usa-fieldset usa-fieldset required-field  "
+          id="applicant_date_of_birth"
+          required=""
         >
-          <div
-            class="bf-hint"
-          >
-            For example: January 19 2000
-          </div>
           <legend
             class="bf-legend usa-legend"
           >
@@ -127,6 +124,11 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
               (required)
             </span>
           </legend>
+          <div
+            class="bf-hint"
+          >
+            For example: January 19 2000
+          </div>
           <div>
             <div
               class="bf-usa-memorable-date usa-memorable-date"
@@ -150,10 +152,9 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
                 <select
                   aria-describedby="month-description-applicant_date_of_birth_0"
                   aria-invalid="false"
-                  class="bf-usa-select usa-select required-field"
+                  class="bf-usa-select usa-select "
                   id="date_of_birth_month-applicant_date_of_birth_0"
                   name="date_of_birth_month-applicant_date_of_birth_0"
-                  required=""
                 >
                   <option
                     disabled=""
@@ -241,11 +242,10 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
                 <input
                   aria-describedby="day-description-applicant_date_of_birth_0"
                   aria-invalid="false"
-                  class="bf-usa-input usa-input required-field"
+                  class="bf-usa-input usa-input "
                   id="date_of_birth_day-applicant_date_of_birth_0"
                   inputmode="numeric"
                   name="date_of_birth_day-applicant_date_of_birth_0"
-                  required=""
                   value=""
                 />
               </div>
@@ -267,11 +267,10 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
                 <input
                   aria-describedby="year-description-applicant_date_of_birth_0"
                   aria-invalid="false"
-                  class="bf-usa-input usa-input required-field"
+                  class="bf-usa-input usa-input "
                   id="date_of_birth_year-applicant_date_of_birth_0"
                   inputmode="numeric"
                   name="date_of_birth_year-applicant_date_of_birth_0"
-                  required=""
                   value=""
                 />
               </div>
@@ -279,7 +278,9 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="bf-usa-fieldset usa-fieldset "
+          class="bf-usa-fieldset usa-fieldset required-field  "
+          id="applicant_relationship_to_the_deceased"
+          required=""
         >
           <legend
             class="bf-legend usa-legend"
@@ -301,10 +302,9 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
             </label>
             <select
               aria-invalid="false"
-              class="bf-usa-select usa-select required-field"
+              class="bf-usa-select usa-select "
               id="applicant_relationship_to_the_deceased_0"
               name="applicant_relationship_to_the_deceased_0"
-              required=""
             >
               <option
                 disabled=""
@@ -341,7 +341,9 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="bf-usa-fieldset usa-fieldset "
+          class="bf-usa-fieldset usa-fieldset required-field  "
+          id="applicant_marital_status"
+          required=""
         >
           <legend
             class="bf-legend usa-legend"
@@ -363,10 +365,9 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
             </label>
             <select
               aria-invalid="false"
-              class="bf-usa-select usa-select required-field"
+              class="bf-usa-select usa-select "
               id="applicant_marital_status_0"
               name="applicant_marital_status_0"
-              required=""
             >
               <option
                 disabled=""
@@ -398,7 +399,7 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="bf-usa-fieldset usa-fieldset "
+          class="bf-usa-fieldset usa-fieldset   "
         >
           <legend
             class="bf-legend usa-legend"
@@ -406,7 +407,6 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
             Are you a U.S. citizen or eligible non-citizen?
           </legend>
           <div
-            aria-invalid="false"
             class="radio-group"
           >
             <div
@@ -446,7 +446,7 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="bf-usa-fieldset usa-fieldset "
+          class="bf-usa-fieldset usa-fieldset   "
         >
           <legend
             class="bf-legend usa-legend"
@@ -454,7 +454,6 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
             Are you caring for the deceased's child who is under age 16 or has a disability?
           </legend>
           <div
-            aria-invalid="false"
             class="radio-group"
           >
             <div
@@ -494,7 +493,7 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="bf-usa-fieldset usa-fieldset "
+          class="bf-usa-fieldset usa-fieldset   "
         >
           <legend
             class="bf-legend usa-legend"
@@ -502,7 +501,6 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
             Did you pay for funeral or burial expenses?
           </legend>
           <div
-            aria-invalid="false"
             class="radio-group"
           >
             <div

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -560,6 +560,7 @@ const LifeEventSection = ({
                     modalOpen={modalOpen}
                     setModalOpen={setModalOpen}
                     completed={currentData.completed}
+                    alertElement={alertFieldRef}
                   />
                 </div>
               )}

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -40,13 +40,11 @@ const LifeEventSection = ({
   modalOpen,
   setModalOpen,
 }) => {
-  // const currentStep = step - 1
   // state
   const [modal, setModal] = useState(false)
   const [currentData, setCurrentData] = useState(() => data && data[step - 1])
-  const [values, setValues] = useState([])
+  const [requiredFieldsets, setRequiredFieldsets] = useState([])
   const [hasError, setHasError] = useState([])
-  const classError = 'usa-input--error'
   const [hasData, setHasData] = useState(false)
   useHandleUnload(hasData) // alert the user if they try to go back in browser
   const resetElement = useResetElement()
@@ -74,8 +72,18 @@ const LifeEventSection = ({
     handleData([...data])
   }
 
-  const handleFieldAlerts = () => {
-    setHasError(Array.from(document.querySelectorAll(`.${classError}`)))
+  const handleCheckForRequiredValues = async () => {
+    const invalidElements = await requiredFieldsets
+      .map(fieldset => {
+        return (
+          Array.from(fieldset.elements)
+            // check all the required inputs, if there is no value, there the input is invalid
+            .filter(el => !el.value)
+        )
+      })
+      .flat()
+    setHasError(invalidElements)
+    return invalidElements.length === 0
   }
 
   /**
@@ -95,15 +103,8 @@ const LifeEventSection = ({
     // remove the display class from the alert
     alertFieldRef.current.classList.remove('display-none')
     alertFieldRef.current.focus()
-    // add to all the collected error fields an error class
-    values.forEach(field => {
-      field.classList.contains('required-field') &&
-        field.classList.add(classError)
-    })
-    handleFieldAlerts()
     currentData.completed = false
     window.scrollTo(0, 0)
-    return false
   }
 
   /**
@@ -113,26 +114,21 @@ const LifeEventSection = ({
   const handleSuccess = () => {
     // hide alert by adding the display class
     alertFieldRef.current.classList.add('display-none')
-    // remove from all the collected error fields the error class
-    values.forEach(field => {
-      field.classList.remove(classError)
-    })
     currentData.completed = true
     handleUpdateData()
-    setValues([])
-    return true
+    setRequiredFieldsets([])
   }
 
   /**
    * a function that collect all the required fields in the current step
    * @function
    */
-  const getRequiredFields = () => {
-    const collectedNodeList = document.querySelectorAll('input, select')
+  const getRequiredFieldsets = () => {
+    const collectedNodeList = document.querySelectorAll('fieldset')
     const requiredNodeList = Array.from(collectedNodeList).filter(
       node => node.attributes.required
     )
-    setValues(Array.from(requiredNodeList))
+    setRequiredFieldsets(Array.from(requiredNodeList))
   }
 
   /**
@@ -142,33 +138,9 @@ const LifeEventSection = ({
    */
   const handleCheckRequriedFields = () => {
     // collect all the required fields in the current step
-    getRequiredFields()
-    // check if any of these elements are valid (will add others later)
-    const valid = element => {
-      return !element.classList.contains('required-field')
-    }
-
-    return values.length === 0 || values.every(valid)
-      ? handleSuccess()
-      : handleAlert()
-  }
-
-  /**
-   * a function that updates our step count and set our data index
-   * @function
-   * @param {array} hasError - collection of error elements
-   * @param {event} event - passed in change handler
-   */
-  const updateAlertArray = (hasError, event) => {
-    hasError.forEach((element, index) => {
-      if (element.id.includes(event.target.id)) {
-        hasError.splice(index, 1)
-      }
+    handleCheckForRequiredValues().then(valid => {
+      valid === true ? handleSuccess() : handleAlert()
     })
-
-    if (hasError.length === 0) {
-      alertFieldRef.current.classList.add('display-none')
-    }
   }
   /**
    *
@@ -183,12 +155,14 @@ const LifeEventSection = ({
    * @return {null} only executes inherited functions
    */
   const handleForwardUpdate = updateIndex => {
-    if (handleCheckRequriedFields() === true) {
-      // set complete step usa-step-indicator__segment--complete
-      setStep(step + updateIndex)
-      setStepData(updateIndex)
-      resetElement && resetElement.current.focus()
-    }
+    handleCheckRequriedFields()
+    handleCheckForRequiredValues().then(valid => {
+      if (valid === true) {
+        setStep(step + updateIndex)
+        setStepData(updateIndex)
+        resetElement && resetElement.current.focus()
+      }
+    })
   }
 
   /**
@@ -217,7 +191,7 @@ const LifeEventSection = ({
       setCurrentData,
       event.target.value
     )
-    updateAlertArray(hasError, event)
+    hasError.length > 0 && handleCheckForRequiredValues()
   }
 
   /**
@@ -237,15 +211,8 @@ const LifeEventSection = ({
         event.target.value,
         event.target.id
       )
-      updateAlertArray(hasError, event)
+      hasError.length > 0 && handleCheckForRequiredValues()
     }
-  }
-
-  const handleDateRequired = (values, item) => {
-    return Object.keys(values?.value).length === 3 &&
-      values?.value?.year?.length === 4
-      ? false
-      : item.fieldset.required
   }
 
   // manage the display of our modal initializer
@@ -256,7 +223,7 @@ const LifeEventSection = ({
   // check for all required fields and scroll to top on mount
   useEffect(() => {
     window.scrollTo(0, 0)
-    getRequiredFields()
+    getRequiredFieldsets()
   }, [])
 
   // handle dataLayer
@@ -300,7 +267,7 @@ const LifeEventSection = ({
                   description={ui.alertBanner.description}
                   type="error"
                   hasError={hasError.length > 0}
-                  errorCount={hasError.length > 0 && hasError.length}
+                  errorCount={hasError.length}
                 ></Alert>
                 <Heading className="bf-usa-section-heading" headingLevel={2}>
                   {currentData.section.heading}
@@ -329,6 +296,20 @@ const LifeEventSection = ({
                           required={item.fieldset.required}
                           requiredLabel={requiredLabel}
                           hidden={hidden && hidden}
+                          id={item.fieldset.criteriaKey}
+                          invalid={
+                            item.fieldset.required &&
+                            hasError
+                              .map(errorItem => {
+                                return (
+                                  errorItem.id !== undefined &&
+                                  errorItem.id.includes(
+                                    item.fieldset?.criteriaKey
+                                  )
+                                )
+                              })
+                              .includes(true)
+                          }
                         >
                           {item.fieldset.inputs.map((input, index) => {
                             const fieldSetId = `${item.fieldset.criteriaKey}_${index}`
@@ -337,13 +318,20 @@ const LifeEventSection = ({
                               value => value.selected !== undefined
                             )
 
+                            const invalid =
+                              item.fieldset.required &&
+                              hasError
+                                .map(item => {
+                                  return (
+                                    item.id !== undefined &&
+                                    fieldSetId.includes(item.id)
+                                  )
+                                })
+                                .includes(true)
+
                             return (
                               <div key={fieldSetId}>
                                 <Select
-                                  required={
-                                    defaultSelected === undefined &&
-                                    item.fieldset.required
-                                  }
                                   ui={ui?.select}
                                   htmlFor={fieldSetId}
                                   key={fieldSetId}
@@ -355,12 +343,7 @@ const LifeEventSection = ({
                                       item.fieldset.criteriaKey
                                     )
                                   }
-                                  invalid={
-                                    hasError.length > 0 &&
-                                    hasError
-                                      .map(item => item.id.includes(fieldSetId))
-                                      .includes(true)
-                                  }
+                                  invalid={invalid}
                                 />
                               </div>
                             )
@@ -389,21 +372,16 @@ const LifeEventSection = ({
                           {item.fieldset.inputs.map((input, index) => {
                             const fieldSetId = `${item.fieldset.criteriaKey}_${index}`
 
-                            const inputValues = input.inputCriteria.values
-                            const optionSelected = inputValues.find(
-                              value => value.selected !== undefined
-                            )
-
                             return (
                               <div
                                 className="radio-group"
                                 key={fieldSetId}
-                                aria-invalid={
-                                  hasError.length > 0 &&
-                                  hasError
-                                    .map(item => item.id.includes(fieldSetId))
-                                    .includes(true)
-                                }
+                                // aria-invalid={
+                                //   hasInvalidInput.length > 0 &&
+                                //   hasInvalidInput
+                                //     .map(item => item.id.includes(fieldSetId))
+                                //     .includes(true)
+                                // }
                               >
                                 {/* map the options */}
                                 {input.inputCriteria.values.map(
@@ -412,10 +390,6 @@ const LifeEventSection = ({
 
                                     return (
                                       <Radio
-                                        required={
-                                          !optionSelected &&
-                                          item.fieldset.required
-                                        }
                                         name={fieldSetId}
                                         key={inputId}
                                         id={inputId}
@@ -455,17 +429,36 @@ const LifeEventSection = ({
                           required={item.fieldset.required}
                           requiredLabel={requiredLabel}
                           hidden={hidden && hidden}
+                          id={item.fieldset.criteriaKey}
+                          invalid={
+                            item.fieldset.required &&
+                            hasError
+                              .map(errorItem => {
+                                return (
+                                  errorItem.id !== undefined &&
+                                  errorItem.id.includes(
+                                    item.fieldset?.criteriaKey
+                                  )
+                                )
+                              })
+                              .includes(true)
+                          }
                         >
                           {item.fieldset.inputs.map((input, index) => {
                             const fieldSetId = `${item.fieldset.criteriaKey}_${index}`
 
+                            const invalid =
+                              item.fieldset.required &&
+                              hasError.filter(item => {
+                                return (
+                                  item.id !== undefined &&
+                                  item.id.includes(fieldSetId)
+                                )
+                              })
+
                             return (
                               <div key={fieldSetId}>
                                 <Date
-                                  required={handleDateRequired(
-                                    input.inputCriteria.values[0],
-                                    item
-                                  )}
                                   value={input.inputCriteria.values[0]?.value}
                                   onChange={event =>
                                     handleDateChanged(
@@ -475,12 +468,7 @@ const LifeEventSection = ({
                                   }
                                   ui={ui}
                                   id={fieldSetId}
-                                  invalid={
-                                    hasError.length > 0 &&
-                                    hasError
-                                      .map(item => item.id.includes(fieldSetId))
-                                      .includes(true)
-                                  }
+                                  invalid={invalid}
                                 />
                               </div>
                             )
@@ -568,7 +556,7 @@ const LifeEventSection = ({
                     navItemTwoLabel={reviewSelectionModal.buttonGroup[1].value}
                     navItemTwoFunction={setViewResults}
                     triggerLabel={buttonGroup[1].value}
-                    handleCheckRequriedFields={handleCheckRequriedFields}
+                    handleCheckRequriedFields={handleCheckForRequiredValues}
                     modalOpen={modalOpen}
                     setModalOpen={setModalOpen}
                     completed={currentData.completed}

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -300,6 +300,7 @@ const LifeEventSection = ({
                   description={ui.alertBanner.description}
                   type="error"
                   hasError={hasError.length > 0}
+                  errorCount={hasError.length > 0 && hasError.length}
                 ></Alert>
                 <Heading className="bf-usa-section-heading" headingLevel={2}>
                   {currentData.section.heading}

--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -39,6 +39,7 @@ const customStyles = {
  * @param {string} modalHeading - heading value
  * @param {string} navItemOneLabel - passed to button for nav item in modal
  * @param {string} navItemTwoLabel - passed to button for nav item in modal
+ * @param {function} handleCheckRequriedFields - inherited async function to check validity of fields
  * @return {html} returns html for seting up a usa-modal component
  */
 const Modal = ({
@@ -62,10 +63,12 @@ const Modal = ({
    * @function
    */
   const handleOpenModal = () => {
-    if (handleCheckRequriedFields() === true) {
-      scrollLock.enableScroll()
-      setModalOpen(true)
-    }
+    handleCheckRequriedFields().then(valid => {
+      if (valid === true) {
+        scrollLock.enableScroll()
+        setModalOpen(true)
+      }
+    })
   }
 
   /**
@@ -242,6 +245,7 @@ Modal.propTypes = {
   navItemOneFunction: PropTypes.func,
   navItemTwoLabel: PropTypes.string,
   navItemTwoFunction: PropTypes.func,
+  handleCheckRequriedFields: PropTypes.func,
 }
 
 export default Modal

--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -54,6 +54,7 @@ const Modal = ({
   handleCheckRequriedFields,
   modalOpen,
   setModalOpen,
+  alertElement,
 }) => {
   // state
   const triggerRef = useRef(null)
@@ -67,6 +68,9 @@ const Modal = ({
       if (valid === true) {
         scrollLock.enableScroll()
         setModalOpen(true)
+      } else {
+        window.scrollTo(0, 0)
+        alertElement.current.focus()
       }
     })
   }

--- a/benefit-finder/src/shared/components/Select/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/Select/__tests__/__snapshots__/index.spec.jsx.snap
@@ -8,6 +8,7 @@ exports[`Select > renders a match to the previous snapshot 1`] = `
     Dropdown Label
   </label>
   <select
+    aria-invalid="false"
     class="bf-usa-select usa-select "
   >
     <option

--- a/benefit-finder/src/shared/components/Select/index.jsx
+++ b/benefit-finder/src/shared/components/Select/index.jsx
@@ -22,15 +22,14 @@ function Select({
   options,
   selected,
   onChange,
-  required,
   ui,
   className,
   invalid,
 }) {
   const { labelSelect, defaultValue } = ui
-  const handleRequired = required === true ? ['required-field'] : ''
-  const defaultClasses = ['bf-usa-select usa-select']
-  const utilityClasses = handleRequired
+  const defaultClasses = [
+    `bf-usa-select usa-select ${invalid === true ? 'usa-input--error' : ''}`,
+  ]
   /**
    * a functional component to create a list of options for a select element.
    * @function
@@ -54,14 +53,12 @@ function Select({
         className={useHandleClassName({
           className,
           defaultClasses,
-          utilityClasses,
         })}
         name={htmlFor}
         id={htmlFor}
         onChange={onChange}
         value={selected || ''}
-        required={required === true}
-        aria-invalid={invalid}
+        aria-invalid={invalid === true}
       >
         <option value="" key="default" disabled>
           {defaultValue}

--- a/benefit-finder/src/shared/locales/en/en.json
+++ b/benefit-finder/src/shared/locales/en/en.json
@@ -39,7 +39,7 @@
     "value": "required"
   },
   "alertBanner": {
-    "heading": "Error",
+    "heading": { "prefix": "Your information contains", "suffix": "errors" },
     "description": "Complete all required fields."
   },
   "buttonGroup": [

--- a/benefit-finder/src/shared/locales/es/es.json
+++ b/benefit-finder/src/shared/locales/es/es.json
@@ -39,7 +39,7 @@
     "value": "requerido"
   },
   "alertBanner": {
-    "heading": "Error",
+    "heading": { "prefix": "Tu información contiene", "suffix": "errores" },
     "description": "Responda los campos requeridos."
   },
   "buttonGroup": [


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This works to refactor or error handling to support reactive field count on errors

## Related Github Issue

- Fixes #1511 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] `cd benefit-finder`
- [ ] `npm install`
- [ ] `npm run start`

<!--- If there are steps for user testing list them here -->
- [ ] navigate to first step of the form, without entering values click "continue"
- [ ] ensure an error is thrown
- [ ] ensure the alert banner is focused
- [ ] ensure the number of errors indicated in the alert is equal to the number of inputs/selects that have errors
- [ ] ensure the fields with errors have red borders around them

expected:
<img width="1509" alt="Screenshot 2024-07-01 at 10 20 59 PM" src="https://github.com/GSA/px-benefit-finder/assets/37077057/a62dd555-ea4c-4e9f-b4ba-36e9508fd16e">

- [ ] begin to resolve errors
- [ ] ensure that resolving an error resolves its css notification
- [ ] ensure that resolving an error updates the count in the alert

expected:
<img width="1512" alt="Screenshot 2024-07-01 at 10 21 16 PM" src="https://github.com/GSA/px-benefit-finder/assets/37077057/6a61dc6e-9b46-4a1e-b237-9a6235d765dd">

- [ ] without resolving all errors CLICK "continue" button again
- [ ] ensure that you can not progress forward
- [ ] ensure the alert banner is focused
- [ ] ensure that when _all_ errors are resolved, the alert banner is not displayed and user can progress forward
