### PR TITLE
1521 disable life event form delete if still used

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
@@ -389,3 +389,78 @@ function _usagov_benefit_finder_content_check_criteria_has_child(int $nid) {
 
   return $return;
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function usagov_benefit_finder_content_form_node_bears_life_event_form_delete_form_alter(array &$form, FormStateInterface $form_state) {
+  _usagov_benefit_finder_content_check_life_event_form_usage($form);
+}
+
+/**
+ * It checks life event form usage in relevant benefit of life event forms.
+ * If still used, it lists the life event forms and disables the delete confirmation button.
+ *
+ * @param array $form
+ *   Form array.
+ */
+function _usagov_benefit_finder_content_check_life_event_form_usage(array &$form) {
+  $description = '';
+
+  $node = \Drupal::routeMatch()->getParameter('node');
+  $nid = $node->id();
+
+  $result = _usagov_benefit_finder_content_check_life_event_form_usage_in_life_event_form($nid);
+  foreach ($result as $row) {
+    $description .= "<li>Life event form: $row[title] ($row[nid])</li>";
+  }
+
+  if (!empty($description)) {
+    $description = '<div class="entity-skip">'
+      . '<span>This life event form cannot be deleted as it is still used in following content:</span>'
+      . "<ul>$description</ul>"
+      . '</div>';
+    $form['description']['#markup'] = t($description);
+    $form['actions']['submit']['#access'] = FALSE;
+  }
+}
+
+/**
+ * It checks life event form usage in relevant benefit of life event forms.
+ *
+ * @param int $nid
+ *   Node ID of given life event form.
+ */
+function _usagov_benefit_finder_content_check_life_event_form_usage_in_life_event_form(int $nid) {
+  $return = [];
+
+  $connection = Database::getConnection();
+
+  $query = $connection->select('paragraph__field_b_life_event_form', 't');
+  $query->fields('t', ['entity_id']);
+  $query->condition('t.bundle', 'b_levent_relevant_benefit');
+  $query->condition('t.field_b_life_event_form_target_id', $nid);
+  $result = $query->execute();
+
+  $entity_ids = [];
+  foreach ($result as $row) {
+    $entity_ids[] = $row->entity_id;
+  }
+
+  if (empty($entity_ids)) {
+    return $return;
+  }
+
+  $query = $connection->select('node_field_data', 't1');
+  $query->join('node__field_b_relevant_benefits', 't2', 't1.nid = t2.entity_id');
+  $query->fields('t1', ['title', 'nid']);
+  $query->condition('t2.field_b_relevant_benefits_target_id', $entity_ids, 'IN');
+  $query->orderBy('title');
+  $result = $query->execute();
+
+  foreach ($result as $row) {
+    $return[] = ['nid' => $row->nid, 'title' => $row->title];
+  }
+
+  return $return;
+}


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This work ensures life event form content can not be delete if still used.
If a life event form still used, it lists the contents that use this this life event form and disables the delete confirmation button.

## Related Github Issue

- Fixes #1521

## Detailed Testing steps

To test in local development site or in dev site.

<!--- If there are steps for local setup list them here -->
- [ ] Pull changes locally
- [ ] Make local development site up at http://localhost
- [ ] Navigate to `admin/content?combine=&type=bears_life_event_form&status=All&langcode=All`
- [ ] Go to life event form "Benefit finder: death of a loved one" edit page
- [ ] Click `Delete`
- [ ] Verify the warning message "cannot delete the life event form" and list of life event forms
- [ ] verify that no `Delete` confirmation button

![image](https://github.com/GSA/px-benefit-finder/assets/88853916/368f55c1-8531-476a-b8b4-c9884ddc4f1a)

- [ ] Go to life event form "Benefit finder: retirement" edit page
- [ ] Remove life event form "Benefit finder: death of a loved one" in relevant benefit

<img width="600" src="https://github.com/GSA/px-benefit-finder/assets/88853916/f2012de8-58ed-4afd-a427-679a7be0a31b">

- [ ] Click `Save`
- [ ] Go to life event form "Benefit finder: disability" edit page
- [ ] Remove life event form "Benefit finder: death of a loved one" in relevant benefit
- [ ] Click `Save`

Now delete life event form "Benefit finder: death of a loved one" again
- [ ] Go to life event form "Benefit finder: death of a loved one" edit page
- [ ] Click Delete
- [ ] Verify message "This action cannot be undone"
- [ ] Verify message "The following entity references will be skipped and leave orphans" and list of benefits

<img width="600" src="https://github.com/GSA/px-benefit-finder/assets/88853916/fe48580e-f2b3-4f6b-8023-959b7aeec6f8">

- [ ] Click Delete button to delete this life event form
- [ ] Verify life event form "Benefit finder: death of a loved one" deleted

<!--- If there are steps for user testing list them here -->