### PR TITLE
remove interactive functions from step indicator component

### DIFF
--- a/benefit-finder/cypress/e2e/storybook/error-message-display.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/error-message-display.cy.js
@@ -159,35 +159,4 @@ describe('Validate correct error messages display for negative scenarios', () =>
       })
     })
   })
-
-  it.only('Should not allow moving forward by clicking step nav when error banner is present', () => {
-    // expect when a user tabs from the focus error they can tab any other error notices in the form
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
-    cy.focused().should('have.class', 'usa-alert--error').tab()
-    pageObjects.bfAlertList().then(() => {
-      pageObjects.bfAlertListItem().then(errors => {
-        cy.get(errors[0])
-          .children()
-          .invoke('attr', 'href')
-          .then(href => {
-            cy.focused().should('have.attr', 'href').and('include', href)
-          })
-      })
-
-      // expect when a user has resolved all errors the top level error notices is not visible or accessible
-      utils.dataInputs({ dob, relation })
-
-      // expect the error notice to be visible and focused if errors are present
-      pageObjects.benefitSectionAlert().should('not.have.class', 'display-none')
-      pageObjects.stepIndicator().click()
-      cy.focused().should('have.class', 'usa-alert--error')
-      // expect date DOM structure alert to be accessible
-      for (const attr in alertDisplayState) {
-        pageObjects
-          .benefitSectionAlert()
-          .invoke('attr', attr)
-          .should('eq', alertDisplayState[attr])
-      }
-    })
-  })
 })

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -258,10 +258,8 @@ const LifeEventSection = ({
           <div className="bf-section-info">
             <StepIndicator
               current={step - 1}
-              setCurrent={setStep}
               data={data}
               backLinkLabel={stepIndicator.stepBackLink}
-              handleCheckRequriedFields={() => handleForwardUpdate(1)}
               key={`step-indicator-${sectionHeadings}`}
             />
             {currentData && (

--- a/benefit-finder/src/shared/components/StepIndicator/index.jsx
+++ b/benefit-finder/src/shared/components/StepIndicator/index.jsx
@@ -47,14 +47,7 @@ const StepIndicator = ({
    * @param {number} index - the index of this item
    * @return {html} returns markup for a usa step indicator segment
    */
-  const StepIndicatorSegment = ({
-    heading,
-    current,
-    setCurrent,
-    completed,
-    index,
-    handleCheckRequriedFields,
-  }) => {
+  const StepIndicatorSegment = ({ heading, current, completed, index }) => {
     const statusClass = current === index ? '--current' : ''
     return (
       <li
@@ -64,11 +57,6 @@ const StepIndicator = ({
             : ''
         }`}
         aria-current={current === index}
-        onClick={() =>
-          completed !== true
-            ? handleCheckRequriedFields() === true && setCurrent(index + 1)
-            : setCurrent(index + 1)
-        }
         key={`step-indicator-${heading}`}
       >
         <span
@@ -125,9 +113,7 @@ StepIndicator.propTypes = {
   data: PropTypes.array,
   noHeadings: PropTypes.bool,
   current: PropTypes.number,
-  setCurrent: PropTypes.func,
   backLinkLabel: PropTypes.string,
-  handleCheckRequiredFields: PropTypes.func,
 }
 
 export default StepIndicator


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This works to remove the interactivity of the step indicator

## Related Github Issue

- Fixes #1639 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] `cd benefit-finder`
- [ ] `npm install`
- [ ] `npm run start`

<!--- If there are steps for user testing list them here -->
- [ ] navigate to `/death`
- [ ] attempt to interact, ie CLICK the step indicator
- [ ] ensure no events are fired resulting in an interaction or side effect of the application
