### PR TITLE
Include increment state for submissions on errors

### DIFF
--- a/benefit-finder/src/shared/components/Alert/index.jsx
+++ b/benefit-finder/src/shared/components/Alert/index.jsx
@@ -34,6 +34,7 @@ const Alert = ({
   tabIndex,
   errorCount,
   errorList,
+  submissionCount,
 }) => {
   const defaultClasses =
     type === 'error'
@@ -53,22 +54,26 @@ const Alert = ({
         ]
 
   useEffect(() => {
-    // handle dataLayer
+    // we use a submission count to force the effect on each submission
     const { errors } = dataLayerUtils.dataLayerStructure
     hasError &&
       errorList &&
-      dataLayerUtils.dataLayerPush(window, {
-        event: errors.event,
-        bfData: {
-          errors: errorList.map(item => item?.id).join(','),
-          errorCount: {
-            number: errorCount,
-            string: `${errorCount}`,
+      dataLayerUtils.dataLayerPush(
+        window,
+        {
+          event: errors.event,
+          bfData: {
+            errors: errorList.map(item => item?.id).join(','),
+            errorCount: {
+              number: errorCount,
+              string: `${errorCount}`,
+            },
+            formSuccess: false,
           },
-          formSuccess: false,
         },
-      })
-  }, [hasError])
+        false
+      )
+  }, [submissionCount])
 
   return (
     <div

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -51,6 +51,7 @@ const LifeEventSection = ({
   const [requiredFieldsets, setRequiredFieldsets] = useState([])
   const [hasError, setHasError] = useState([])
   const [hasData, setHasData] = useState(false)
+  const [submissionCount, setSubmissionCount] = useState(0)
   useHandleUnload(hasData) // alert the user if they try to go back in browser
   const resetElement = useResetElement()
 
@@ -94,6 +95,7 @@ const LifeEventSection = ({
     // remove the display class from the alert
     alertFieldRef.current.classList.remove('display-none')
     alertFieldRef.current.focus()
+    setSubmissionCount(submissionCount + 1)
     currentData.completed = false
     window.scrollTo(0, 0)
     return false
@@ -272,6 +274,7 @@ const LifeEventSection = ({
                   hasError={hasError.length > 0}
                   errorCount={hasError.length}
                   errorList={hasError}
+                  submissionCount={submissionCount}
                 ></Alert>
                 <div className="bf-form-heading-group">
                   <Heading


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This forces our dataLayer push on errors even if the error count has not changed

## Related Github Issue

- Fixes #1669 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] `cd benefit-finder`
- [ ] `npm install`
- [ ] enable adswerve browser extension, https://chromewebstore.google.com/detail/adswerve-datalayer-inspec/kmcbdogdandhihllalknlcjfpdjcleom

<!--- If there are steps for user testing list them here -->
- [ ] follow the test steps included in the attached document
[Error.Tracking.QA.docx](https://github.com/user-attachments/files/16603502/Error.Tracking.QA.docx)

ensure that the following are true true

- [ ] if a user resubmits, even if the the error count length hasn't changed...
we submit another event with the same data object values

- [ ] if a user resubmits, and the error count length has changed...
we submit a new event with the updated data object values
