### PR TITLE
1737 date validation not required

### DIFF
--- a/benefit-finder/src/shared/components/Date/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/Date/__tests__/__snapshots__/index.spec.jsx.snap
@@ -34,7 +34,6 @@ exports[`Date > renders a match to the previous snapshot 1`] = `
         name="applicant_date_of_birth_0_month"
       >
         <option
-          disabled=""
           value=""
         >
           -Select-

--- a/benefit-finder/src/shared/components/Date/index.jsx
+++ b/benefit-finder/src/shared/components/Date/index.jsx
@@ -103,7 +103,7 @@ const Date = ({
             aria-errormessage={`month-error-description-${id}`}
             data-datetype="month"
           >
-            <option value="" key="default" disabled>
+            <option value="" key="default">
               {dateDefaultValue}
             </option>
             {monthOptions.map((option, i) => (
@@ -165,7 +165,7 @@ Date.propTypes = {
   value: PropTypes.object,
   ui: PropTypes.object,
   id: PropTypes.string,
-  invalid: PropTypes.array,
+  invalid: PropTypes.bool || PropTypes.array,
 }
 
 export default Date

--- a/benefit-finder/src/shared/components/Date/index.jsx
+++ b/benefit-finder/src/shared/components/Date/index.jsx
@@ -165,7 +165,7 @@ Date.propTypes = {
   value: PropTypes.object,
   ui: PropTypes.object,
   id: PropTypes.string,
-  invalid: PropTypes.bool || PropTypes.array,
+  invalid: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
 }
 
 export default Date

--- a/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.jsx.snap
@@ -175,7 +175,6 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
                     name="applicant_date_of_birth_0_month"
                   >
                     <option
-                      disabled=""
                       value=""
                     >
                       -Select-
@@ -338,7 +337,6 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
                 name="applicant_relationship_to_the_deceased_0"
               >
                 <option
-                  disabled=""
                   value=""
                 >
                   -Select-
@@ -408,7 +406,6 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
                 name="applicant_marital_status_0"
               >
                 <option
-                  disabled=""
                   value=""
                 >
                   -Select-

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -203,22 +203,37 @@ const LifeEventSection = ({
    * @return {object} object as state
    */
   const handleDateChanged = (event, criteriaKey) => {
+    // if event target is empty check if all values in date are empty
     event.target.value.length > 0 && setHasData(true)
     window.history.replaceState({}, '', window.location.pathname)
-    if (dateInputValidation(event) === true) {
-      apiCalls.PUT.DataDate(
-        criteriaKey,
-        currentData,
-        setCurrentData,
-        event.target.value,
-        event.target.id
-      )
-      hasError.length > 0 &&
-        errorHandling.handleCheckForRequiredValues(
-          requiredFieldsets,
-          setHasError
+
+    async function validUpdate() {
+      if (dateInputValidation(event) === true) {
+        apiCalls.PUT.DataDate(
+          criteriaKey,
+          currentData,
+          setCurrentData,
+          event.target.value,
+          event.target.id
         )
+        hasError.length > 0 &&
+          errorHandling.handleCheckForRequiredValues(
+            requiredFieldsets,
+            setHasError
+          )
+      }
     }
+
+    validUpdate().then(() => {
+      errorHandling.getNonRequiredFieldsets(
+        criteriaKey,
+        requiredFieldsets,
+        setRequiredFieldsets,
+        setHasError,
+        hasError,
+        apiCalls.GET.SelectedValueAll(data)
+      )
+    })
   }
 
   // manage the display of our modal initializer
@@ -316,7 +331,6 @@ const LifeEventSection = ({
                           hidden={hidden && hidden}
                           id={item.fieldset.criteriaKey}
                           invalid={errorHandling.handleInvalid({
-                            required: item.fieldset.required,
                             hasError,
                             criteriaKey: item.fieldset?.criteriaKey,
                           })}
@@ -346,7 +360,6 @@ const LifeEventSection = ({
                                     )
                                   }
                                   invalid={errorHandling.handleInvalid({
-                                    required: item.fieldset.required,
                                     hasError,
                                     criteriaKey: item.fieldset?.criteriaKey,
                                     fieldSetId,
@@ -385,14 +398,12 @@ const LifeEventSection = ({
                               hidden={hidden && hidden}
                               ui={ui.errorText}
                               invalid={errorHandling.handleInvalid({
-                                required: item.fieldset.required,
                                 hasError,
                                 criteriaKey: item.fieldset?.criteriaKey,
                               })}
                             >
                               <RadioGroup
                                 invalid={errorHandling.handleInvalid({
-                                  required: item.fieldset.required,
                                   hasError,
                                   criteriaKey: item.fieldset?.criteriaKey,
                                 })}
@@ -430,7 +441,6 @@ const LifeEventSection = ({
                           hidden={hidden && hidden}
                           id={item.fieldset.criteriaKey}
                           invalid={errorHandling.handleInvalid({
-                            required: item.fieldset.required,
                             hasError,
                             criteriaKey: item.fieldset?.criteriaKey,
                           })}
@@ -454,7 +464,6 @@ const LifeEventSection = ({
                                   parentLegend={item.fieldset.legend}
                                   id={fieldSetId}
                                   invalid={errorHandling.handleInvalid({
-                                    required: item.fieldset.required,
                                     hasError,
                                     criteriaKey: item.fieldset?.criteriaKey,
                                     fieldSetId,

--- a/benefit-finder/src/shared/components/Select/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/Select/__tests__/__snapshots__/index.spec.jsx.snap
@@ -17,7 +17,6 @@ exports[`Select > renders a match to the previous snapshot 1`] = `
     name="applicant_relationship_to_the_deceased"
   >
     <option
