### PR TITLE
PXBF-remove-npm-step-deploy: Remove npm install cmd from linters step

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -38,7 +38,6 @@ jobs:
           cd ..
       - name: Install Linters and Sniffers
         run: |
-          npm install --prefix ./benefit-finder
           composer global config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer false
           composer global require --dev drupal/coder php-parallel-lint/php-parallel-lint squizlabs/php_codesniffer=*
           COMPOSER_DIR=$(composer -n config --global home)


### PR DESCRIPTION
## PR Summary

This is a quick change to remove an npm command from the linters step of the deploy pipeline as it should not longer be needed and should save time once removed.

## Related Github Issue

N/A

## Detailed Testing steps

Once merged to develop, watch execution, confirm working as expected.
