### PR TITLE
1858 do not use archived content in building JSON data

### DIFF
--- a/usagov_benefit_finder/src/Traits/BenefitFinderTrait.php
+++ b/usagov_benefit_finder/src/Traits/BenefitFinderTrait.php
@@ -8,6 +8,7 @@
 namespace Drupal\usagov_benefit_finder\Traits;
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 
 /**
@@ -158,6 +159,15 @@ trait BenefitFinderTrait {
    *   The node revision entity.
    */
   public function getNode($nid, $mode) {
+    $node = Node::load($nid);
+
+    if ($node->hasField('moderation_state')) {
+      $moderation_state = $node->get('moderation_state')->value;
+      if ($moderation_state == 'archived') {
+          return NULL;
+      }
+    }
+
     if ($mode == "published") {
       $query = $this->entityTypeManager->getStorage('node')
         ->getQuery()


### PR DESCRIPTION
## PR Summary

This work adds code to not use archived content in building JSON data.

## Related Github Issue

- Fixes #1858

## Detailed Testing steps

To test in local development site or in dev site.

- [ ] Pull changes locally
- [ ] Make local development site up at http://localhost
- [ ] Navigate to benefit-finder/api/life-event/death
- [ ] Verify benefit "COVID-19 funeral assistance" in JSON data

<img width="700" src="https://github.com/user-attachments/assets/d5764679-4997-47ea-94c7-52321d37e739">

- [ ] Navigate to `admin/content?combine=COVID&type=bears_benefit&status=All&langcode=All`
- [ ] Go to benefit "COVID-19 funeral assistance" edit page
- [ ] Change to archived

<img width="350" src="https://github.com/user-attachments/assets/addc4f85-6e9b-4b98-a065-b98d89e57490">

- [ ] CLICK `Save`
- [ ] Navigate to benefit-finder/api/life-event/death
- [ ] Verify no benefit "COVID-19 funeral assistance" in JSON data

