### PR TITLE
1651 include radio groups with error validation

### DIFF
--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -96,6 +96,7 @@ const LifeEventSection = ({
     alertFieldRef.current.focus()
     currentData.completed = false
     window.scrollTo(0, 0)
+    return false
   }
 
   /**
@@ -108,6 +109,7 @@ const LifeEventSection = ({
     currentData.completed = true
     handleUpdateData()
     setRequiredFieldsets([])
+    return true
   }
 
   /**
@@ -117,10 +119,10 @@ const LifeEventSection = ({
    */
   const handleCheckRequriedFields = () => {
     // collect all the required fields in the current step
-    errorHandling
+    return errorHandling
       .handleCheckForRequiredValues(requiredFieldsets, setHasError)
       .then(valid => {
-        valid === true ? handleSuccess() : handleAlert()
+        return valid === true ? handleSuccess() : handleAlert()
       })
   }
   /**

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -73,32 +73,7 @@ const LifeEventSection = ({
   }
 
   const handleCheckForRequiredValues = async () => {
-    // TODO: collect and handle radio groups
-    // const invalidRadioFieldSets = await requiredFieldsets
-    //   .map(fieldset => {
-    //     const radioGroup = Array.from(fieldset.elements).filter(
-    //       el => el.attributes.type?.value === 'radio'
-    //     )
-
-    //     // find the parent fieldset and return
-    //     if (radioGroup.every(group => !group.checked)) {
-    //       // get an id from the radio group
-    //       const groupId = radioGroup[0]?.name
-    //       const trimmedGroupId = groupId && groupId.replace(/_[0-9]/, '')
-    //       // if the id matches the id in our fieldset return the fieldset
-    //       const invalidRadioSets = requiredFieldsets.filter(
-    //         fieldset => fieldset.id === trimmedGroupId
-    //       )
-    //       return invalidRadioSets
-    //     } else {
-    //       return undefined
-    //     }
-    //   })
-    //   .flat()
-
-    // console.log('invalidRadioFieldSets', invalidRadioFieldSets)
-
-    const invalidElements = await requiredFieldsets
+    const invalidElements = requiredFieldsets
       .map(fieldset => {
         return (
           Array.from(fieldset.elements)
@@ -108,16 +83,38 @@ const LifeEventSection = ({
               if (el.attributes['data-datetype']?.value === 'year') {
                 return !el.value || (el.value && el.value.length !== 4)
               }
+
               return !el.value
             })
         )
       })
       .flat()
 
-    // const mergeInvalidElements = [...invalidElements]
+    // handle radios/checks seperately
+    const invalidRadioFieldSets = requiredFieldsets
+      .map(fieldset => {
+        if (
+          Array.from(fieldset.elements).every(
+            el => !el.attributes.type?.value === 'radio'
+          )
+        ) {
+          return []
+        }
 
-    setHasError(invalidElements)
-    return invalidElements.length === 0
+        const radios = Array.from(fieldset.elements).filter(
+          el => el.attributes.type?.value === 'radio'
+        )
+
+        if (radios.length > 0 && radios.every(el => !el.checked)) {
+          return fieldset
+        }
+        return []
+      })
+      .flat()
+
+    const mergeInvalidElements = [invalidElements, invalidRadioFieldSets].flat()
+    setHasError(mergeInvalidElements)
+    return mergeInvalidElements.length === 0
   }
 
   /**

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -305,19 +305,11 @@ const LifeEventSection = ({
                           requiredLabel={requiredLabel}
                           hidden={hidden && hidden}
                           id={item.fieldset.criteriaKey}
-                          invalid={
-                            item.fieldset.required &&
-                            hasError
-                              .map(errorItem => {
-                                return (
-                                  errorItem.id !== undefined &&
-                                  errorItem.id.includes(
-                                    item.fieldset?.criteriaKey
-                                  )
-                                )
-                              })
-                              .includes(true)
-                          }
+                          invalid={errorHandling.handleInvalid({
+                            required: item.fieldset.required,
+                            hasError,
+                            criteriaKey: item.fieldset?.criteriaKey,
+                          })}
                           ui={ui.errorText}
                         >
                           {item.fieldset.inputs.map((input, index) => {
@@ -326,17 +318,6 @@ const LifeEventSection = ({
                             const defaultSelected = inputValues.find(
                               value => value.selected !== undefined
                             )
-
-                            const invalid =
-                              item.fieldset.required &&
-                              hasError
-                                .map(item => {
-                                  return (
-                                    item.id !== undefined &&
-                                    fieldSetId.includes(item.id)
-                                  )
-                                })
-                                .includes(true)
 
                             const { select, errorText } = ui
 
@@ -354,7 +335,12 @@ const LifeEventSection = ({
                                       item.fieldset.criteriaKey
                                     )
                                   }
-                                  invalid={invalid}
+                                  invalid={errorHandling.handleInvalid({
+                                    required: item.fieldset.required,
+                                    hasError,
+                                    criteriaKey: item.fieldset?.criteriaKey,
+                                    fieldSetId,
+                                  })}
                                   legend={item.fieldset.legend}
                                   errorMessage={item.fieldset.errorMessage}
                                 />
@@ -377,19 +363,6 @@ const LifeEventSection = ({
                         {item.fieldset.inputs.map((input, index) => {
                           const fieldSetId = `${item.fieldset.criteriaKey}_${index}`
 
-                          const invalid =
-                            item.fieldset.required &&
-                            hasError
-                              .map(errorItem => {
-                                return (
-                                  errorItem.id !== undefined &&
-                                  errorItem.id.includes(
-                                    item.fieldset?.criteriaKey
-                                  )
-                                )
-                              })
-                              .includes(true)
-
                           return (
                             <Fieldset
                               key={`radio-${item.fieldset.criteriaKey}-${index}`}
@@ -401,10 +374,18 @@ const LifeEventSection = ({
                               requiredLabel={requiredLabel}
                               hidden={hidden && hidden}
                               ui={ui.errorText}
-                              invalid={invalid}
+                              invalid={errorHandling.handleInvalid({
+                                required: item.fieldset.required,
+                                hasError,
+                                criteriaKey: item.fieldset?.criteriaKey,
+                              })}
                             >
                               <RadioGroup
-                                invalid={invalid}
+                                invalid={errorHandling.handleInvalid({
+                                  required: item.fieldset.required,
+                                  hasError,
+                                  criteriaKey: item.fieldset?.criteriaKey,
+                                })}
                                 key={fieldSetId}
                                 fieldSetId={fieldSetId}
                                 handleChanged={handleChanged}
@@ -438,32 +419,15 @@ const LifeEventSection = ({
                           requiredLabel={requiredLabel}
                           hidden={hidden && hidden}
                           id={item.fieldset.criteriaKey}
-                          invalid={
-                            item.fieldset.required &&
-                            hasError
-                              .map(errorItem => {
-                                return (
-                                  errorItem.id !== undefined &&
-                                  errorItem.id.includes(
-                                    item.fieldset?.criteriaKey
-                                  )
-                                )
-                              })
-                              .includes(true)
-                          }
+                          invalid={errorHandling.handleInvalid({
+                            required: item.fieldset.required,
+                            hasError,
+                            criteriaKey: item.fieldset?.criteriaKey,
+                          })}
                           ui={ui.errorText}
                         >
                           {item.fieldset.inputs.map((input, index) => {
                             const fieldSetId = `${item.fieldset.criteriaKey}_${index}`
-
-                            const invalid =
-                              item.fieldset.required &&
-                              hasError.filter(item => {
-                                return (
-                                  item.id !== undefined &&
-                                  item.id.includes(fieldSetId)
-                                )
-                              })
 
                             return (
                               <div key={fieldSetId}>
@@ -479,7 +443,13 @@ const LifeEventSection = ({
                                   errorMessage={item.fieldset.errorMessage}
                                   parentLegend={item.fieldset.legend}
                                   id={fieldSetId}
-                                  invalid={invalid}
+                                  invalid={errorHandling.handleInvalid({
+                                    required: item.fieldset.required,
+                                    hasError,
+                                    criteriaKey: item.fieldset?.criteriaKey,
+                                    fieldSetId,
+                                    useFilter: true,
+                                  })}
                                 />
                               </div>
                             )

--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -66,8 +66,8 @@ const Modal = ({
    */
   const handleOpenModal = () => {
     handleCheckRequriedFields().then(valid =>
-      valid
-        ? setModalOpen(true) && scrollLock.enableScroll()
+      valid === true
+        ? setModalOpen(true)
         : window.scrollTo(0, 0) && alertElement.current.focus()
     )
   }
@@ -88,6 +88,10 @@ const Modal = ({
   }
 
   const handleKeyValidation = e => e.which === 32 || e.which === 13
+
+  useEffect(() => {
+    modalOpen && scrollLock.enableScroll()
+  }, [modalOpen])
 
   // effects
   useEffect(() => {

--- a/benefit-finder/src/shared/utils/errorHandling/index.js
+++ b/benefit-finder/src/shared/utils/errorHandling/index.js
@@ -58,4 +58,33 @@ export const handleCheckForRequiredValues = async (
   return mergeInvalidElements.length === 0
 }
 
-export default { getRequiredFieldsets, handleCheckForRequiredValues }
+export const handleInvalid = ({
+  required,
+  hasError,
+  criteriaKey,
+  fieldSetId,
+  useFilter = false,
+}) => {
+  const handleMap = hasError
+    .map(errorItem => {
+      return (
+        (errorItem.id !== undefined &&
+          fieldSetId &&
+          fieldSetId.includes(errorItem.id)) ||
+        (errorItem.id !== undefined && errorItem.id.includes(criteriaKey))
+      )
+    })
+    .includes(true)
+
+  const hanldeFilter = hasError.filter(errorItem => {
+    return errorItem.id !== undefined && errorItem.id.includes(fieldSetId)
+  })
+
+  return required && useFilter === true ? hanldeFilter : handleMap
+}
+
+export default {
+  getRequiredFieldsets,
+  handleCheckForRequiredValues,
+  handleInvalid,
+}

--- a/benefit-finder/src/shared/utils/errorHandling/index.js
+++ b/benefit-finder/src/shared/utils/errorHandling/index.js
@@ -1,0 +1,61 @@
+/**
+ * a function that collect all the required fields in the current step
+ * @function
+ */
+export const getRequiredFieldsets = (document, setHandler) => {
+  const collectedNodeList = document.querySelectorAll('fieldset')
+  const requiredNodeList = Array.from(collectedNodeList).filter(
+    node => node.attributes.required
+  )
+  setHandler(Array.from(requiredNodeList))
+}
+
+export const handleCheckForRequiredValues = async (
+  requiredFieldsets,
+  setHasError
+) => {
+  const invalidElements = requiredFieldsets
+    .map(fieldset => {
+      return (
+        Array.from(fieldset.elements)
+          // check all the required inputs, if there is no value, there the input is invalid
+          .filter(el => {
+            // we need to custom handle our dates verification to ensure a 4 digit year
+            if (el.attributes['data-datetype']?.value === 'year') {
+              return !el.value || (el.value && el.value.length !== 4)
+            }
+
+            return !el.value
+          })
+      )
+    })
+    .flat()
+
+  // handle radios/checks seperately
+  const invalidRadioFieldSets = requiredFieldsets
+    .map(fieldset => {
+      if (
+        Array.from(fieldset.elements).every(
+          el => !el.attributes.type?.value === 'radio'
+        )
+      ) {
+        return []
+      }
+
+      const radios = Array.from(fieldset.elements).filter(
+        el => el.attributes.type?.value === 'radio'
+      )
+
+      if (radios.length > 0 && radios.every(el => !el.checked)) {
+        return fieldset
+      }
+      return []
+    })
+    .flat()
+
+  const mergeInvalidElements = [invalidElements, invalidRadioFieldSets].flat()
+  setHasError(mergeInvalidElements)
+  return mergeInvalidElements.length === 0
+}
+
+export default { getRequiredFieldsets, handleCheckForRequiredValues }

--- a/benefit-finder/src/shared/utils/errorHandling/index.js
+++ b/benefit-finder/src/shared/utils/errorHandling/index.js
@@ -14,6 +14,7 @@ export const handleCheckForRequiredValues = async (
   requiredFieldsets,
   setHasError
 ) => {
+  // handle most elements
   const invalidElements = requiredFieldsets
     .map(fieldset => {
       return (

--- a/benefit-finder/src/shared/utils/index.js
+++ b/benefit-finder/src/shared/utils/index.js
@@ -1,4 +1,5 @@
 export { default as buildURIParameter } from './buildURIParameter'
+export { default as errorHandling } from './errorHandling'
 export { default as createMarkup } from './createMarkup'
 export { default as dataLayerUtils } from './dataLayerUtils'
 export { default as dateInputValidation } from './dateInputValidation'


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This works to incorporate radio groups into our updated error handling functionality

## Related Github Issue

- Fixes #1651 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [x] pull changes locally
- [x] `cd benefit-finder`
- [x] change the first radio group `required` value to `true` in `mock-data/current.js`

```JSON
              {
                "fieldset": {
                  "criteriaKey": "applicant_citizen_status",
                  "legend": "Are you a U.S. citizen or eligible non-citizen?",
                  "required": true, // update value here
                  "hint": "",
                 ...
```

- [x] `npm run dev:storybook`

<!--- If there are steps for user testing list them here -->
- [x] navigate to the App component
- [x] ensure that the radio group assigned as required displays correctly
- [x] without providing any values, CLICK `Continue`
- [x] ensure that radio group error is included in the error alert
- [x] ensure radio group has error border styling
- [ ] resolve error by checking one of the radio group values
- [ ] ensure radio group styling has been removed
- [ ] ensure that radio group error is _NOT_ included in the error alert
