### PR TITLE
1536 1537 1538 datalayer updates

### DIFF
--- a/benefit-finder/cypress/e2e/storybook/dataLayer.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/dataLayer.cy.js
@@ -33,15 +33,9 @@ const dataLayerValues = [
     bfData: {
       pageView: resultsView.bfData.pageView[0],
       viewTitle: 'Your potential benefits',
-      viewState: resultsView.bfData.viewState[1],
-    },
-  },
-  {
-    event: benefitCount.event,
-    bfData: {
-      eligible: 4,
-      moreInfo: 1,
-      notEligible: 25,
+      eligibleBenefitCount: { number: 4, string: '4' },
+      moreInfoBenefitCount: { number: 1, string: '1' },
+      notEligibleBenefitCount: { number: 25, string: '25' },
     },
   },
   {
@@ -122,7 +116,7 @@ describe('Calls to Google Analytics Object', function () {
         .then(() => {
           // we wait for the last event to fire
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          cy.wait(1000).then(() => {
+          cy.wait(2000).then(() => {
             // check last page change event
             const ev = {
               ...window.dataLayer.filter(
@@ -131,21 +125,18 @@ describe('Calls to Google Analytics Object', function () {
             }
             delete ev[0]['gtm.uniqueEventId']
 
-            cy.log(resultsView.bfData.pageView[1])
-            cy.log(dataLayerValues[2])
-
-            expect(dataLayerValues[2]).to.deep.equal(ev[0])
+            expect(ev[0]).to.deep.equal(dataLayerValues[2])
 
             // // check count event
-            const evCount = {
-              ...window.dataLayer.filter(
-                x => x.event === dataLayerValues[3].event
-              ),
-            }
+            // const evCount = {
+            //   ...window.dataLayer.filter(
+            //     x => x.event === dataLayerValues[2].event
+            //   ),
+            // }
 
-            delete evCount[0]['gtm.uniqueEventId']
+            // delete evCount[0]['gtm.uniqueEventId']
 
-            expect(dataLayerValues[3]).to.deep.equal(evCount[0])
+            // expect(dataLayerValues[3]).to.deep.equal(evCount[0])
           })
         })
     })
@@ -166,12 +157,12 @@ describe('Calls to Google Analytics Object', function () {
           // check last page change event
           const ev = {
             ...window.dataLayer.filter(
-              x => x?.event === dataLayerValues[4].event
+              x => x?.event === dataLayerValues[3].event
             ),
           }
           delete ev[0]['gtm.uniqueEventId']
 
-          expect(dataLayerValues[4]).to.deep.equal(ev[0])
+          expect(dataLayerValues[3]).to.deep.equal(ev[0])
         })
 
       pageObjects
@@ -181,7 +172,7 @@ describe('Calls to Google Analytics Object', function () {
           // check last page change event
           const ev = {
             ...window.dataLayer.filter(
-              x => x?.event === dataLayerValues[4].event
+              x => x?.event === dataLayerValues[3].event
             ),
           }
           // we ignore dedup here so there can be multiple fires

--- a/benefit-finder/cypress/e2e/storybook/dataLayer.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/dataLayer.cy.js
@@ -5,13 +5,8 @@ import { pageObjects } from '../../support/pageObjects'
 import * as EN_LOCALE_DATA from '../../../../benefit-finder/src/shared/locales/en/en.json'
 import * as BENEFITS_ELIBILITY_DATA from '../../fixtures/benefits-eligibility.json'
 
-const {
-  intro,
-  lifeEventSection,
-  resultsView,
-  benefitCount,
-  openAllBenefitAccordions,
-} = dataLayerUtils.dataLayerStructure
+const { intro, lifeEventSection, resultsView, openAllBenefitAccordions } =
+  dataLayerUtils.dataLayerStructure
 
 const dataLayerValues = [
   {
@@ -116,7 +111,7 @@ describe('Calls to Google Analytics Object', function () {
         .then(() => {
           // we wait for the last event to fire
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          cy.wait(2000).then(() => {
+          cy.wait(100).then(() => {
             // check last page change event
             const ev = {
               ...window.dataLayer.filter(
@@ -126,17 +121,6 @@ describe('Calls to Google Analytics Object', function () {
             delete ev[0]['gtm.uniqueEventId']
 
             expect(ev[0]).to.deep.equal(dataLayerValues[2])
-
-            // // check count event
-            // const evCount = {
-            //   ...window.dataLayer.filter(
-            //     x => x.event === dataLayerValues[2].event
-            //   ),
-            // }
-
-            // delete evCount[0]['gtm.uniqueEventId']
-
-            // expect(dataLayerValues[3]).to.deep.equal(evCount[0])
           })
         })
     })

--- a/benefit-finder/cypress/e2e/usagov-public-site/links.cy.js
+++ b/benefit-finder/cypress/e2e/usagov-public-site/links.cy.js
@@ -51,6 +51,7 @@ const validateLinks = ({ selectedData, path }) => {
 
 // to be removed when uncaught exceptions are addressed
 Cypress.on('uncaught:exception', (error, runnable) => {
+  console.log(error)
   return false
 })
 

--- a/benefit-finder/cypress/e2e/usagov-public-site/links.cy.js
+++ b/benefit-finder/cypress/e2e/usagov-public-site/links.cy.js
@@ -50,6 +50,7 @@ const validateLinks = ({ selectedData, path }) => {
 }
 
 // to be removed when uncaught exceptions are addressed
+// eslint-disable-next-line n/handle-callback-err
 Cypress.on('uncaught:exception', (error, runnable) => {
   return false
 })
@@ -58,6 +59,7 @@ describe('Verify correct status code handling', () => {
   // negate validation on our functional code
   Cypress.on('fail', (error, runnable) => {
     if (JSON.stringify(error).includes('httpstat')) {
+      // eslint-disable-next-line no-unused-expressions
       expect(error).to.not.be.undefined
     } else {
       throw error

--- a/benefit-finder/cypress/e2e/usagov-public-site/links.cy.js
+++ b/benefit-finder/cypress/e2e/usagov-public-site/links.cy.js
@@ -51,7 +51,6 @@ const validateLinks = ({ selectedData, path }) => {
 
 // to be removed when uncaught exceptions are addressed
 Cypress.on('uncaught:exception', (error, runnable) => {
-  console.log(error)
   return false
 })
 

--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
@@ -348,7 +348,7 @@ exports[`loads window query scenario 1 1`] = `
               >
                 <h4
                   aria-level="4"
-                  class=""
+                  class="bf-usa-summary-box__heading usa-summary-box__heading font-family-sans"
                   id="bf-summary-box-key-information"
                   role="heading"
                 >
@@ -6728,7 +6728,7 @@ exports[`loads window query scenario 1 1`] = `
             >
               <h3
                 aria-level="3"
-                class=""
+                class="bf-result-view-unmet-heading font-family-sans"
                 id=""
                 role="heading"
               >
@@ -7104,7 +7104,7 @@ exports[`loads window query scenario 2 1`] = `
               >
                 <h4
                   aria-level="4"
-                  class=""
+                  class="bf-usa-summary-box__heading usa-summary-box__heading font-family-sans"
                   id="bf-summary-box-key-information"
                   role="heading"
                 >
@@ -13496,7 +13496,7 @@ exports[`loads window query scenario 2 1`] = `
             >
               <h3
                 aria-level="3"
-                class=""
+                class="bf-result-view-unmet-heading font-family-sans"
                 id=""
                 role="heading"
               >

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -561,6 +561,7 @@ const LifeEventSection = ({
                 <div>
                   <Modal
                     id="nav-modal"
+                    dataLayerValue={{ viewTitle: currentData.section.heading }}
                     modalHeading={reviewSelectionModal.heading}
                     navItemOneLabel={reviewSelectionModal.buttonGroup[0].value}
                     navItemOneFunction={setVerifyStep}

--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -53,6 +53,7 @@ const Modal = ({
   handleCheckRequriedFields,
   modalOpen,
   setModalOpen,
+  dataLayerValue,
 }) => {
   // state
   const triggerRef = useRef(null)
@@ -107,7 +108,8 @@ const Modal = ({
       dataLayerUtils.dataLayerPush(window, {
         event: modal.event,
         bfData: {
-          modalOpen,
+          pageView: modal.bfData.pageView,
+          viewTitle: dataLayerValue.viewTitle,
         },
       })
   }, [])

--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -109,7 +109,7 @@ const Modal = ({
         event: modal.event,
         bfData: {
           pageView: modal.bfData.pageView,
-          viewTitle: dataLayerValue.viewTitle,
+          viewTitle: `${dataLayerValue.viewTitle} modal`,
         },
       })
   }, [])

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -48,9 +48,9 @@ const ResultsView = ({
 
   const [notEligibleView, setnotEligibleView] = useState(false)
   const [eligibilityCount, setEligibilityCount] = useState({
-    eligible: 0,
-    notEligible,
-    moreInfo: 0,
+    eligibleBenefitCount: { number: 0, string: '0' },
+    notEligibleBenefitCount: { number: 0, string: '0' },
+    moreInfoBenefitCount: { number: 0, string: '0' },
   })
 
   const resetElement = useResetElement()
@@ -81,7 +81,7 @@ const ResultsView = ({
         matches.push(div)
       }
     }
-    return matches.length
+    return { number: matches.length, string: `${matches.length}` }
   }
 
   const handleViewToggle = () => {
@@ -90,18 +90,18 @@ const ResultsView = ({
     resetElement.current.focus()
   }
 
-  const zeroBenefitsResult = eligibilityCount.eligible === 0
+  const zeroBenefitsResult = eligibilityCount.eligibleBenefitCount.number === 0
 
   useEffect(() => {
     window.scrollTo(0, 0)
     setEligibilityCount({
-      eligible: handleEligibilityLength(
+      eligibleBenefitCount: handleEligibilityLength(
         ui.benefitAccordion.eligibleStatusLabels[0]
       ),
-      moreInfo: handleEligibilityLength(
+      moreInfoBenefitCount: handleEligibilityLength(
         ui.benefitAccordion.eligibleStatusLabels[1]
       ),
-      notEligible: handleEligibilityLength(
+      notEligibleBenefitCount: handleEligibilityLength(
         ui.benefitAccordion.eligibleStatusLabels[2]
       ),
     })
@@ -110,7 +110,7 @@ const ResultsView = ({
   // handle dataLayer
   useEffect(() => {
     const { resultsView } = dataLayerUtils.dataLayerStructure
-    eligibilityCount.notEligible >= 0 &&
+    eligibilityCount.notEligibleBenefitCount.number >= 0 &&
       dataLayerUtils.dataLayerPush(window, {
         event: resultsView.event,
         bfData: {
@@ -124,19 +124,10 @@ const ResultsView = ({
                 eligible.chevron.heading
               : (zeroBenefitsResult && zeroBenefits.chevron.heading) ||
                 notEligible.chevron.heading,
+          ...eligibilityCount,
         },
       })
   }, [notEligibleView, eligibilityCount])
-
-  // handle dataLayer
-  useEffect(() => {
-    const { benefitCount } = dataLayerUtils.dataLayerStructure
-    eligibilityCount.notEligible >= 0 &&
-      dataLayerUtils.dataLayerPush(window, {
-        event: benefitCount.event,
-        bfData: eligibilityCount,
-      })
-  }, [eligibilityCount])
 
   // compare the selected criteria array with benefits
   return (
@@ -149,9 +140,15 @@ const ResultsView = ({
       }
       data-analytics-content-criteria-values={criteriaValues}
       data-analytics-content-benefits={benefitsLength}
-      data-analytics-content-eligible={eligibilityCount.eligible}
-      data-analytics-content-not-eligible={eligibilityCount.notEligible}
-      data-analytics-content-more-info={eligibilityCount.moreInfo}
+      data-analytics-content-eligible={
+        eligibilityCount.eligibleBenefitCount.number
+      }
+      data-analytics-content-not-eligible={
+        eligibilityCount.notEligibleBenefitCount.number
+      }
+      data-analytics-content-more-info={
+        eligibilityCount.moreInfoBenefitCount.number
+      }
     >
       <Chevron
         heading={

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -124,12 +124,6 @@ const ResultsView = ({
                 eligible.chevron.heading
               : (zeroBenefitsResult && zeroBenefits.chevron.heading) ||
                 notEligible.chevron.heading,
-          viewState:
-            notEligibleView === true
-              ? (zeroBenefitsResult && resultsView.bfData.viewState[2]) ||
-                resultsView.bfData.viewState[0]
-              : (zeroBenefitsResult && resultsView.bfData.viewState[3]) ||
-                resultsView.bfData.viewState[1],
         },
       })
   }, [notEligibleView, eligibilityCount])

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -47,11 +47,7 @@ const ResultsView = ({
   } = ui
 
   const [notEligibleView, setnotEligibleView] = useState(false)
-  const [eligibilityCount, setEligibilityCount] = useState({
-    eligibleBenefitCount: { number: 0, string: '0' },
-    notEligibleBenefitCount: { number: 0, string: '0' },
-    moreInfoBenefitCount: { number: 0, string: '0' },
-  })
+  const [eligibilityCount, setEligibilityCount] = useState(null)
 
   const resetElement = useResetElement()
 
@@ -90,7 +86,7 @@ const ResultsView = ({
     resetElement.current.focus()
   }
 
-  const zeroBenefitsResult = eligibilityCount.eligibleBenefitCount.number === 0
+  const zeroBenefitsResult = eligibilityCount?.eligibleBenefitCount.number === 0
 
   useEffect(() => {
     window.scrollTo(0, 0)
@@ -110,7 +106,7 @@ const ResultsView = ({
   // handle dataLayer
   useEffect(() => {
     const { resultsView } = dataLayerUtils.dataLayerStructure
-    eligibilityCount.notEligibleBenefitCount.number >= 0 &&
+    eligibilityCount !== null &&
       dataLayerUtils.dataLayerPush(window, {
         event: resultsView.event,
         bfData: {
@@ -141,13 +137,13 @@ const ResultsView = ({
       data-analytics-content-criteria-values={criteriaValues}
       data-analytics-content-benefits={benefitsLength}
       data-analytics-content-eligible={
-        eligibilityCount.eligibleBenefitCount.number
+        eligibilityCount?.eligibleBenefitCount.number
       }
       data-analytics-content-not-eligible={
-        eligibilityCount.notEligibleBenefitCount.number
+        eligibilityCount?.notEligibleBenefitCount.number
       }
       data-analytics-content-more-info={
-        eligibilityCount.moreInfoBenefitCount.number
+        eligibilityCount?.moreInfoBenefitCount.number
       }
     >
       <Chevron

--- a/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
+++ b/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
@@ -29,12 +29,6 @@ const dataLayerStructure = {
     bfData: {
       pageView: ['bf-result-eligible-view', 'bf-result-not-eligible-view'],
       viewTitle: null,
-      viewState: [
-        'bf-not-eligible-view',
-        'bf-eligible-view',
-        'bf-not-eligible-view-zero-benefits',
-        'bf-eligible-view-zero-benefits',
-      ],
     },
   },
   openAllBenefitAccordions: {

--- a/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
+++ b/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
@@ -49,7 +49,6 @@ const dataLayerStructure = {
       benefitTitle: null,
     },
   },
-  benefitCount: { event: 'bf_count', bfData: null },
 }
 
 export default dataLayerStructure

--- a/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
+++ b/benefit-finder/src/shared/utils/dataLayerUtils/dataLayerStructure.js
@@ -11,9 +11,10 @@ const dataLayerStructure = {
     },
   },
   modal: {
-    event: 'bf_modal_open',
+    event: 'bf_page_change',
     bfData: {
-      modalOpen: false,
+      pageView: 'bf-form-completion-modal',
+      viewTitle: null,
     },
   },
   verifySelections: {


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

This addresses refinements to the dataLayer work in Sprint 34

[Consolidate bf_count data layer event with bf_page_change ](https://github.com/GSA/px-benefit-finder/issues/1538)	https://github.com/GSA/px-benefit-finder/issues/1538
[Change modal_open event to a page_change event](https://github.com/GSA/px-benefit-finder/issues/1537)	https://github.com/GSA/px-benefit-finder/issues/1537
[Remove viewState data layer variable](https://github.com/GSA/px-benefit-finder/issues/1536)	https://github.com/GSA/px-benefit-finder/issues/1536

## Related Github Issue

- Fixes #1538
- Fixes #1537
- Fixes #1536

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] `cd benefit-finder`
- [ ] `npm install`
- [ ] `npm run start`


[Change modal_open event to a page_change event](https://github.com/GSA/px-benefit-finder/issues/1537)	https://github.com/GSA/px-benefit-finder/issues/1537

- [ ] navigate to `/benefit-finder/death`
- [ ] complete required fields and answer YES to radio values
- [ ] after triggering the modal open, console.log(window.dataLayer)
- [ ] confirm dataLayer event reflects

```
{
	event: "bf_page_change",
	bfData: {
		pageView: "bf-form-completion-modal",
		viewTitle: "{current form step heading} modal"
	}
}
```

[Consolidate bf_count data layer event with bf_page_change ](https://github.com/GSA/px-benefit-finder/issues/1538)	https://github.com/GSA/px-benefit-finder/issues/1538

- [ ] CLICK "See Results" button
- [ ] console.log(window.dataLayer)
- [ ] confirm dataLayer event reflects to include benefit counts in "bf_page_change" event

```
{
	event: "bf_page_change",
	bfData: {
		pageView: "bf-result-eligible-view",
		viewTitle: "Your potential benefits",
		eligibleBenefitCount: {
			number: 5,
			string: "5"
		},
		moreInfoBenefitCount: {
			number: 0,
			string: "0"
		},
		notEligibleBenefitCount: {
			number: 25,
			string: "25"
		}
	}
}
```

[Remove viewState data layer variable](https://github.com/GSA/px-benefit-finder/issues/1536)	https://github.com/GSA/px-benefit-finder/issues/1536

- [ ] ensure viewState values are not included in the bfData object on eligible results or ineligible results view