### PR TITLE
Adding drush CR to post db restore script

### DIFF
--- a/scripts/drush-post-deploy.sh
+++ b/scripts/drush-post-deploy.sh
@@ -4,6 +4,7 @@
 ## It reads lines based on new lines.
 
 echo  "Updating drupal ... "
+drush cr
 drush state:set system.maintenance_mode 1 -y
 drush cr
 drush updatedb --no-cache-clear -y


### PR DESCRIPTION
…command

## PR Summary

This PR adds a drush cr right before it sets the database to maintenance mode. This is to rebuild cache coming in from backup which in this case appears to be bad.

## Related Github Issue

- Fixes #(issue)

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] Setup step 1
- [ ] etc...

<!--- If there are steps for user testing list them here -->
