### PR TITLE
PXBF-1816-fix-beforeunload-event: determine if form has value based o…

### DIFF
--- a/benefit-finder/src/shared/api/apiCalls.js
+++ b/benefit-finder/src/shared/api/apiCalls.js
@@ -424,7 +424,26 @@ export async function DataDate(
         } else {
           inputValues[0].value = eventTargetValue
         }
-        inputValues[0].selected = true
+
+        const dateHasValues = obj => {
+          for (const key in obj) {
+            if (
+              obj[key] !== null &&
+              obj[key] !== undefined &&
+              obj[key] !== ''
+            ) {
+              return true
+            }
+          }
+          return false
+        }
+
+        if (dateHasValues(inputValues[0].value) === false) {
+          inputValues[0].selected = false
+        } else {
+          inputValues[0].selected = true
+        }
+
         return setCurrentData(newData)
       }
     })

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -51,7 +51,9 @@ const LifeEventSection = ({
   const [currentData, setCurrentData] = useState(() => data && data[step - 1])
   const [requiredFieldsets, setRequiredFieldsets] = useState([])
   const [hasError, setHasError] = useState([])
-  const [hasData, setHasData] = useState(false)
+  const [hasData, setHasData] = useState(
+    () => apiCalls.GET.SelectedValueAll(data).length > 0
+  )
   const [submissionCount, setSubmissionCount] = useState(0)
   const { lifeEventSection } = dataLayerUtils.dataLayerStructure
   useHandleUnload(hasData) // alert the user if they try to go back in browser
@@ -185,8 +187,8 @@ const LifeEventSection = ({
    * @return {object} object as state
    */
   const handleChanged = (event, criteriaKey) => {
-    event.target.value.length > 0 && setHasData(true)
     window.history.replaceState({}, '', window.location.pathname)
+
     apiCalls.PUT.Data(
       criteriaKey,
       currentData,
@@ -195,6 +197,7 @@ const LifeEventSection = ({
     )
     hasError.length > 0 &&
       errorHandling.handleCheckForRequiredValues(requiredFieldsets, setHasError)
+    setHasData(apiCalls.GET.SelectedValueAll(data).length > 0)
   }
 
   /**
@@ -205,7 +208,6 @@ const LifeEventSection = ({
    */
   const handleDateChanged = (event, criteriaKey) => {
     // if event target is empty check if all values in date are empty
-    event.target.value.length > 0 && setHasData(true)
     window.history.replaceState({}, '', window.location.pathname)
 
     async function validUpdate() {
@@ -234,6 +236,7 @@ const LifeEventSection = ({
         hasError,
         apiCalls.GET.SelectedValueAll(data)
       )
+      setHasData(apiCalls.GET.SelectedValueAll(data).length > 0)
     })
   }
 


### PR DESCRIPTION
…n selected values in data array

## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

## Related Github Issue

- Fixes #1816 

## Detailed Testing steps

What happened
Ernie Deeb (USAGov, NYC, he/him)

If the form has any data in it, browser back prompts the data loss modal. If I'm on page 2 but haven't entered any data, back does not prompt the data loss modal. However data is still lost (the first page)

That can happen on a fresh page 2, on the review results modal, or on the results page

<!--- If there are steps for local setup list them here -->
- [ ] navigate to /death
- [ ] enter data for first step of form
- [ ] CLICK back button in browser
- [ ] expect to see an alert
- [ ] cancel
- [ ] complete required fields in first step of form
- [ ] navigate to second step
- [ ] CLICK back button in browser
- [ ] expect to see an alert
- [ ] repeat for steps to test on results page

<!--- If there are steps for user testing list them here -->
