### PR TITLE
1817 display raw html

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
@@ -320,6 +320,7 @@ class LifeEventController extends ControllerBase {
       "benefits" => $benefits,
     ];
     $json = json_encode($result, JSON_PRETTY_PRINT);
+    $json = htmlspecialchars($json);
 
     if ($this->displayData) {
       print_r("<p>JSON Data<pre>");


### PR DESCRIPTION
## PR Summary

This work adds code to display raw html when viewing JSON data.

## Related Github Issue

- Fixes #1817

## Detailed Testing steps

To test in local development site or in dev site.

- [ ] pull changes locally
- [ ] make local development site up at http://localhost
- [ ] navigate to `admin/content?combine=&type=bears_life_event_form&status=All&langcode=All`
- [ ] go to life event form "Benefit finder: retirement" edit page
- [ ] add `<a href="http://usagov.gov">USAGov</a>` in summary field
- [ ] save as published
- [ ] navigate to `benefit-finder/api/life-event/retirement`
- [ ] verify the hyperlink in summary as raw html

<img width="800" src="https://github.com/user-attachments/assets/135d71eb-f3ec-4abe-9222-559b1c96cb3e">
