### PR TITLE
1769 set link field of relevant benefit as required

### DIFF
--- a/usagov_benefit_finder/configuration/field.field.paragraph.b_levent_relevant_benefit.field_b_link.yml
+++ b/usagov_benefit_finder/configuration/field.field.paragraph.b_levent_relevant_benefit.field_b_link.yml
@@ -1,0 +1,19 @@
+uuid: dd2cf9a0-3be8-4a3b-8378-afed2dcafb73
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_b_link
+    - paragraphs.paragraphs_type.b_levent_relevant_benefit
+id: paragraph.b_levent_relevant_benefit.field_b_link
+field_name: field_b_link
+entity_type: paragraph
+bundle: b_levent_relevant_benefit
+label: Link
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string


### PR DESCRIPTION
## PR Summary

This work makes link field of relevant benefit in life event form to be required.

## Related Github Issue

- Fixes #1769

## Detailed Testing steps

To test in local development site or in dev site.

- [ ] pull changes locally
- [ ] make local development site up at http://localhost
- [ ] if in local, `bin/drush cim --partial --source=modules/custom/usagov_benefit_finder/configuration -y`
- [ ] navigate to `admin/content?combine=&type=bears_life_event_form&status=All&langcode=All`
- [ ] go to life event form "Benefit finder: death of a loved one" edit page
- [ ] verify that link field of relevant benefit is required

<img width="800" src="https://github.com/user-attachments/assets/f65437bc-a55f-4ca7-8e0a-6908172c4218">

