### PR TITLE
1564 content update zero benefits header

### DIFF
--- a/benefit-finder/src/shared/components/ResultsView/components/Results/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/components/Results/index.jsx
@@ -39,16 +39,19 @@ const Results = ({
       <Chevron
         heading={
           notEligibleView === false
-            ? (zeroBenefitsResult && zeroBenefits?.chevron.heading) ||
+            ? (zeroBenefitsResult && zeroBenefits?.eligible.chevron.heading) ||
               eligible?.chevron.heading
-            : (zeroBenefitsResult && zeroBenefits?.chevron.heading) ||
+            : (zeroBenefitsResult &&
+                zeroBenefits?.notEligible.chevron.heading) ||
               notEligible?.chevron.heading
         }
         description={
           notEligibleView === false
-            ? (zeroBenefitsResult && zeroBenefits?.chevron.description) ||
+            ? (zeroBenefitsResult &&
+                zeroBenefits?.eligible.chevron.description) ||
               eligible?.chevron.description
-            : (zeroBenefitsResult && zeroBenefits?.chevron.description) ||
+            : (zeroBenefitsResult &&
+                zeroBenefits?.notEligible.chevron.description) ||
               notEligible?.chevron.description
         }
       />

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -103,9 +103,11 @@ const ResultsView = ({
               : resultsView.bfData.pageView[0],
           viewTitle:
             notEligibleView === false
-              ? (zeroBenefitsResult && ui.zeroBenefits.chevron.heading) ||
+              ? (zeroBenefitsResult &&
+                  ui.zeroBenefits.eligible.chevron.heading) ||
                 ui?.eligible.chevron.heading
-              : (zeroBenefitsResult && ui?.zeroBenefits.chevron.heading) ||
+              : (zeroBenefitsResult &&
+                  ui?.zeroBenefits.notEligible.chevron.heading) ||
                 ui?.notEligible.chevron.heading,
           ...eligibilityCount,
         },

--- a/benefit-finder/src/shared/locales/en/en.json
+++ b/benefit-finder/src/shared/locales/en/en.json
@@ -106,9 +106,17 @@
       "description": "<strong>Based on your answers you are not eligible for these benefits.</strong>You may become eligible if you enter additional information or your situation changes."
     },
     "zeroBenefits": {
-      "chevron": {
-        "heading": "You are likely not eligible for these benefits.",
-        "description": "<div><p>If you reached these results by mistake, please go back to review your answers.</p></div>"
+      "eligible": {
+        "chevron": {
+          "heading": "You are likely not eligible for these benefits.",
+          "description": "<div><p>If you reached these results by mistake, please go back to review your answers.</p></div>"
+        }
+      },
+      "notEligible": {
+        "chevron": {
+          "heading": "Benefits you did not qualify for",
+          "description": "<div><p>According to your answers you are not eligible for these benefits.</p></div>"
+        }
       },
       "heading": "No eligible results.",
       "description": "Based on your answers you are likely not eligible for benefits. You may become eligible if you enter more information or your situation changes.",

--- a/benefit-finder/src/shared/locales/es/es.json
+++ b/benefit-finder/src/shared/locales/es/es.json
@@ -106,9 +106,17 @@
       "description": "<strong>Según sus respuestas no es elegible para estos beneficios.<strong/> Podría calificar si tiene información adicional o si su situación cambia."
     },
     "zeroBenefits": {
-      "chevron": {
-        "heading": "Usted parece no ser elegible para estos beneficios.",
-        "description": "<div><p>Si cree que cometió un error, por favor regrese para corregir sus respuestas.</p></div>"
+      "eligible": {
+        "chevron": {
+          "heading": "Usted parece no ser elegible para estos beneficios",
+          "description": "<div><p>Si cree que cometió un error, por favor regrese para corregir sus respuestas.</p></div>"
+        }
+      },
+      "notEligible": {
+        "chevron": {
+          "heading": "Beneficios a los que no calificó",
+          "description": "<div><p>Según sus respuestas usted no es elegible para estos beneficios.</p></div>"
+        }
       },
       "heading": "No tiene resultados elegibles.",
       "description": "Basado en sus respuestas usted no es elegible para estos beneficios. Podría ser elegible si ingresa más información o si su situación cambia.",


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

## Related Github Issue

- Fixes #1564 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [x] pull changes locally
- [x] `cd benefit-finder`
- [x] `npm install`
- [x] `npm run start`

<!--- If there are steps for user testing list them here -->
- [x] navigate to `/death`
- [x] complete form, only providing values to required fields
- [x] ensure zero benefits view
- [x]  Click See all benefits button

In English

 On the All non-eligible benefits page:
 - [ ] ensure H1 has changed from "You are likely not eligible for these benefits" --> "Benefits you did not qualify for"
 - [ ] ensure H2 has changed from "If you reached these results by mistake, please go back to review your answers" --> "According to your answers you are not eligible for these benefits."

- [ ] toggle spanish view

In Spanish


 - [ ] ensure the  period in the H1 "Usted parece no ser eligible para estos beneficios." --> "Usted parece no ser eligible para estos beneficios"
 - [ ] Click Ver todos los resultados button
 
On the All non-eligible benefits page:
 - [ ] ensure  H1 has changed from "Usted parece no ser eligible para estos beneficios." --> "Beneficios a los que no calificó"
  - [ ] ensure H2 has changed from "Si cree que cometió un error, por favor regrese para corregir sus respuestas." --> "Según sus respuestas usted no es elegible para estos beneficios."
