### PR TITLE
PXBF-1585-fix-modal-zoom: update modal scale and position

### DIFF
--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -15,6 +15,7 @@ const customStyles = {
     right: 0,
     bottom: 0,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    zIndex: 999,
   },
   content: {
     top: '50%',
@@ -26,7 +27,7 @@ const customStyles = {
     width: '80%',
     borderRadius: '8px',
     borderColor: '#005ea2',
-    padding: '4rem 1.5rem',
+    padding: '5% 10%',
     maxWidth: '32.5rem',
   },
 }


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

## Related Github Issue

- Fixes #1585 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] move latest code in app to usagov-2021 container
- [ ] navigate to `/benefit-finder/death` -> modal view step

<!--- If there are steps for user testing list them here -->

- [ ] ensure modal overlay sits above usagov global elements

expected
<img width="1512" alt="Screenshot 2024-09-12 at 11 51 25 AM" src="https://github.com/user-attachments/assets/fb9cefc3-65b8-4620-ad98-43ebae0e07e0">

- [ ] zoom browser window to 400%
- [ ] ensure close, title, and both nav buttons are in the view

expected
<img width="1512" alt="Screenshot 2024-09-12 at 11 51 08 AM" src="https://github.com/user-attachments/assets/fe5a0a2d-7f29-4ccb-ac71-7232576565af">



