### PR TITLE
1787 change hint field to formatted

### DIFF
--- a/usagov_benefit_finder/configuration/core.entity_form_display.paragraph.b_levent_elg_criteria.default.yml
+++ b/usagov_benefit_finder/configuration/core.entity_form_display.paragraph.b_levent_elg_criteria.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - paragraphs.paragraphs_type.b_levent_elg_criteria
   module:
     - paragraphs
+    - text
 id: paragraph.b_levent_elg_criteria.default
 targetEntityType: paragraph
 bundle: b_levent_elg_criteria
@@ -19,7 +20,7 @@ mode: default
 content:
   field_b_children:
     type: paragraphs
-    weight: 6
+    weight: 5
     region: content
     settings:
       title: Paragraph
@@ -51,11 +52,11 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_b_hint:
-    type: string_textfield
+    type: text_textarea
     weight: 3
     region: content
     settings:
-      size: 60
+      rows: 5
       placeholder: ''
     third_party_settings: {  }
   field_b_legend:

--- a/usagov_benefit_finder/configuration/core.entity_view_display.paragraph.b_levent_elg_criteria.default.yml
+++ b/usagov_benefit_finder/configuration/core.entity_view_display.paragraph.b_levent_elg_criteria.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - paragraphs.paragraphs_type.b_levent_elg_criteria
   module:
     - entity_reference_revisions
+    - text
 id: paragraph.b_levent_elg_criteria.default
 targetEntityType: paragraph
 bundle: b_levent_elg_criteria
@@ -24,7 +25,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 6
+    weight: 4
     region: content
   field_b_criteria_key:
     type: entity_reference_label
@@ -40,13 +41,12 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 7
+    weight: 5
     region: content
   field_b_hint:
-    type: string
+    type: text_default
     label: above
-    settings:
-      link_to_entity: false
+    settings: {  }
     third_party_settings: {  }
     weight: 2
     region: content

--- a/usagov_benefit_finder/configuration/field.field.paragraph.b_levent_elg_criteria.field_b_hint.yml
+++ b/usagov_benefit_finder/configuration/field.field.paragraph.b_levent_elg_criteria.field_b_hint.yml
@@ -1,0 +1,22 @@
+uuid: 96756355-9a7a-4487-956a-c55e7d93d268
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_b_hint
+    - paragraphs.paragraphs_type.b_levent_elg_criteria
+  module:
+    - text
+id: paragraph.b_levent_elg_criteria.field_b_hint
+field_name: field_b_hint
+entity_type: paragraph
+bundle: b_levent_elg_criteria
+label: Hint
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats: {  }
+field_type: text_long

--- a/usagov_benefit_finder/configuration/field.storage.paragraph.field_b_hint.yml
+++ b/usagov_benefit_finder/configuration/field.storage.paragraph.field_b_hint.yml
@@ -1,0 +1,23 @@
+uuid: c0a37ed2-140b-421d-94ae-577f210ac42a
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - paragraphs
+    - text
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: paragraph.field_b_hint
+field_name: field_b_hint
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## PR Summary

This work changes hint field to be formatted.

## Related Github Issue

- Fixes #1787

## Detailed Testing steps

To test in local development site or in dev site.

- [ ] pull changes locally
- [ ] make local development site up at http://localhost
- [ ] if in local, `bin/drush cim --partial --source=modules/custom/usagov_benefit_finder/configuration -y`
- [ ] navigate to `admin/content?combine=&type=bears_life_event_form&status=All&langcode=All`
- [ ] go to life event form "Benefit finder: retirement" edit page
- [ ] verify that it has Display Order field
- [ ] Input hint in criteria "Applicant income" 
`Your annual household income is within the <a href="https://aspe.hhs.gov/topics/poverty-economic-mobility/poverty-guidelines">federal poverty guideline</a>.`

<img width="800" src="https://github.com/user-attachments/assets/043da3ab-7c7b-4686-87bd-dbe008b731eb">

- [ ] Verify the system generates JSON files
- [ ] Go to life event retirement app`benefit-finder/retirement`
- [ ] CLICK "Start finding benefits"
- [ ] Verify hint of criteria "Applicant income" to have hyperlink code

<img width="500" src="https://github.com/user-attachments/assets/978dedd9-f76a-415d-821e-825fe7a4e3dd">

