### PR TITLE
1614 error label

### DIFF
--- a/usagov_benefit_finder/configuration/core.entity_form_display.paragraph.b_levent_elg_criteria.default.yml
+++ b/usagov_benefit_finder/configuration/core.entity_form_display.paragraph.b_levent_elg_criteria.default.yml
@@ -1,0 +1,78 @@
+uuid: db5a90fd-79f0-4e5e-8ac2-134d60fe051e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.b_levent_elg_criteria.field_b_children
+    - field.field.paragraph.b_levent_elg_criteria.field_b_criteria_key
+    - field.field.paragraph.b_levent_elg_criteria.field_b_error_message
+    - field.field.paragraph.b_levent_elg_criteria.field_b_hint
+    - field.field.paragraph.b_levent_elg_criteria.field_b_legend
+    - field.field.paragraph.b_levent_elg_criteria.field_b_required
+    - paragraphs.paragraphs_type.b_levent_elg_criteria
+  module:
+    - paragraphs
+id: paragraph.b_levent_elg_criteria.default
+targetEntityType: paragraph
+bundle: b_levent_elg_criteria
+mode: default
+content:
+  field_b_children:
+    type: paragraphs
+    weight: 6
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: button
+      form_display_mode: default
+      default_paragraph_type: _none
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+  field_b_criteria_key:
+    type: options_select
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_b_error_message:
+    type: string_textfield
+    weight: 4
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_hint:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_legend:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_required:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/usagov_benefit_finder/configuration/core.entity_view_display.paragraph.b_levent_elg_criteria.default.yml
+++ b/usagov_benefit_finder/configuration/core.entity_view_display.paragraph.b_levent_elg_criteria.default.yml
@@ -1,0 +1,71 @@
+uuid: fcc81bd6-5893-44e4-a916-7608e635ae2d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.b_levent_elg_criteria.field_b_children
+    - field.field.paragraph.b_levent_elg_criteria.field_b_criteria_key
+    - field.field.paragraph.b_levent_elg_criteria.field_b_error_message
+    - field.field.paragraph.b_levent_elg_criteria.field_b_hint
+    - field.field.paragraph.b_levent_elg_criteria.field_b_legend
+    - field.field.paragraph.b_levent_elg_criteria.field_b_required
+    - paragraphs.paragraphs_type.b_levent_elg_criteria
+  module:
+    - entity_reference_revisions
+id: paragraph.b_levent_elg_criteria.default
+targetEntityType: paragraph
+bundle: b_levent_elg_criteria
+mode: default
+content:
+  field_b_children:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  field_b_criteria_key:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_b_error_message:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  field_b_hint:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_b_legend:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_b_required:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 3
+    region: content
+hidden: {  }

--- a/usagov_benefit_finder/configuration/field.field.paragraph.b_levent_elg_criteria.field_b_error_message.yml
+++ b/usagov_benefit_finder/configuration/field.field.paragraph.b_levent_elg_criteria.field_b_error_message.yml
@@ -1,0 +1,19 @@
+uuid: a0fc7f06-ba1a-437c-b5f0-e937ddf08838
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_b_error_message
+    - paragraphs.paragraphs_type.b_levent_elg_criteria
+id: paragraph.b_levent_elg_criteria.field_b_error_message
+field_name: field_b_error_message
+entity_type: paragraph
+bundle: b_levent_elg_criteria
+label: 'Error Message'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_benefit_finder/configuration/field.storage.paragraph.field_b_error_message.yml
+++ b/usagov_benefit_finder/configuration/field.storage.paragraph.field_b_error_message.yml
@@ -1,0 +1,25 @@
+uuid: 7e6798e8-10e6-4bba-9f73-4ee9aa54ce15
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - paragraphs
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: paragraph.field_b_error_message
+field_name: field_b_error_message
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
@@ -328,6 +328,7 @@ class LifeEventController {
       "legend" => $criteria->get('field_b_legend')->value ?? "",
       "required" => $criteria->get('field_b_required')->value ? TRUE : FALSE,
       "hint" => $criteria->get('field_b_hint')->value ?? "",
+      "errorMessage" => $criteria->get('field_b_error_message')->value ?? "",
     ];
 
     // Build inputCriteria.


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This work:

1. adds error message field in criteria field set of life event form
2. adds errorMessage field in JSON data

## Related Github Issue

- Fixes #1614

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->

To test in local development site or in dev site.

<!--- If there are steps for local setup list them here -->
- [ ] Pull changes locally
- [ ] Make local development site up at http://localhost
- [ ] Navigate to `admin/content?combine=&type=bears_life_event_form&status=All&langcode=All`
- [ ] Go to life event form "Benefit finder: death of a loved one" edit page
- [ ] Add "Input the date of birth" in `Error Message` field

<img width="663" src="https://github.com/user-attachments/assets/2608b481-295f-4db7-b81d-83aa02bb6225">

- [ ] Save as published
- [ ] Navigate to `benefit-finder/api/life-event/death`
- [ ] Verify errorMessage "Input the date of birth"

<img width="663" src="https://github.com/user-attachments/assets/2645d12d-f898-4843-b019-290cfcb204f5">


<!--- If there are steps for user testing list them here -->
