### PR TITLE
1846 No JSON file generation for needs review

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_api/usagov_benefit_finder_api.module
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_api/usagov_benefit_finder_api.module
@@ -16,8 +16,22 @@ use Drupal\usagov_benefit_finder_api\Controller\LifeEventController;
  * @param Node $node
  */
 function usagov_benefit_finder_api_node_update(Node $node) {
+  $generate_json_files = 1;
   $url = _usagov_benefit_finder_api_get_current_page_url();
+
   if (strpos($url, "/admin/content") === FALSE) {
+    if ($node->hasField('moderation_state')) {
+      $moderation_state = $node->get('moderation_state')->value;
+      if ($moderation_state == 'needs_review') {
+        $generate_json_files = 0;
+      }
+    }
+  }
+  else {
+    $generate_json_files = 0;
+  }
+
+  if ($generate_json_files == 1) {
     _usagov_benefit_finder_api_batch_generate_json_data_files($node);
   }
   else {


### PR DESCRIPTION
## PR Summary

This work adds code to not generate JSON files when content changing to needs review state.

## Related Github Issue

- Fixes #1846

## Detailed Testing steps

To test in local development site or in dev site.

- [ ] Confirm PR https://github.com/GSA/px-benefit-finder/pull/1842 merged.
- [ ] Pull changes locally
- [ ] Make local development site up at http://localhost
- [ ] If in local, bin/drush cim --partial --source=modules/custom/usagov_benefit_finder/configuration -y
- [ ] Navigate to `admin/content?combine=&type=bears_agency&status=All&langcode=All`
- [ ] Go to agency "Department of Education (DOE)" edit page
- [ ] Change to `Draft `
- [ ] CLICK Save
- [ ] Verify JSON file generation
- [ ] Go to agency "Department of Education (DOE)" edit page
- [ ] Change to `Needs Review`
- [ ] CLICK Save
- [ ] Verify no JSON file generation
- [ ] Verify seeing warning message

<img width="500" src="https://github.com/user-attachments/assets/b36de3aa-043b-4491-824a-4f43f6b63d24">

