### PR TITLE
FIX: Error handling on required fields not persisting with default select options

### DIFF
--- a/benefit-finder/src/shared/utils/errorHandling/index.js
+++ b/benefit-finder/src/shared/utils/errorHandling/index.js
@@ -28,36 +28,40 @@ export const getNonRequiredFieldsets = (
 ) => {
   const node = document.getElementById(`${criteriaKey}`)
 
-  const dateDataObj = data.filter(item => item.criteriaKey === criteriaKey)
+  const notRequired = !node.attributes.required
 
-  const dateValues = dateDataObj[0].values.value
+  if (notRequired) {
+    const dateDataObj = data.filter(item => item.criteriaKey === criteriaKey)
 
-  const isEmpty = obj => {
-    for (const key in obj) {
-      if (obj[key] !== '') {
-        return false // returns false if object has a non-empty string value
+    const dateValues = dateDataObj[0].values.value
+
+    const isEmpty = obj => {
+      for (const key in obj) {
+        if (obj[key] !== '') {
+          return false // returns false if object has a non-empty string value
+        }
       }
+      return true // returns true if all values are empty strings
     }
-    return true // returns true if all values are empty strings
+
+    const addToRequiredFields = [...requiredFieldsets, node]
+
+    const makeUniq = [...new Set(addToRequiredFields)]
+
+    const removeFromRequiredFields = makeUniq.filter(
+      item => !item.id === criteriaKey
+    )
+
+    const removeFromErrorArray = hasError.filter(
+      item => !item.id.includes(criteriaKey)
+    )
+
+    isEmpty(dateValues) && setHasError(removeFromErrorArray)
+
+    isEmpty(dateValues)
+      ? setHandler(removeFromRequiredFields)
+      : setHandler(makeUniq)
   }
-
-  const addToRequiredFields = [...requiredFieldsets, node]
-
-  const makeUniq = [...new Set(addToRequiredFields)]
-
-  const removeFromRequiredFields = makeUniq.filter(
-    item => !item.id === criteriaKey
-  )
-
-  const removeFromErrorArray = hasError.filter(
-    item => !item.id.includes(criteriaKey)
-  )
-
-  isEmpty(dateValues) && setHasError(removeFromErrorArray)
-
-  isEmpty(dateValues)
-    ? setHandler(removeFromRequiredFields)
-    : setHandler(makeUniq)
 }
 
 export const handleCheckForRequiredValues = async (


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This works to resolve an bug where  

> the error isn't getting flagged when (a user) put(s) the valid input back to select.

## Related Github Issue

- Fixes #1772 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] proxy `bf-cms-dev.bxdev`

<!--- If there are steps for user testing list them here -->
- [ ] navigate to `/death`
- [ ] CLICK continue without providing any values
- [ ] ensure error alert is rendered
- [ ] SELECT a month value from the date fieldset
- [ ] ensure the error notification for month is cleared
- [ ] SELECT the default option `--Select--`  from the now valid input
- [ ] ensure the error is flagged and the DOM updates as expected

reference the bug report in https://github.com/orgs/GSA/projects/48/views/10?pane=issue&itemId=78753927 and ensure this is resolved and no longer happening.

- [ ] SELECT an option from a fieldset with `<select />` input
- [ ] ensure the error is cleared
- [ ] SELECT the default option `--Select--`  from the now valid input
- [ ] ensure the error is flagged and the DOM updates as expected

expected:

https://github.com/user-attachments/assets/8cc10631-edeb-42d7-b862-a8ec563ec9b9

- [ ] publish `all_benefits` node
- [ ]  navigate to `/all_benefits`
- [ ] on the first step of the form, SELECT a month value from the date fieldset
- [ ] CLICK continue
- [ ] ensure that the error alert is rendered
- [ ] SELECT the default option `--Select--`  from the now invalid input
- [ ] ensure that the error alert is cleared
- [ ] CLICK continue
- [ ] ensure that you can proceed to the next step
- [ ] CLICK back to return to the first step
- [ ] SELECT a month value from the date fieldset
- [ ] CLICK continue
- [ ] ensure that the error alert is rendered
- [ ] SELECT the default option `--Select--`  from the now invalid input
- [ ] ensure that the error alert is cleared
- [ ] enter a day value to the date fieldset
- [ ] CLICK continue
- [ ] ensure that the error alert is rendered

expected:

https://github.com/user-attachments/assets/cb56f5d6-ee52-4f5a-adbb-8c7454cb1469
