### PR TITLE
1710 content workflow

### DIFF
--- a/usagov_benefit_finder/configuration/user.role.benefits_finder_content_manager.yml
+++ b/usagov_benefit_finder/configuration/user.role.benefits_finder_content_manager.yml
@@ -1,0 +1,85 @@
+uuid: 75d7efed-afe2-4f3a-8750-2a898df6086e
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.bears_agency
+    - node.type.bears_benefit
+    - node.type.bears_criteria
+    - node.type.bears_life_event
+    - node.type.bears_life_event_form
+    - taxonomy.vocabulary.bears_tags
+    - workflows.workflow.basic_workflow
+  module:
+    - block
+    - content_lock
+    - content_moderation
+    - node
+    - system
+    - taxonomy
+    - toolbar
+id: benefits_finder_content_manager
+label: 'Benefits Finder Content Manager'
+weight: 6
+is_admin: null
+permissions:
+  - 'access administration pages'
+  - 'access content overview'
+  - 'access site in maintenance mode'
+  - 'access toolbar'
+  - 'administer blocks'
+  - 'administer menu'
+  - 'administer nodes'
+  - 'break content lock'
+  - 'create bears_agency content'
+  - 'create bears_benefit content'
+  - 'create bears_criteria content'
+  - 'create bears_life_event content'
+  - 'create bears_life_event_form content'
+  - 'create terms in bears_tags'
+  - 'delete any bears_agency content'
+  - 'delete any bears_benefit content'
+  - 'delete any bears_criteria content'
+  - 'delete any bears_life_event content'
+  - 'delete any bears_life_event_form content'
+  - 'delete bears_agency revisions'
+  - 'delete bears_benefit revisions'
+  - 'delete bears_criteria revisions'
+  - 'delete bears_life_event revisions'
+  - 'delete bears_life_event_form revisions'
+  - 'delete own bears_agency content'
+  - 'delete own bears_benefit content'
+  - 'delete own bears_criteria content'
+  - 'delete own bears_life_event content'
+  - 'delete own bears_life_event_form content'
+  - 'delete terms in bears_tags'
+  - 'edit any bears_agency content'
+  - 'edit any bears_benefit content'
+  - 'edit any bears_criteria content'
+  - 'edit any bears_life_event content'
+  - 'edit any bears_life_event_form content'
+  - 'edit own bears_agency content'
+  - 'edit own bears_benefit content'
+  - 'edit own bears_criteria content'
+  - 'edit own bears_life_event content'
+  - 'edit own bears_life_event_form content'
+  - 'edit terms in bears_tags'
+  - 'revert bears_agency revisions'
+  - 'revert bears_benefit revisions'
+  - 'revert bears_criteria revisions'
+  - 'revert bears_life_event revisions'
+  - 'revert bears_life_event_form revisions'
+  - 'use basic_workflow transition archive'
+  - 'use basic_workflow transition create_new_draft'
+  - 'use basic_workflow transition move_to_review'
+  - 'use basic_workflow transition publish'
+  - 'use basic_workflow transition restore'
+  - 'view any unpublished content'
+  - 'view bears_agency revisions'
+  - 'view bears_benefit revisions'
+  - 'view bears_criteria revisions'
+  - 'view bears_life_event revisions'
+  - 'view bears_life_event_form revisions'
+  - 'view latest version'
+  - 'view own unpublished content'
+  - 'view the administration theme'

--- a/usagov_benefit_finder/configuration/workflows.workflow.basic_workflow.yml
+++ b/usagov_benefit_finder/configuration/workflows.workflow.basic_workflow.yml
@@ -1,0 +1,84 @@
+uuid: d8ae2079-7547-46f2-9b73-b10cb68bfff4
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.basic_page
+    - node.type.bears_agency
+    - node.type.bears_benefit
+    - node.type.bears_criteria
+    - node.type.bears_life_event
+    - node.type.bears_life_event_form
+  module:
+    - content_moderation
+id: basic_workflow
+label: 'Basic Workflow'
+type: content_moderation
+type_settings:
+  states:
+    archived:
+      label: 'Archived (Unpublish)'
+      weight: 2
+      published: false
+      default_revision: true
+    draft:
+      label: Draft
+      weight: -2
+      published: false
+      default_revision: false
+    needs_review:
+      label: 'Needs Review'
+      weight: -1
+      published: false
+      default_revision: false
+    published:
+      label: Published
+      weight: 1
+      published: true
+      default_revision: true
+  transitions:
+    archive:
+      label: Archive
+      from:
+        - published
+      to: archived
+      weight: 2
+    create_new_draft:
+      label: 'Create New Draft'
+      from:
+        - draft
+        - needs_review
+        - published
+      to: draft
+      weight: -3
+    move_to_review:
+      label: 'Move to Review'
+      from:
+        - draft
+        - needs_review
+        - published
+      to: needs_review
+      weight: -2
+    publish:
+      label: Publish
+      from:
+        - draft
+        - needs_review
+        - published
+      to: published
+      weight: 1
+    restore:
+      label: Restore
+      from:
+        - archived
+      to: draft
+      weight: 3
+  entity_types:
+    node:
+      - basic_page
+      - bears_agency
+      - bears_benefit
+      - bears_criteria
+      - bears_life_event
+      - bears_life_event_form
+  default_moderation_state: draft


### PR DESCRIPTION
## PR Summary

This work sets benefit finder content to basic workflow.
This work sets content moderation permission for benefit finder content manager.

## Related Github Issue

- Fixes #1710

## Detailed Testing steps

To test in local development site or in dev site.

- [ ] Pull changes locally
- [ ] Make local development site up at http://localhost
- [ ] If in local, `bin/drush cim --partial --source=modules/custom/usagov_benefit_finder/configuration -y`
- [ ] Navigate to `node/add`
- [ ] CLICK `Agency`
- [ ] Create an agency
- [ ] Save as "Draft

<img width=300 src=https://github.com/user-attachments/assets/bcd3cef5-3449-4b43-9138-05b3b65a464b>

- [ ] CLICK "Edit"
- [ ] Save as "Needs Review"

<img width=300 src=https://github.com/user-attachments/assets/2d901f41-3b6c-48c3-bfca-a57e4e114add>

- [ ] CLICK "Edit"
- [ ] Save as Published

<img width=300 src=https://github.com/user-attachments/assets/61cfefaa-6d71-4daa-8998-7bc29fe9e330>

- [ ] CLICK "Edit"
- [ ] Save as Archived

<img width=300 src=https://github.com/user-attachments/assets/f0072c0b-fd38-49b6-b2df-971f29789d91>

- [ ] CLICK "Edit"
- [ ] Save as Draft

<img width=300 src=https://github.com/user-attachments/assets/82cf9749-5fd3-4fa0-af1a-3f9fd7f66817>

