### PR TITLE
1866 do not archive criteria if still used

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
@@ -214,41 +214,86 @@ function _usagov_benefit_finder_content_check_agency_usage() {
 /**
  * Implements hook_form_FORM_ID_alter().
  */
+function usagov_benefit_finder_content_form_node_bears_criteria_edit_form_alter(array &$form, FormStateInterface $form_state) {
+  $form['#validate'][] = '_usagov_benefit_finder_content_node_bears_criteria_edit_form_validate';
+  $form['#validate'][] = '_usagov_benefit_finder_content_criteria_archived';
+}
+
+/**
+ * It checks criteria usage in benefits and life event forms when a criteria to be archived.
+ * If still used, it lists the benefits and life event forms and prevents the criteria to be archived.
+ *
+ * @param array $form
+ *   Form array.
+ * @param FormStateInterface $form_state
+ *   Form state object.
+ */
+function _usagov_benefit_finder_content_criteria_archived(array &$form, FormStateInterface $form_state) {
+  $line = 0;
+  $moderation_state = $form_state->getValue('moderation_state');
+  $state_value = $moderation_state[0]['value'];
+  if ($state_value == 'archived') {
+    $result = _usagov_benefit_finder_content_check_criteria_usage();
+    if (!empty($result)) {
+      $form_state->setErrorByName(++$line, t("This criteria cannot be archived as it is still used in following contents:"));
+      foreach ($result as $row) {
+        $form_state->setErrorByName(++$line, "$row[type]: $row[title] ($row[nid])");
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
 function usagov_benefit_finder_content_form_node_bears_criteria_delete_form_alter(array &$form, FormStateInterface $form_state) {
-  _usagov_benefit_finder_content_check_criteria_usage($form);
+  $return = _usagov_benefit_finder_content_check_criteria_usage();
+  if (!empty($return)) {
+    $description = '';
+    foreach ($return as $row) {
+      $description .= "<li>$row[type]: $row[title] ($row[nid])</li>";
+    }
+    $description = '<div class="entity-skip">'
+      . '<span>This criteria cannot be deleted as it is still used in following contents:</span>'
+      . "<ul>$description</ul>"
+      . '</div>';
+    $form['description']['#markup'] = $description;
+    $form['actions']['submit']['#access'] = FALSE;
+  }
 }
 
 /**
  * It checks criteria usage in benefits and life event forms.
- * If still used, it lists the benefits and life event forms and disables the criteria delete confirmation button.
+ * If still used, it returns array of node ID and title of these benefits and life event forms.
  *
- * @param array $form
- *   Form array.
+ * @return array
+ *   An array containing node ID and title.
  */
-function _usagov_benefit_finder_content_check_criteria_usage(array &$form) {
-  $description = '';
+function _usagov_benefit_finder_content_check_criteria_usage() {
+  $return = [];
 
   $node = \Drupal::routeMatch()->getParameter('node');
   $nid = $node->id();
 
   $result = _usagov_benefit_finder_content_check_criteria_usage_in_life_event_form($nid);
   foreach ($result as $row) {
-    $description .= "<li>Life event form: $row[title] ($row[nid])</li>";
+    $return[] = [
+      'type' => 'Life event form',
+      'nid' => $row['nid'],
+      'title' => $row['title'],
+    ];
   }
 
   $result = _usagov_benefit_finder_content_check_criteria_usage_in_benefit($nid);
   foreach ($result as $row) {
-    $description .= "<li>Benefit: $row[title] ($row[nid])</li>";
+    $return[] = [
+      'type' => 'Benefit',
+      'nid' => $row['nid'],
+      'title' => $row['title'],
+    ];
   }
 
-  if (!empty($description)) {
-    $description = '<div class="entity-skip">'
-      . '<span>This criteria cannot be deleted as it is still used in following content:</span>'
-      . "<ul>$description</ul>"
-      . '</div>';
-    $form['description']['#markup'] = t($description);
-    $form['actions']['submit']['#access'] = FALSE;
-  }
+  return $return;
 }
 
 /**
@@ -338,18 +383,6 @@ function _usagov_benefit_finder_content_check_criteria_usage_in_benefit(int $nid
   }
 
   return $return;
-}
-
-/**
- * Implements hook_form_FORM_ID_alter().
- *
- * @param array $form
- *   Form array.
- * @param FormStateInterface $form_state
- *   Form state object.
- */
-function usagov_benefit_finder_content_form_node_bears_criteria_edit_form_alter(array &$form, FormStateInterface $form_state) {
-  $form['#validate'][] = '_usagov_benefit_finder_content_node_bears_criteria_edit_form_validate';
 }
 
 /**


### PR DESCRIPTION
## PR Summary

This work prevents criteria  archived if it is still used.
The system lists the content that use the criteria.

## Related Github Issue

- Fixes #1866

## Detailed Testing steps

To test in local development site or in dev site.

- [ ] Pull changes locally

Get latest USAGov dev code.
- [ ] `cd usagov-2021`
- [ ] `git checkout dev & git pull`

Continue testing.
- [ ] Make local development site up at http://localhost
- [ ] hNavigate to `admin/content?combine=&type=bears_criteria&status=All&langcode=All`
- [ ] Go to criteria "Applicant date of birth" edit page
- [ ] Change to `Archived`
- [ ] CLICK `Save`

<img width="350" src="https://github.com/user-attachments/assets/5f69966a-5e11-47fd-9cda-87db117e23fa">

- [ ] Verify error message with list of benefits and life event forms that use this criteria

<img width="700" src="https://github.com/user-attachments/assets/510c0825-3c87-4627-bba8-a5b44b82dcf9">
