### PR TITLE
PXBF-1786-fix-bf-change-event: async data handling in modal

### DIFF
--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -115,27 +115,33 @@ const Modal = ({
 
   // handle dataLayer
   useEffect(() => {
-    modalOpen === true &&
-      dataLayerUtils.dataLayerPush(window, {
-        event: modal.event,
-        bfData: {
-          pageView: modal.bfData.pageView,
-          viewTitle: `${dataLayerValue.viewTitle} modal`,
-        },
-      })
-    // handle dataLayer
-    modalOpen === true &&
-      dataLayerUtils.dataLayerPush(window, {
-        event: errors.event,
-        bfData: {
-          errors: '',
-          errorCount: {
-            number: 0,
-            string: `0`,
+    const handleModalData = async () => {
+      modalOpen === true &&
+        dataLayerUtils.dataLayerPush(window, {
+          event: modal.event,
+          bfData: {
+            pageView: modal.bfData.pageView,
+            viewTitle: `${dataLayerValue.viewTitle} modal`,
           },
-          formSuccess: true,
-        },
-      })
+        })
+    }
+
+    // async so we can handle duplicates if needed
+    handleModalData().then(() => {
+      // handle dataLayer
+      modalOpen === true &&
+        dataLayerUtils.dataLayerPush(window, {
+          event: errors.event,
+          bfData: {
+            errors: '',
+            errorCount: {
+              number: 0,
+              string: `0`,
+            },
+            formSuccess: true,
+          },
+        })
+    })
   }, [])
 
   /**


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

## Related Github Issue

- Fixes #1786

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] cd `benefit-finder`
- [ ] `npm install`
- [ ] `npm run start`

<!--- If there are steps for user testing list them here -->
- [ ] navigate to `disability`
- [ ] CLICK start
- [ ] CLICK next
- [ ] resolve error
- [ ] CLICK next
- [ ] CLICK next
- [ ] console.log(window.dataLayer)
- [ ] ensure that `bf_page_change` event for modal and form page 2 only fire once

expected:

![Screenshot 2024-09-12 at 12 41 43 PM](https://github.com/user-attachments/assets/9421ebf1-dde3-4b5b-982c-30d03639d71f)
