### PR TITLE
PXBF-1544-zero-benefits-view: add zero benefits view validation

### DIFF
--- a/benefit-finder/cypress/e2e/storybook/selected-criteria-eligibility-benefits.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/selected-criteria-eligibility-benefits.cy.js
@@ -207,4 +207,24 @@ describe('Validate correct eligibility benefits display based on selected criter
       .keyEligibilityCriteriaListIcon()
       .should('have.class', 'bf-checkmark--green')
   })
+
+  it('Should display Zero benefit view when no benefit are eligible', () => {
+    const selectedData = BENEFITS_ELIBILITY_DATA.zero_benefit_view.en.param
+    const enResults = BENEFITS_ELIBILITY_DATA.zero_benefit_view.en.results
+    const scenario = utils.encodeURIFromObject(selectedData)
+    cy.visit(`${utils.storybookUri}${scenario}`)
+
+    pageObjects
+      .zeroBenefitsViewHeading()
+      .should('contain', EN_LOCALE_DATA.resultsView.zeroBenefits.heading)
+
+    pageObjects
+      .benefitsAccordion()
+      .filter(':visible')
+      .should('have.length', enResults.eligible.length)
+
+    pageObjects
+      .seeAllBenefitsButton()
+      .should('contain', EN_LOCALE_DATA.resultsView.zeroBenefits.cta)
+  })
 })

--- a/benefit-finder/cypress/fixtures/benefits-eligibility.json
+++ b/benefit-finder/cypress/fixtures/benefits-eligibility.json
@@ -209,5 +209,29 @@
         "shared": "true"
       }
     }
+  },
+  "zero_benefit_view": {
+    "en": {
+      "param": {
+        "applicant_date_of_birth": {
+          "month": 4,
+          "day": 5,
+          "year": 1972
+        },
+        "applicant_relationship_to_the_deceased": "Parent",
+        "applicant_marital_status": "Married",
+        "deceased_date_of_death": {
+          "month": 12,
+          "day": 12,
+          "year": 2023
+        },
+        "shared": "true"
+      },
+      "results": {
+        "eligible": {
+          "length": 0
+        }
+      }
+    }
   }
 }

--- a/benefit-finder/cypress/support/pageObjects.js
+++ b/benefit-finder/cypress/support/pageObjects.js
@@ -124,6 +124,14 @@ class PageObjects {
   stepBackLink() {
     return cy.get('.bf-step-back-link')
   }
+
+  zeroBenefitsViewHeading() {
+    return cy.get('[data-testid="zero-benefits-view-heading"]')
+  }
+
+  seeAllBenefitsButton() {
+    return cy.get('.bf-zero-benefits-view-cta .bf-usa-button')
+  }
 }
 
 export const pageObjects = new PageObjects()

--- a/benefit-finder/cypress/support/pageObjects.js
+++ b/benefit-finder/cypress/support/pageObjects.js
@@ -130,7 +130,7 @@ class PageObjects {
   }
 
   seeAllBenefitsButton() {
-    return cy.get('.bf-zero-benefits-view-cta .bf-usa-button')
+    return cy.get('[data-testid="zero-benefits-view-cta-button"]')
   }
 }
 

--- a/benefit-finder/src/shared/components/ResultsView/components/blocks/ZeroBenefitsHeading/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/ResultsView/components/blocks/ZeroBenefitsHeading/__tests__/__snapshots__/index.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`ZeroBenefitsHeading > renders a match to the previous snapshot 1`] = `
   <h2
     aria-level="2"
     class="bf-zero-benefits-view-heading font-family-sans"
+    data-testid="zero-benefits-view-heading"
     role="heading"
   />
   <h3
@@ -17,6 +18,7 @@ exports[`ZeroBenefitsHeading > renders a match to the previous snapshot 1`] = `
   >
     <button
       class="bf-usa-button usa-button bf-usa-button--outline usa-button--outline"
+      data-testid="zero-benefits-view-cta-button"
       type="button"
     />
   </div>

--- a/benefit-finder/src/shared/components/ResultsView/components/blocks/ZeroBenefitsHeading/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/components/blocks/ZeroBenefitsHeading/index.jsx
@@ -11,7 +11,11 @@ const ZeroBenefitsHeadingBlock = ({
 }) => {
   return (
     <>
-      <Heading className="bf-zero-benefits-view-heading" headingLevel={2}>
+      <Heading
+        className="bf-zero-benefits-view-heading"
+        data-testid="zero-benefits-view-heading"
+        headingLevel={2}
+      >
         {ui?.heading}
       </Heading>
       <Heading
@@ -21,7 +25,11 @@ const ZeroBenefitsHeadingBlock = ({
       />
       {!notEligibleView && (
         <div className="bf-zero-benefits-view-cta">
-          <Button onClick={handleViewToggle} secondary>
+          <Button
+            data-testid="zero-benefits-view-cta-button"
+            onClick={handleViewToggle}
+            secondary
+          >
             {ui?.cta}
           </Button>
         </div>


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This PR add cypress automated tests to validate the view that renders when no benefits are eligible. Only required fields have been completed in the death of a loved one which results in zero benefits state. Validations have been added to expect no eligible results, no accordions in view and also that "See all benefits" button displays
## Related Github Issue

- Fixes #1544 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ]  `cd benefit finder`
- [ ] `npm run dev:storybook`
- [ ]  `npm run cy:run` and verify all test pass
<!--- If there are steps for user testing list them here -->
