### PR TITLE
PXBF-1641-allow-custom-branch-checkout-setup: split the param and the…

### DIFF
--- a/scripts/local/setup-usagov-benefit-finder.sh
+++ b/scripts/local/setup-usagov-benefit-finder.sh
@@ -32,12 +32,22 @@ then
     git checkout prod
 
     for param in "$@"; do
+    PARAM=$(echo "$param" | cut -d= -f1)
+    BRANCH=$(echo "$param" | cut -d= -f2)
+
     # stop and checkout if --dev flag is passed
-        if [ "$param" = "--dev" ]; then
-            echo "Parameter found: ${param}"
+        if [ "$PARAM" = "--dev" ]; then
+            echo "Parameter found: ${PARAM}"
             echo "checking out dev branch"
             git fetch origin dev:dev
             git checkout dev
+        fi
+    # stop and checkout custom branch request
+        if [ "$PARAM" = "--branch" ]; then
+            echo "Parameter found: ${PARAM}"
+            echo "checking out ${BRANCH}"
+            git fetch origin "${BRANCH}:${BRANCH}"
+            git checkout "${BRANCH}"
         fi
     done
     # set up usagov project

--- a/scripts/local/setup-usagov-benefit-finder.sh
+++ b/scripts/local/setup-usagov-benefit-finder.sh
@@ -6,6 +6,7 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 # usagov-2021 project
 USAGOV_PROJECT_LOCATION="${ROOT_DIR}/usagov-2021"
 SCRIPTS_LOCATION="${ROOT_DIR}/scripts/pipeline"
+BRANCH=""
 
 
 # make specific to usagov
@@ -35,13 +36,6 @@ then
     PARAM=$(echo "$param" | cut -d= -f1)
     BRANCH=$(echo "$param" | cut -d= -f2)
 
-    # stop and checkout if --dev flag is passed
-        if [ "$PARAM" = "--dev" ]; then
-            echo "Parameter found: ${PARAM}"
-            echo "checking out dev branch"
-            git fetch origin dev:dev
-            git checkout dev
-        fi
     # stop and checkout custom branch request
         if [ "$PARAM" = "--branch" ]; then
             echo "Parameter found: ${PARAM}"
@@ -65,6 +59,7 @@ then
     bash "${SCRIPTS_LOCATION}/mv-usagov_benefit_finder.sh"
 
     cd "${USAGOV_PROJECT_LOCATION}" || exit 1
+    git checkout "${BRANCH}"
 
     docker-compose up -d
     bin/db-update


### PR DESCRIPTION
… value so we can handle the branch value

## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
allows a developer to pass `--branch` flag with a custom branch name from the submodule origin during setup script

## Related Github Issue

- Fixes #(issue)

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] stash any modified files
- [ ] from the terminal run `scripts/local/setup-usagov-benefit-finder.sh --branch="<branch-name>"`


<!--- If there are steps for user testing list them here -->
- [ ] confirm the output in the script step includes 

```bash
Parameter found: --branch
checking out <branch-name>
```


