### PR TITLE
1571 update life event controller to use benefit finder trait

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
@@ -3,6 +3,7 @@
 namespace Drupal\usagov_benefit_finder_api\Controller;
 
 use Drupal\Core\File\FileSystemInterface;
+use Drupal\usagov_benefit_finder\Traits\BenefitFinderTrait;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
@@ -10,6 +11,8 @@ use Symfony\Component\HttpFoundation\JsonResponse;
  * @package Drupal\usagov_benefit_finder_api\Controller
  */
 class LifeEventController {
+
+  use BenefitFinderTrait;
 
   /**
    * The entity type manager service.
@@ -119,7 +122,7 @@ class LifeEventController {
     $fileUrlString = $this->fileUrlGenerator->generate($filename)->toString();
 
     // Assign the file to JSON data file field of life event of given ID.
-    $life_event = $this->getLifeEvent($id);
+    $life_event = $this->getLifeEventById($id, $this->mode);
     if ($life_event) {
       $field_name = '';
       if ($this->mode == "published") {
@@ -174,7 +177,7 @@ class LifeEventController {
     }
 
     // Get life event form node and node ID of given life event.
-    $life_event_form_node = $this->getLifeEventForm($id);
+    $life_event_form_node = $this->getLifeEventFormById($id, $this->mode);
     if (empty($life_event_form_node)) {
       $result = [];
       $json = json_encode($result, JSON_PRETTY_PRINT);
@@ -248,7 +251,7 @@ class LifeEventController {
     $life_event_form['sectionsEligibilityCriteria'] = $life_event_form_sections;
 
     // Get benefits of given life event form.
-    $benefit_nodes = $this->getBenefits($life_event_form_node_id);
+    $benefit_nodes = $this->getBenefitsByLifeEventForm($life_event_form_node_id, $this->mode);
 
     // Build benefits.
     foreach ($benefit_nodes as $benefit_node) {
@@ -271,57 +274,6 @@ class LifeEventController {
     }
 
     return $result;
-  }
-
-  /**
-   * Gets life event of given ID.
-   * @param $id
-   * @return \Drupal\node\NodeInterface
-   *   The life event node.
-   */
-  public function getLifeEvent($id) {
-    $query = \Drupal::entityQuery('node')
-      ->accessCheck(TRUE)
-      ->condition('type', 'bears_life_event')
-      ->condition('field_b_id', $id)
-      ->range(0, 1);
-    $node_id = current($query->execute());
-    return $this->getNode($node_id, $this->mode);
-  }
-
-  /**
-   * Gets life event form of given ID.
-   * @param $id
-   * @return \Drupal\node\NodeInterface
-   *   The life event form node.
-   */
-  public function getLifeEventForm($id) {
-    $query = \Drupal::entityQuery('node')
-      ->accessCheck(TRUE)
-      ->condition('type', 'bears_life_event_form')
-      ->condition('field_b_id', $id)
-      ->range(0, 1);
-    $node_id = current($query->execute());
-    return $this->getNode($node_id, $this->mode);
-  }
-
-  /**
-   * Gets benefits of given life event form.
-   * @param $nid
-   * @return \Drupal\node\NodeInterface[]
-   *   The benefit nodes.
-   */
-  public function getBenefits($nid) {
-    $nodes = [];
-    $query = \Drupal::entityQuery('node')
-      ->accessCheck(TRUE)
-      ->condition('type', 'bears_benefit')
-      ->condition('field_b_life_event_forms', $nid, 'CONTAINS');
-    $nids = $query->execute();
-    foreach ($nids as $nid) {
-      $nodes[] = $this->getNode($nid, $this->mode);
-    }
-    return $nodes;
   }
 
   /**
@@ -363,7 +315,7 @@ class LifeEventController {
 
     // Get criteria node.
     $target_id = $criteria->get('field_b_criteria_key')->target_id;
-    $criteria_node = $this->getCriteria($target_id);
+    $criteria_node = $this->getCriteria($target_id, $this->mode);
 
     // Do not build missing criteria.
     if (empty($criteria_node)) {
@@ -447,7 +399,7 @@ class LifeEventController {
 
     // Get agency node and build benefit agency.
     $target_id = $node->get('field_b_agency')->target_id;
-    $agency = $this->getAgency($target_id);
+    $agency = $this->getAgency($target_id, $this->mode);
     if ($agency) {
       $benefit["agency"] = [
         "title" => $agency->get('title')->value,
@@ -472,7 +424,7 @@ class LifeEventController {
       $benefit_eligibility = [];
 
       $target_id = $eligibility->get('field_b_criteria_key')->target_id;
-      $criteria_node = $this->getCriteria($target_id);
+      $criteria_node = $this->getCriteria($target_id, $this->mode);
       if ($criteria_node) {
         $ckey = $criteria_node->get('field_b_criteria_key')->value;
 
@@ -492,76 +444,6 @@ class LifeEventController {
     $benefit['eligibility'] = $benefit_eligibilitys;
 
     return $benefit;
-  }
-
-  /**
-   * Gets criteria of given nid.
-   *
-   * @param $nid
-   *   The criteria node ID.
-   * @return \Drupal\node\NodeInterface
-   *   The criteria node.
-   */
-  public function getCriteria($nid) {
-    return $this->getNode($nid, $this->mode);
-  }
-
-  /**
-   * Gets agency of given nid.
-   *
-   * @param $nid
-   *   The agency node ID.
-   * @return \Drupal\node\NodeInterface
-   *   The agency node.
-   */
-  public function getAgency($nid) {
-    return $this->getNode($nid, $this->mode);
-  }
-
-  /**
-   * Gets node of given nid and mode.
-   *
-   * @param $nid
-   *   The node ID.
-   * @param $mode
-   *   The mode.
-   * @return \Drupal\node\NodeInterface
-   *   The node.
-   */
-  public function getNode($nid, $mode) {
-    $vid = 0;
-
-    if ($mode == "published") {
-      $query = $this->entityTypeManager->getStorage('node')
-        ->getQuery()
-        ->allRevisions()
-        ->condition('nid', $nid)
-        ->condition('status', 1)
-        ->sort('vid', 'DESC')
-        ->range(0, 1)
-        ->accessCheck(TRUE);
-    }
-    elseif ($mode == "draft") {
-      $query = $this->entityTypeManager->getStorage('node')
-        ->getQuery()
-        ->allRevisions()
-        ->condition('nid', $nid)
-        ->sort('vid', 'DESC')
-        ->range(0, 1)
-        ->accessCheck(TRUE);
-    }
-
-    $result = $query->execute();
-
-    if (!empty($result)) {
-      $revision_id = key($result);
-      $node = $this->entityTypeManager->getStorage('node')->loadRevision($revision_id);
-    }
-    else {
-      $node = NULL;
-    }
-
-    return $node;
   }
 
 }


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This work updates life event controller to use benefit finder trait.

