### PR TITLE
1554 fix accordion open all

### DIFF
--- a/benefit-finder/cypress/e2e/storybook/benefitAccordionGroup.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/benefitAccordionGroup.cy.js
@@ -1,0 +1,43 @@
+import * as utils from '../../support/utils'
+import * as BENEFITS_ELIBILITY_DATA from '../../fixtures/benefits-eligibility.json'
+
+beforeEach(() => {
+  const selectedData = BENEFITS_ELIBILITY_DATA.scenario_1_covid.en.param
+  const scenario = utils.encodeURIFromObject(selectedData)
+  cy.visit(`${utils.storybookUri}${scenario}`)
+})
+
+describe('BenefitAccordionGroup component tests', () => {
+  it('Validate opening individual accordion only expands the clicked accordion and clicking it again closes it', () => {
+    cy.get('.bf-usa-accordion__button.usa-accordion__button').eq(0).click()
+    cy.get('.bf-usa-accordion__button.usa-accordion__button')
+      .eq(0)
+      .should('have.attr', 'aria-expanded', 'true')
+    cy.get('.bf-usa-accordion__button.usa-accordion__button')
+      .eq(1)
+      .should('have.attr', 'aria-expanded', 'false')
+    cy.get('.bf-usa-accordion__button.usa-accordion__button').eq(0).click()
+    cy.get('.bf-usa-accordion__button.usa-accordion__button').each(
+      accordion => {
+        cy.wrap(accordion).should('have.attr', 'aria-expanded', 'false')
+      }
+    )
+  })
+
+  it('Validate clicking Expand all opens all accordions', () => {
+    cy.get('.bf-expand-all').click()
+    cy.get('.bf-expand-all').should('contain.text', 'Close all')
+    cy.get('.usa-accordion__button').each(accordion => {
+      cy.wrap(accordion).should('have.attr', 'aria-expanded', 'true')
+    })
+  })
+
+  it('Validate clicking Collapse all closes all accordions', () => {
+    cy.get('.bf-expand-all').click()
+    cy.get('.bf-expand-all').click()
+    cy.get('.bf-expand-all').should('contain.text', 'Open all')
+    cy.get('.usa-accordion__button').each(accordion => {
+      cy.wrap(accordion).should('have.attr', 'aria-expanded', 'false')
+    })
+  })
+})

--- a/benefit-finder/cypress/e2e/storybook/openAllAccordions.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/openAllAccordions.cy.js
@@ -8,7 +8,7 @@ beforeEach(() => {
   cy.visit(`${utils.storybookUri}${scenario}`)
 })
 