-      disabled=""
       value=""
     />
     <option

--- a/benefit-finder/src/shared/components/Select/index.jsx
+++ b/benefit-finder/src/shared/components/Select/index.jsx
@@ -69,7 +69,7 @@ function Select({
         data-errormessage={errorMessageValue}
         aria-errormessage={`error-description-${htmlFor}`}
       >
-        <option value="" key="default" disabled>
+        <option value="" key="default">
           {select?.defaultValue}
         </option>
         <Options options={options} />

--- a/benefit-finder/src/shared/utils/dateInputValidation/__tests__/index.spec.jsx
+++ b/benefit-finder/src/shared/utils/dateInputValidation/__tests__/index.spec.jsx
@@ -23,13 +23,13 @@ test('month value should be determined if valid', async () => {
       id: monthElement.id,
     },
   }
+
+  expect(dateInputValidation(customEvent)).toBe(true)
 })
 
 test('day value should be determined if valid', async () => {
   render(<IndexHTML />)
   const dayElement = screen.getByTestId('input-day')
-
-  expect(dateInputValidation(customEvent)).toBe(false)
 
   customEvent = {
     target: {
@@ -46,6 +46,8 @@ test('day value should be determined if valid', async () => {
       id: dayElement.id,
     },
   }
+
+  expect(dateInputValidation(customEvent)).toBe(true)
 })
 
 test('year value should be determined if valid', async () => {

--- a/benefit-finder/src/shared/utils/dateInputValidation/index.js
+++ b/benefit-finder/src/shared/utils/dateInputValidation/index.js
@@ -21,8 +21,9 @@ const dateInputValidation = event => {
     }
   }
 
+  // always return true for month values so we can select default options
   if (event.target.id.includes('month')) {
-    return event.target.value.length >= 1
+    return true
   }
 }
 

--- a/benefit-finder/src/shared/utils/errorHandling/index.js
+++ b/benefit-finder/src/shared/utils/errorHandling/index.js
@@ -1,3 +1,5 @@
+// import * as apiCalls from '../../api/apiCalls'
+
 /**
  * a function that collect all the required fields in the current step
  * @function
@@ -8,6 +10,54 @@ export const getRequiredFieldsets = (document, setHandler) => {
     node => node.attributes.required
   )
   setHandler(Array.from(requiredNodeList))
+}
+
+/**
+ * a function that collect all the non required fields in the current step which still need to be validated if there are requirements
+ * @function
+ */
+
+// if a date fieldset has values, add it to required fieldsets array even if not attributed as required
+export const getNonRequiredFieldsets = (
+  criteriaKey,
+  requiredFieldsets,
+  setHandler,
+  setHasError,
+  hasError,
+  data
+) => {
+  const node = document.getElementById(`${criteriaKey}`)
+
+  const dateDataObj = data.filter(item => item.criteriaKey === criteriaKey)
+
+  const dateValues = dateDataObj[0].values.value
+
+  const isEmpty = obj => {
+    for (const key in obj) {
+      if (obj[key] !== '') {
+        return false // returns false if object has a non-empty string value
+      }
+    }
+    return true // returns true if all values are empty strings
+  }
+
+  const addToRequiredFields = [...requiredFieldsets, node]
+
+  const makeUniq = [...new Set(addToRequiredFields)]
+
+  const removeFromRequiredFields = makeUniq.filter(
+    item => !item.id === criteriaKey
+  )
+
+  const removeFromErrorArray = hasError.filter(
+    item => !item.id.includes(criteriaKey)
+  )
+
+  isEmpty(dateValues) && setHasError(removeFromErrorArray)
+
+  isEmpty(dateValues)
+    ? setHandler(removeFromRequiredFields)
+    : setHandler(makeUniq)
 }
 
 export const handleCheckForRequiredValues = async (
@@ -64,7 +114,7 @@ export const handleCheckForRequiredValues = async (
 }
 
 export const handleInvalid = ({
-  required,
+  // required,
   hasError,
   criteriaKey,
   fieldSetId,
@@ -85,11 +135,12 @@ export const handleInvalid = ({
     return errorItem.id !== undefined && errorItem.id.includes(fieldSetId)
   })
 
-  return required && useFilter === true ? hanldeFilter : handleMap
+  return useFilter === true ? hanldeFilter : handleMap
 }
 
 export default {
   getRequiredFieldsets,
+  getNonRequiredFieldsets,
   handleCheckForRequiredValues,
   handleInvalid,
 }


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This works to accomplish three changes; 

1. allow users to select the default value of selects, while still throwing an alert if the field is required
3. handle validation on date fields even if they are not required
4. allow users to clear error alerts on invalid date fields if all fields are empty

## Related Github Issue

- Fixes #1737 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [x] pull changes locally
- [x] `cd benefit-finder`
- [x] update proxy url to point at our `main` bxdev env
- [x] `npm run start`

<!--- If there are steps for user testing list them here -->
- [x] navigate to `/death`
- [x] CLICK continue without providing any values
- [x] ensure error alert is rendered
- [x] SELECT an option from a fieldset with `<select />` input
- [x] ensure the error is cleared
- [x] SELECT the default option `--Select--`  from the now valid input
- [x] ensure the error is flagged and the DOM updates as expected

expected:

https://github.com/user-attachments/assets/8cc10631-edeb-42d7-b862-a8ec563ec9b9

- [x] navigate to `/all_benefits`
- [x] on the first step of the form, SELECT a month value from the date fieldset
- [x] CLICK continue
- [x] ensure that the error alert is rendered
- [x] SELECT the default option `--Select--`  from the now invalid input
- [x] ensure that the error alert is cleared
- [x] CLICK continue
- [x] ensure that you can proceed to the next step
- [x] CLICK back to return to the first step
- [x] SELECT a month value from the date fieldset
- [x] CLICK continue
- [x] ensure that the error alert is rendered
- [x] SELECT the default option `--Select--`  from the now invalid input
- [x] ensure that the error alert is cleared
- [x] enter a day value to the date fieldset
- [x] CLCIK continue
- [x] ensure that the error alert is rendered

expected:

https://github.com/user-attachments/assets/cb56f5d6-ee52-4f5a-adbb-8c7454cb1469