## Related Github Issue

- Fixes #1571

## Detailed Testing steps

To test in local development site or in dev site.

<!--- If there are steps for local setup list them here -->
- [ ] Pull changes locally
- [ ] Make local development site up at http://localhost
- [ ] In local, `$ docker restart cms`
- [ ] In local, `$ bin/drush cr`
- [ ] Navigate to `admin/content?combine=&type=bears_life_event_form&status=All&langcode=All`
- [ ] Go to life event form "Benefit finder: death of a loved one" edit page
- [ ] Change Time Estimate to 10-20 minutes
- [ ] Save as published
- [ ] Verify that the system generates both draft and published JSON files

![image](https://github.com/user-attachments/assets/e3c3ced5-8567-4bae-b2cd-10a849c7ddf9)

- [ ] Go to app draft mode: `benefit-finder/death?mode=draft`
- [ ] Verify estimated time 10-20 minutes
- [ ] Go to app published mode:  `benefit-finder/death`
- [ ] Verify estimated time 10-20 minutes

![image](https://github.com/user-attachments/assets/00ab6dcf-f16e-4acf-9d7a-e48a1e473792)

- [ ] Open code diff site: `https://www.w3docs.com/tools/code-diff/`
- [ ] Open JSON formatter site: `https://jsonformatter.org/`
- [ ] Get JSON data  from `https://www.usa.gov/s3/files/benefit-finder/api/life-event/death.json`
- [ ] Format JSON data and put data into left panel of code diff site
- [ ] Get JSON data from s3/files/benefit-finder/api/life-event/death.json
- [ ] Format JSON data and put data into right panel of code diff site
- [ ] Compare JSON data
- [ ] Verify that their data structures are same besides some content difference due to the difference of your testing site database and USA prod database

Content updated in estimated time field
![image](https://github.com/user-attachments/assets/5a029891-0acc-433a-b003-c371712cba84)

Content updated with an option removed
![image](https://github.com/user-attachments/assets/279a2154-0f5c-405e-8865-c40e5644ba21)

Content updated
![image](https://github.com/user-attachments/assets/fe7890a0-a2c1-4109-b466-9d5b4563f026)




<!--- If there are steps for user testing list them here -->