-describe('BenefitAccordionGroup component tests', () => {
+describe('open all interaction tests', () => {
   it('Validate clicking open all expands the accordions', () => {
     pageObjects
       .expandAll()

--- a/benefit-finder/cypress/e2e/storybook/openAllAccordions.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/openAllAccordions.cy.js
@@ -1,0 +1,122 @@
+import * as utils from '../../support/utils'
+import { pageObjects } from '../../support/pageObjects'
+import * as BENEFITS_ELIBILITY_DATA from '../../fixtures/benefits-eligibility.json'
+
+beforeEach(() => {
+  const selectedData = BENEFITS_ELIBILITY_DATA.scenario_1_covid.en.param
+  const scenario = utils.encodeURIFromObject(selectedData)
+  cy.visit(`${utils.storybookUri}${scenario}`)
+})
+
+describe('BenefitAccordionGroup component tests', () => {
+  it('Validate clicking open all expands the accordions', () => {
+    pageObjects
+      .expandAll()
+      .click()
+      .then(() => {
+        cy.get('.bf-usa-accordion__button.usa-accordion__button').each(
+          accordion => {
+            cy.wrap(accordion).should('have.attr', 'aria-expanded', 'true')
+          }
+        )
+      })
+  })
+
+  it('Validate clicking close all closes all the accordions', () => {
+    pageObjects
+      .expandAll()
+      .click()
+      .then(() => {
+        pageObjects
+          .expandAll()
+          .click()
+          .then(() => {
+            cy.get('.bf-usa-accordion__button.usa-accordion__button').each(
+              accordion => {
+                cy.wrap(accordion).should('have.attr', 'aria-expanded', 'false')
+              }
+            )
+          })
+      })
+  })
+
+  it('Validate clicking open all expands the accordions, then toggling eligible view, sets them back to close', () => {
+    pageObjects
+      .expandAll()
+      .click()
+      .then(() => {
+        cy.get('.bf-usa-accordion__button.usa-accordion__button').each(
+          accordion => {
+            cy.wrap(accordion).should('have.attr', 'aria-expanded', 'true')
+          }
+        )
+
+        pageObjects
+          .notEligibleResultsButton()
+          .click()
+          .then(() => {
+            cy.get('.bf-usa-accordion__button.usa-accordion__button').each(
+              accordion => {
+                cy.wrap(accordion).should('have.attr', 'aria-expanded', 'false')
+              }
+            )
+          })
+      })
+  })
+
+  it('from the not eligible view, validate clicking open all expands the accordions, then toggling eligible view, sets them back to close', () => {
+    pageObjects
+      .notEligibleResultsButton()
+      .click()
+      .then(() => {
+        cy.get('.bf-usa-accordion__button.usa-accordion__button').each(
+          accordion => {
+            cy.wrap(accordion).should('have.attr', 'aria-expanded', 'false')
+          }
+        )
+
+        pageObjects
+          .expandAll()
+          .click()
+          .then(() => {
+            cy.get('.bf-usa-accordion__button.usa-accordion__button').each(
+              accordion => {
+                cy.wrap(accordion).should('have.attr', 'aria-expanded', 'true')
+              }
+            )
+
+            pageObjects
+              .stepBackLink()
+              .click()
+              .then(() => {
+                cy.get('.bf-usa-accordion__button.usa-accordion__button').each(
+                  accordion => {
+                    cy.wrap(accordion).should(
+                      'have.attr',
+                      'aria-expanded',
+                      'false'
+                    )
+                  }
+                )
+              })
+          })
+      })
+  })
+
+  // it('Validate clicking Expand all opens all accordions', () => {
+  //   cy.get('.bf-expand-all').click()
+  //   cy.get('.bf-expand-all').should('contain.text', 'Close all')
+  //   cy.get('.usa-accordion__button').each(accordion => {
+  //     cy.wrap(accordion).should('have.attr', 'aria-expanded', 'true')
+  //   })
+  // })
+
+  // it('Validate clicking Collapse all closes all accordions', () => {
+  //   cy.get('.bf-expand-all').click()
+  //   cy.get('.bf-expand-all').click()
+  //   cy.get('.bf-expand-all').should('contain.text', 'Open all')
+  //   cy.get('.usa-accordion__button').each(accordion => {
+  //     cy.wrap(accordion).should('have.attr', 'aria-expanded', 'false')
+  //   })
+  // })
+})

--- a/benefit-finder/cypress/support/pageObjects.js
+++ b/benefit-finder/cypress/support/pageObjects.js
@@ -116,6 +116,14 @@ class PageObjects {
   benefitResultsView() {
     return cy.get('.bf-result-view')
   }
+
+  notEligibleResultsButton() {
+    return cy.get('.bf-result-view-unmet > .usa-button')
+  }
+
+  stepBackLink() {
+    return cy.get('.bf-step-back-link')
+  }
 }
 
 export const pageObjects = new PageObjects()

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/indexBenefitAccordionGroup.cy.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/indexBenefitAccordionGroup.cy.jsx
@@ -1,48 +1,12 @@
 import { composeStories } from '@storybook/react'
 import * as stories from '../index.stories'
-const { Primary, ExpandAll, SourceIsEnglish } = composeStories(stories)
+const { SourceIsEnglish } = composeStories(stories)
 
+// Todo: consider moving this out of compoents test
 describe('BenefitAccordionGroup component tests', () => {
-  it('Validate opening individual accordion only expands the clicked accordion and clicking it again closes it', () => {
-    cy.mount(<Primary />)
-    cy.get('.bf-usa-accordion__button.usa-accordion__button').eq(0).click()
-    cy.get('.bf-usa-accordion__button.usa-accordion__button')
-      .eq(0)
-      .should('have.attr', 'aria-expanded', 'true')
-    cy.get('.bf-usa-accordion__button.usa-accordion__button')
-      .eq(1)
-      .should('have.attr', 'aria-expanded', 'false')
-    cy.get('.bf-usa-accordion__button.usa-accordion__button').eq(0).click()
-    cy.get('.bf-usa-accordion__button.usa-accordion__button').each(
-      accordion => {
-        cy.wrap(accordion).should('have.attr', 'aria-expanded', 'false')
-      }
-    )
-  })
-
-  it('Validate clicking Expand all opens all accordions', () => {
-    cy.mount(<ExpandAll />)
-    cy.get('.bf-expand-all').click()
-    cy.get('.bf-expand-all').should('contain.text', 'Close all')
-    cy.get('.usa-accordion__button').each(accordion => {
-      cy.wrap(accordion).should('have.attr', 'aria-expanded', 'true')
-    })
-  })
-
-  it('Validate clicking Collapse all closes all accordions', () => {
-    cy.mount(<ExpandAll />)
-    cy.get('.bf-expand-all').click()
-    cy.get('.bf-expand-all').click()
-    cy.get('.bf-expand-all').should('contain.text', 'Open all')
-    cy.get('.usa-accordion__button').each(accordion => {
-      cy.wrap(accordion).should('have.attr', 'aria-expanded', 'false')
-    })
-  })
-
   it('Validate SourceIsEnglish results in the display of (en inglés)', () => {
     const content = '(en inglés)'
     cy.mount(<SourceIsEnglish />)
-    cy.get('.bf-expand-all').click()
     cy.get('.bf-usa-link').then(links => {
       cy.wrap(links[0]).should('contain', content)
       cy.wrap(links[1]).should('not.contain', content)

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/index.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/index.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+// import { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import { createMarkup, dataLayerUtils } from '../../utils'
 import {
@@ -16,12 +16,18 @@ import './_index.scss'
  * @param {array} data - our benefits data
  * @param {string} entryKey - which key in the array to target
  * @param {bool} expandAll - determnines if we include ExpandAll component
+ * @param {bool} isExpandAll - determines if all the accordions in the group are expanded
+ * @param {function} setExpandAll - inherited useState function
+ * @param {function} notEligibleView - inherited bolean state
+ * @param {object} ui - inherited ui content
  * @return {html} returns html
  */
 const BenefitAccordionGroup = ({
   data,
   entryKey,
   expandAll,
+  isExpandAll,
+  setExpandAll,
   notEligibleView,
   ui,
 }) => {
@@ -36,12 +42,6 @@ const BenefitAccordionGroup = ({
   const { closedState, openState } = benefitAccordionGroup
   const { benefitLink, openAllBenefitAccordions } =
     dataLayerUtils.dataLayerStructure
-  /**
-   * a hook that hanldes our open state of the accordions in our group
-   * @function
-   * @return {boolean} returns true or false
-   */
-  const [isExpandAll, setExpandAll] = useState(false)
 
   /**
    * a function that returns the string value of our expanded action
@@ -261,6 +261,10 @@ BenefitAccordionGroup.propTypes = {
   data: PropTypes.array,
   entryKey: PropTypes.string,
   expandAll: PropTypes.bool,
+  isExpandAll: PropTypes.bool,
+  setExpandAll: PropTypes.func,
+  notEligibleView: PropTypes.bool,
+  ui: PropTypes.object,
 }
 
 export default BenefitAccordionGroup

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/index.stories.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/index.stories.jsx
@@ -1,3 +1,4 @@
+// import { useState } from 'react'
 import BenefitAccordionGroup from './index.jsx'
 import content from '../../api/mock-data/current.js'
 import * as en from '../../locales/en/en.json'
@@ -12,6 +13,9 @@ const { resultsView } = en
 const SourceIsEnglishBenefits = b.slice(5, 7)
 SourceIsEnglishBenefits[0].benefit.SourceIsEnglish = true // ensure true
 SourceIsEnglishBenefits[1].benefit.SourceIsEnglish = false // ensure false
+
+let isExpandAll = false
+const setExpandAll = () => (isExpandAll = !isExpandAll)
 
 export default {
   component: BenefitAccordionGroup,
@@ -34,6 +38,8 @@ export const ExpandAll = {
     ...Primary.args,
     data: b.slice(3, 5),
     expandAll: true,
+    isExpandAll: false,
+    setExpandAll,
   },
 }
 

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -49,6 +49,13 @@ const ResultsView = ({
   const [notEligibleView, setnotEligibleView] = useState(false)
   const [eligibilityCount, setEligibilityCount] = useState(null)
 
+  /**
+   * a hook that hanldes our open state of the accordions in our group
+   * @function
+   * @return {boolean} returns true or false
+   */
+  const [isExpandAll, setExpandAll] = useState(false)
+
   const resetElement = useResetElement()
 
   useEffect(() => {
@@ -81,6 +88,8 @@ const ResultsView = ({
   }
 
   const handleViewToggle = () => {
+    console.log('handleToggleView', isExpandAll)
+    setExpandAll(false)
     setnotEligibleView(!notEligibleView)
     window.scrollTo(0, 0)
     resetElement.current.focus()
@@ -233,6 +242,8 @@ const ResultsView = ({
                 zeroBenefitsResult === false ||
                 (zeroBenefitsResult && notEligibleView)
               }
+              isExpandAll={isExpandAll}
+              setExpandAll={setExpandAll}
               ui={ui}
             />
           </div>

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -88,7 +88,6 @@ const ResultsView = ({
   }
 
   const handleViewToggle = () => {
-    console.log('handleToggleView', isExpandAll)
     setExpandAll(false)
     setnotEligibleView(!notEligibleView)
     window.scrollTo(0, 0)


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

This work updates the functionality of the application to ensure that when a user toggles between eligible and not eligible views, the accordions are default set to closed.

## Related Github Issue

- Fixes #1554 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] `cd benefit-finder`
- [ ] `npm install`
- [ ] `npm run start`

<!--- If there are steps for user testing list them here -->
- [x] visit `benefit-finder/death`
- [x] navigate the form filling out required fields, an answering yes to all radio questions
- [x] in the results view, ensure that the radios are default closed
- [x] console.log(window.dataLayer)
- [x] ensure that the `bf_open_all_accordions` hasn't yet fired
- [x] CLICK `open all +` toggle
- [x] ensure `open all +` toggle updates to `close all -`
- [x] ensure that the accordions all open
- [x] console.log(window.dataLayer)
- [x] ensure that the `bf_open_all_accordions` has fired once
- [x] CLICK `see benefits you do not qualify for` button
- [x] ensure `close all -` toggle updates to `open all +`
- [x] console.log(window.dataLayer)
- [x] ensure that the `bf_open_all_accordions` has fired once
- [x] CLICK `open all +` toggle
- [x] ensure `open all +` toggle updates to `close all -`
- [x] ensure that the accordions all open
- [x] CLICK `back` link
- [x] ensure `close all -` toggle updates to `open all +`
- [ ] console.log(window.dataLayer)
- [x] ensure that the `bf_open_all_accordions` has fired twice

expected:


https://github.com/GSA/px-benefit-finder/assets/37077057/8a1911fa-4998-45b6-ac07-5b588b7b0218




