### PR TITLE
1795 add display order field in life event node

### DIFF
--- a/usagov_benefit_finder/configuration/core.entity_form_display.node.bears_life_event.default.yml
+++ b/usagov_benefit_finder/configuration/core.entity_form_display.node.bears_life_event.default.yml
@@ -1,0 +1,217 @@
+uuid: 99c745fb-37ed-4061-89ac-3bf52d328117
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.bears_life_event.field_b_display_order
+    - field.field.node.bears_life_event.field_b_id
+    - field.field.node.bears_life_event.field_b_search_title
+    - field.field.node.bears_life_event.field_draft_json_data_file
+    - field.field.node.bears_life_event.field_draft_json_data_file_path
+    - field.field.node.bears_life_event.field_header_html
+    - field.field.node.bears_life_event.field_json_data_file
+    - field.field.node.bears_life_event.field_json_data_file_path
+    - field.field.node.bears_life_event.field_language_toggle
+    - field.field.node.bears_life_event.field_meta_description
+    - field.field.node.bears_life_event.field_page_intro
+    - field.field.node.bears_life_event.field_short_description
+    - field.field.node.bears_life_event.field_summary
+    - node.type.bears_life_event
+  module:
+    - allowed_formats
+    - content_moderation
+    - file
+    - path
+    - text
+id: node.bears_life_event.default
+targetEntityType: node
+bundle: bears_life_event
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_b_display_order:
+    type: number
+    weight: 26
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_id:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_search_title:
+    type: string_textfield
+    weight: 7
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_draft_json_data_file:
+    type: file_generic
+    weight: 21
+    region: content
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+  field_draft_json_data_file_path:
+    type: string_textfield
+    weight: 19
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_header_html:
+    type: text_textarea
+    weight: 22
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '0'
+  field_json_data_file:
+    type: file_generic
+    weight: 20
+    region: content
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+  field_json_data_file_path:
+    type: string_textfield
+    weight: 18
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_language_toggle:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_meta_description:
+    type: string_textarea
+    weight: 5
+    region: content
+    settings:
+      rows: 1
+      placeholder: ''
+    third_party_settings: {  }
+  field_page_intro:
+    type: string_textarea
+    weight: 4
+    region: content
+    settings:
+      rows: 1
+      placeholder: ''
+    third_party_settings: {  }
+  field_short_description:
+    type: string_textarea
+    weight: 6
+    region: content
+    settings:
+      rows: 1
+      placeholder: ''
+    third_party_settings: {  }
+  field_summary:
+    type: string_textarea
+    weight: 8
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 0
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 16
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 13
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 11
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 15
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 17
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 12
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 9
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 14
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  menu_entity_index: true

