### PR TITLE
1747 adjust button widths mobile

### DIFF
--- a/benefit-finder/src/shared/components/LifeEventSection/_index.scss
+++ b/benefit-finder/src/shared/components/LifeEventSection/_index.scss
@@ -35,13 +35,28 @@
     min-width: rem(120px);
   }
 
-  .bf-usa-button:first-of-type {
-    margin-right: space.$space-lg-plus;
+  .bf-usa-modal-group {
+    width: 100%;
   }
 
   button,
   .bf-usa-modal-group a {
-    margin-bottom: space.$space-md;
+    margin: 0;
+  }
+
+  @media (width >= $tablet) {
+    .bf-usa-button:first-of-type {
+      margin-right: space.$space-lg-plus;
+    }
+
+    .bf-usa-modal-group {
+      width: auto;
+    }
+
+    button,
+    .bf-usa-modal-group a {
+      margin-bottom: space.$space-md;
+    }
   }
 }
 

--- a/benefit-finder/src/shared/styles/breakpoints/_index.scss
+++ b/benefit-finder/src/shared/styles/breakpoints/_index.scss
@@ -1,3 +1,4 @@
 @use '../functions/index.scss' as *;
 
 $desktop: rem(1049px);
+$tablet: rem(479px);


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

## Related Github Issue

- Fixes #1747

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] Setup step 1
- [ ] etc...

<!--- If there are steps for user testing list them here -->

- [ ] open inspector
- [ ] set width to 478 px on responsive window mode
- [ ] navigate app noting that these inconsistencies have been resolved

before:

<img width="569" alt="Screenshot 2024-08-30 at 12 20 57 PM" src="https://github.com/user-attachments/assets/523756d9-802a-49a7-88a0-9121c33f49fb">
<img width="569" alt="Screenshot 2024-08-30 at 12 20 08 PM" src="https://github.com/user-attachments/assets/128b9ead-96a0-43cc-ab56-18245aa571cf">
<img width="593" alt="Screenshot 2024-08-30 at 12 19 16 PM" src="https://github.com/user-attachments/assets/a3ba04e7-258a-49a5-a7bf-dad02a34b97d">


expected:
<img width="661" alt="Screenshot 2024-08-30 at 12 58 36 PM" src="https://github.com/user-attachments/assets/2f0cb86f-924f-4310-9620-41c7908922cb">

