### PR TITLE
1541 remove deprecated function

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
@@ -531,16 +531,6 @@ class LifeEventController {
   public function getNode($nid, $mode) {
     $vid = 0;
 
-    // Do not use node of moderation state archived.
-    $id = $this->database
-      ->query('SELECT id FROM content_moderation_state_field_data
-                        WHERE moderation_state = :mstate AND content_entity_id = :nid',
-                        [':mstate' => 'archived', ':nid' => $nid])
-      ->fetchField();
-    if ($id) {
-      return NULL;
-    }
-
     if ($mode == "published") {
       $query = $this->entityTypeManager->getStorage('node')
         ->getQuery()


### PR DESCRIPTION
## PR Summary

This work removes deprecated function and uses entity API to get node.

## Related Github Issue

- Fixes #1541

## Detailed Testing steps

To test in local development site or dev site.

- [ ] Pull changes locally
- [ ] Copy usagov_benefit_finder modules to local development site custom module usagov_benefit_finder
        Run`bash scripts/pipeline/mv-usagov_benefit_finder.sh`
- [ ] Make local development site up at http://localhost
- [ ] Navigate to a`dmin/content?combine=&type=bears_life_event_form&status=All&langcode=All`
- [ ] Go to life event form "Benefit finder: death of a loved one" edit page
- [ ] Changed Time Estimate from 5-10 minutes to 10-20 minutes
- [ ] Save as published to generate both draft and published JSON files
- [ ] Navigate to benefit finder tool draft mode benefit-finder/death?mode=draft
- [ ] Verify estimated time 10-20 minutes

<img width="800" src="https://github.com/GSA/px-benefit-finder/assets/88853916/f19c9f51-020b-4ad9-b41c-693081b5a06c">

- [ ] Navigate to benefit finder tool published mode benefit-finder/death
- [ ] Verify estimated time 10-20 minutes

<img width="800" src="https://github.com/GSA/px-benefit-finder/assets/88853916/d6c0cf2b-16db-4d71-84be-cf3d1e9d1a69">
