### PR TITLE
PXBF-1679-adjust-css-errror-vert-spacing

### DIFF
--- a/benefit-finder/src/shared/components/Fieldset/_index.scss
+++ b/benefit-finder/src/shared/components/Fieldset/_index.scss
@@ -28,6 +28,11 @@
   padding-left: space.$space-md-gap;
 }
 
+.bf-fieldset-wrapper:has(fieldset.usa-input--error)
+  + .bf-fieldset-wrapper:has(fieldset:not(.usa-input--error)) {
+  padding-top: space.$space-md-gap;
+}
+
 .bf-fieldset-wrapper:has(fieldset.display-none) {
   padding: 0;
 }


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

This works to adjust the sibling of an error fieldset to include padding

## Related Github Issue

- Fixes #1679 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] `cd benefit-finder`
- [ ] `npm install`
- [ ] `npm run start`
- [ ] navigate to `/death`

<!--- If there are steps for user testing list them here -->
- [ ] without providing any values, CLICK `continue` to trigger the error state

previous:
<img width="1067" alt="Screenshot 2024-08-15 at 2 53 12 PM" src="https://github.com/user-attachments/assets/54fb7057-d111-4ba1-a2a7-5ecede10f7ef">

expected:

https://github.com/user-attachments/assets/7f218aad-c263-4f3d-bb28-1822bff6661c