--- a/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_life_event.default.yml
+++ b/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_life_event.default.yml
@@ -1,0 +1,148 @@
+uuid: 6a658720-5cd1-4c61-bf1c-a8f0c9a40680
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.bears_life_event.field_b_display_order
+    - field.field.node.bears_life_event.field_b_id
+    - field.field.node.bears_life_event.field_b_search_title
+    - field.field.node.bears_life_event.field_draft_json_data_file
+    - field.field.node.bears_life_event.field_draft_json_data_file_path
+    - field.field.node.bears_life_event.field_header_html
+    - field.field.node.bears_life_event.field_json_data_file
+    - field.field.node.bears_life_event.field_json_data_file_path
+    - field.field.node.bears_life_event.field_language_toggle
+    - field.field.node.bears_life_event.field_meta_description
+    - field.field.node.bears_life_event.field_page_intro
+    - field.field.node.bears_life_event.field_short_description
+    - field.field.node.bears_life_event.field_summary
+    - node.type.bears_life_event
+  module:
+    - file
+    - text
+    - user
+id: node.bears_life_event.default
+targetEntityType: node
+bundle: bears_life_event
+mode: default
+content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
+  field_b_display_order:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 13
+    region: content
+  field_b_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_b_search_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 12
+    region: content
+  field_draft_json_data_file:
+    type: file_default
+    label: above
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
+    weight: 9
+    region: content
+  field_draft_json_data_file_path:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  field_header_html:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  field_json_data_file:
+    type: file_default
+    label: above
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
+    weight: 8
+    region: content
+  field_json_data_file_path:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  field_language_toggle:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_meta_description:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_page_intro:
+    type: basic_string
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_short_description:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 11
+    region: content
+  field_summary:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  langcode:
+    type: language
+    label: above
+    settings:
+      link_to_entity: false
+      native_language: false
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_life_event.teaser.yml
+++ b/usagov_benefit_finder/configuration/core.entity_view_display.node.bears_life_event.teaser.yml
@@ -1,0 +1,52 @@
+uuid: 75f24593-dd3f-4f75-aea4-27d8ca76f40b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.bears_life_event.field_b_display_order
+    - field.field.node.bears_life_event.field_b_id
+    - field.field.node.bears_life_event.field_b_search_title
+    - field.field.node.bears_life_event.field_draft_json_data_file
+    - field.field.node.bears_life_event.field_draft_json_data_file_path
+    - field.field.node.bears_life_event.field_header_html
+    - field.field.node.bears_life_event.field_json_data_file
+    - field.field.node.bears_life_event.field_json_data_file_path
+    - field.field.node.bears_life_event.field_language_toggle
+    - field.field.node.bears_life_event.field_meta_description
+    - field.field.node.bears_life_event.field_page_intro
+    - field.field.node.bears_life_event.field_short_description
+    - field.field.node.bears_life_event.field_summary
+    - node.type.bears_life_event
+  module:
+    - user
+id: node.bears_life_event.teaser
+targetEntityType: node
+bundle: bears_life_event
+mode: teaser
+content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  field_b_display_order: true
+  field_b_id: true
+  field_b_search_title: true
+  field_draft_json_data_file: true
+  field_draft_json_data_file_path: true
+  field_header_html: true
+  field_json_data_file: true
+  field_json_data_file_path: true
+  field_language_toggle: true
+  field_meta_description: true
+  field_page_intro: true
+  field_short_description: true
+  field_summary: true
+  langcode: true

--- a/usagov_benefit_finder/configuration/field.field.node.bears_life_event.field_b_display_order.yml
+++ b/usagov_benefit_finder/configuration/field.field.node.bears_life_event.field_b_display_order.yml
@@ -1,0 +1,23 @@
+uuid: 09004dc5-fcc7-4802-a64f-64629089ee4a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_display_order
+    - node.type.bears_life_event
+id: node.bears_life_event.field_b_display_order
+field_name: field_b_display_order
+entity_type: node
+bundle: bears_life_event
+label: 'Display Order'
+description: 'The display order in benefit finder tool box of benefit finder landing page (https://www.usa.gov/benefit-finder)'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/usagov_benefit_finder/configuration/field.storage.node.field_b_display_order.yml
+++ b/usagov_benefit_finder/configuration/field.storage.node.field_b_display_order.yml
@@ -1,0 +1,24 @@
+uuid: ab4533d6-5920-4bba-9e8d-39269f7625d5
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_b_display_order
+field_name: field_b_display_order
+entity_type: node
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## PR Summary

This work adds display order field in life event content type.

## Related Github Issue

- Fixes #1795

## Detailed Testing steps

To test in local development site or in dev site.

- [ ] pull changes locally
- [ ] make local development site up at http://localhost
- [ ] if in local, `bin/drush cim --partial --source=modules/custom/usagov_benefit_finder/configuration -y`
- [ ] navigate to `admin/content?combine=&type=bears_life_event&status=All&langcode=All`
- [ ] go to life event "Benefit finder: death of a loved one" edit page
- [ ] verify that it has Display Order field

<img width="800" src="https://github.com/user-attachments/assets/436197b7-5845-4536-87b1-0a15c2674bc2">

