### PR TITLE
1891 adjust modal margins

### DIFF
--- a/benefit-finder/src/Routes/LifeEventSection/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/Routes/LifeEventSection/__tests__/__snapshots__/index.spec.jsx.snap
@@ -8,7 +8,7 @@ exports[`LifeEventSection > renders a match to the previous snapshot 1`] = `
     id="skip-to-h1"
     role="heading"
   >
-    Answer these questions
+    Answer the following questions
   </h1>
   <div
     class="bf-section-wrapper"

--- a/benefit-finder/src/Routes/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/Routes/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
@@ -91,10 +91,10 @@ exports[`loads view 1`] = `
                     class="bf-usa-list usa-list"
                   >
                     <li>
-                      Visit each agency’s website to find full eligibility requirements.
+                      You need to visit each agency’s website to find full eligibility requirements and apply.
                     </li>
                     <li>
-                      Your results may change if you answer more questions or modify your answers.
+                      Your results may vary if your situation or answers change.
                     </li>
                     <li>
                        
@@ -102,7 +102,7 @@ exports[`loads view 1`] = `
                         class="bf-usa-summary-box__link usa-summary-box__link"
                         href="#"
                       >
-                        Clear my answers and restart the form.
+                        Clear your answers and restart the form.
                       </a>
                     </li>
                   </ul>
@@ -6063,7 +6063,7 @@ exports[`loads view 1`] = `
                 data-testid="bf-result-view-unmet-button"
                 type="button"
               >
-                Explore other potential benefits
+                Explore benefits you did not qualify for
               </button>
             </div>
           </div>
@@ -6473,10 +6473,10 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                     class="bf-usa-list usa-list"
                   >
                     <li>
-                      Visit each agency’s website to find full eligibility requirements.
+                      You need to visit each agency’s website to find full eligibility requirements and apply.
                     </li>
                     <li>
-                      Your results may change if you answer more questions or modify your answers.
+                      Your results may vary if your situation or answers change.
                     </li>
                     <li>
                        
@@ -6484,7 +6484,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                         class="bf-usa-summary-box__link usa-summary-box__link"
                         href="#"
                       >
-                        Clear my answers and restart the form.
+                        Clear your answers and restart the form.
                       </a>
                     </li>
                   </ul>
@@ -12445,7 +12445,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 data-testid="bf-result-view-unmet-button"
                 type="button"
               >
-                Explore other potential benefits
+                Explore benefits you did not qualify for
               </button>
             </div>
           </div>

--- a/benefit-finder/src/Routes/ResultsView/components/Results/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/Routes/ResultsView/components/Results/__tests__/__snapshots__/index.spec.jsx.snap
@@ -74,10 +74,10 @@ exports[`Results > renders a match to the previous snapshot 1`] = `
                 class="bf-usa-list usa-list"
               >
                 <li>
-                  Visit each agency’s website to find full eligibility requirements.
+                  You need to visit each agency’s website to find full eligibility requirements and apply.
                 </li>
                 <li>
-                  Your results may change if you answer more questions or modify your answers.
+                  Your results may vary if your situation or answers change.
                 </li>
                 <li>
                    
@@ -85,7 +85,7 @@ exports[`Results > renders a match to the previous snapshot 1`] = `
                     class="bf-usa-summary-box__link usa-summary-box__link"
                     href="#"
                   >
-                    Clear my answers and restart the form.
+                    Clear your answers and restart the form.
                   </a>
                 </li>
               </ul>

--- a/benefit-finder/src/Routes/ResultsView/components/blocks/ZeroBenefitsHeading/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/Routes/ResultsView/components/blocks/ZeroBenefitsHeading/__tests__/__snapshots__/index.spec.jsx.snap
@@ -15,7 +15,7 @@ exports[`ZeroBenefitsHeading > renders a match to the previous snapshot 1`] = `
     class="bf-zero-benefits-view-description "
     role="heading"
   >
-    Based on your answers you are likely not eligible for benefits. You may become eligible if you enter more information or your situation changes.
+    Based on your answers, you are currently not eligible for this life event’s benefits. You may become eligible if your situation or answers change in the future. Visit your city, state, or employer for other potential benefits.
   </h3>
   <div
     class="bf-back-to-form-cta"

--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -26,7 +26,7 @@ const customStyles = {
     width: '80%',
     borderRadius: '8px',
     borderColor: '#005ea2',
-    padding: '5% 10%',
+    padding: '5% 0',
     maxWidth: '32.5rem',
   },
 }

--- a/benefit-finder/src/shared/components/Summary/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/Summary/__tests__/__snapshots__/index.spec.jsx.snap
@@ -25,10 +25,10 @@ exports[`Summary > renders a match to the previous snapshot 1`] = `
           class="bf-usa-list usa-list"
         >
           <li>
-            Visit each agency’s website to find full eligibility requirements.
+            You need to visit each agency’s website to find full eligibility requirements and apply.
           </li>
           <li>
-            Your results may change if you answer more questions or modify your answers.
+            Your results may vary if your situation or answers change.
           </li>
           <li>
              
@@ -36,7 +36,7 @@ exports[`Summary > renders a match to the previous snapshot 1`] = `
               class="bf-usa-summary-box__link usa-summary-box__link"
               href="#"
             >
-              Clear my answers and restart the form.
+              Clear your answers and restart the form.
             </a>
           </li>
         </ul>


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
this adjust the modal to correct for screen zoom percentages

## Related Github Issue

- Fixes #1891 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ] cd benefit-finder
- [ ] npm install
- [ ] npm run start

<!--- If there are steps for user testing list them here -->
- [ ] navigate to modal
- [ ] zoom window to '500%'
- [ ] zoom window to '40%'
- [ ] ensure content remains centered

expected:

https://github.com/user-attachments/assets/84051e12-fb61-4a36-ad3d-88e197d3f1d1



