### PR TITLE
Revert PR 1667 "Revert PR 1663 update check data controller dependency injection"

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_content/src/Controller/CheckDataController.php
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_content/src/Controller/CheckDataController.php
@@ -2,13 +2,21 @@
 
 namespace Drupal\usagov_benefit_finder_content\Controller;
 
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\file\FileRepositoryInterface;
 use Drupal\usagov_benefit_finder\Traits\BenefitFinderTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Class CheckDataController
  * @package Drupal\usagov_benefit_finder_content\Controller
  */
-class CheckDataController {
+class CheckDataController extends ControllerBase {
 
   use BenefitFinderTrait;
 
@@ -48,11 +56,11 @@ class CheckDataController {
   protected $database;
 
   /**
-   * Retrieves the currently active request object.
+   * The request stack.
    *
-   * @var \Symfony\Component\HttpFoundation\Request
+   * @var \Symfony\Component\HttpFoundation\RequestStack
    */
-  protected $request;
+  protected $requestStack;
 
   /**
    * The benefit finder content mode.
@@ -76,15 +84,49 @@ class CheckDataController {
   protected $expanded;
 
   /**
-   * Constructs a new LifeEventController object.
+   * Constructs a new CheckDataController object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
+   *   The file system service.
+   * @param \Drupal\file\FileRepositoryInterface|null $file_repository
+   *   The file repository.
+   * @param \Drupal\Core\File\FileUrlGeneratorInterface $file_url_generator
+   *   The file URL generator.
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The database connection.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack.
    */
-  public function __construct() {
-    $this->entityTypeManager = \Drupal::service('entity_type.manager');
-    $this->fileSystem = \Drupal::service('file_system');
-    $this->fileRepository = \Drupal::service('file.repository');
-    $this->fileUrlGenerator = \Drupal::service('file_url_generator');
-    $this->database = \Drupal::service('database');
-    $this->request = \Drupal::request();
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    FileSystemInterface $file_system,
+    FileRepositoryInterface $file_repository,
+    FileUrlGeneratorInterface $file_url_generator,
+    Connection $database,
+    RequestStack $request_stack
+  ) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->fileSystem = $file_system;
+    $this->fileRepository = $file_repository;
+    $this->fileUrlGenerator = $file_url_generator;
+    $this->database = $database;
+    $this->requestStack = $request_stack;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('file_system'),
+      $container->get('file.repository'),
+      $container->get('file_url_generator'),
+      $container->get('database'),
+      $container->get('request_stack'),
+    );
   }
 
   /**
@@ -95,12 +137,12 @@ class CheckDataController {
 
     // Get langcode.
     if (empty($this->langcode)) {
-      $this->langcode = $this->request->get('langcode') ?? "en";
+      $this->langcode = $this->requestStack->getCurrentRequest()->query->get('langcode') ?? "en";
     }
 
     // Get expanded.
     if (empty($this->expanded)) {
-      $this->expanded = $this->request->get('expanded') ?? "false";
+      $this->expanded = $this->requestStack->getCurrentRequest()->query->get('expanded') ?? "false";
     }
 
     $help = <<<EOD


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This work reverts PR 1667 "Revert PR 1663 update check data controller dependency injection".

## Related Github Issue

- Fixes #1646

## Detailed Testing steps

To test in local development site or in dev site.

<!--- If there are steps for local setup list them here -->

- [ ] Pull changes locally
- [ ] Make local development site up at http://localhost
- [ ] In local, `$ docker restart cms`
- [ ] In local, `$ bin/drush cr`
- [ ] Navigate to `benefit-finder/content/report`
- [ ] Verify it shows 3 sections of criteria, benefit, and life event form
- [ ] Open criteria "Applicant date of birth"
- [ ] Navigate to `admin/content?combine=&type=bears_criteria&status=All&langcode=All`
- [ ] Go to criteria "Applicant date of birth" edit page
- [ ] Verify criteria report data is correct

<img width="600" src="https://github.com/user-attachments/assets/228400ef-7d66-4651-a6fd-bc70e9af52cd">

- [ ] Open benefit "COVID-19 funeral assistance
- [ ] Navigate to `admin/content?combine=&type=bears_benefit&status=All&langcode=All`
- [ ] Go to benefit "COVID-19 funeral assistance" edit page
- [ ] Verify benefit report data is correct

<img width="600" src="https://github.com/user-attachments/assets/2a95755c-ca62-4f6a-83c5-00e9b9cdcfc8">

- [ ] Open life event form "Benefit finder: death of a loved one"
- [ ] Navigate to `admin/content?combine=&type=bears_life_event_form&status=All&langcode=All`
- [ ] Go to life event form "Benefit finder: death of a loved one" edit page
- [ ] Verify life event form report data is correct

<img width="600" src="https://github.com/user-attachments/assets/8feb2b12-2f32-4e1d-b525-6e58107ccc4e">

<!--- If there are steps for user testing list them here -->
