### PR TITLE
PXBF-1814-fix-ui-markup: update closing p tag in description

### DIFF
--- a/benefit-finder/src/shared/components/ResultsView/components/Results/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/ResultsView/components/Results/__tests__/__snapshots__/index.spec.jsx.snap
@@ -21,7 +21,7 @@ exports[`Results > renders a match to the previous snapshot 1`] = `
       >
         <div>
           <p>
-            According to your answers you are not eligible for these benefits./p&gt;
+            According to your answers you are not eligible for these benefits.
           </p>
         </div>
       </div>

--- a/benefit-finder/src/shared/locales/en/en.json
+++ b/benefit-finder/src/shared/locales/en/en.json
@@ -104,7 +104,7 @@
     "notEligible": {
       "chevron": {
         "heading": "Benefits you did not qualify for",
-        "description": "<div><p>According to your answers you are not eligible for these benefits./p></div>"
+        "description": "<div><p>According to your answers you are not eligible for these benefits.</p></div>"
       },
       "heading": "Results",
       "description": "<strong>Based on your answers you are not eligible for these benefits.</strong>You may become eligible if you enter additional information or your situation changes."


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

## Related Github Issue

- Fixes #1814 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] navigate to `/death?applicant_date_of_birth=%7B%22month%22%3A%220%22%2C%22day%22%3A%222%22%2C%22year%22%3A%222022%22%7D&applicant_relationship_to_the_deceased=Spouse&applicant_marital_status=Married&deceased_date_of_death=%7B%22month%22%3A%220%22%2C%22day%22%3A%222%22%2C%22year%22%3A%222022%22%7D&deceased_death_location_is_US=Yes&deceased_paid_into_SS=Yes&deceased_public_safety_officer=Yes&deceased_miner=Yes&deceased_american_indian=Yes&deceased_died_of_COVID=Yes&deceased_served_in_active_military=No&shared=true`
- [ ] on results view CLICK, "Explore other potential benefits"
- [ ] ensure closing `</p>` tag is not rendered in string

<!--- If there are steps for user testing list them here -->

reported:
<img width="1506" alt="Screenshot 2024-09-17 at 10 33 36 AM" src="https://github.com/user-attachments/assets/3980ca63-bd8c-4ffe-b205-75ebaaae273a">


expected:
<img width="1512" alt="Screenshot 2024-09-17 at 10 27 47 AM" src="https://github.com/user-attachments/assets/3e7e8742-d1c6-4337-9f47-015f36b4dbb8">
<img width="1512" alt="Screenshot 2024-09-17 at 10 29 04 AM" src="https://github.com/user-attachments/assets/eb77a0bf-3b59-4a14-8eb0-60cf4dd542c5">

