### PR TITLE
1770 fix ajax http error

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
@@ -226,9 +226,11 @@ class LifeEventController extends ControllerBase {
     if (empty($life_event_form_node)) {
       $result = [];
       $json = json_encode($result, JSON_PRETTY_PRINT);
-      print_r("<p>JSON Data<pre>");
-      print_r($json);
-      print_r("</pre>");
+      if ($this->displayData) {
+        print_r("<p>JSON Data<pre>");
+        print_r($json);
+        print_r("</pre>");
+      }
       return $result;
     }
 

--- a/usagov_benefit_finder/src/Traits/BenefitFinderTrait.php
+++ b/usagov_benefit_finder/src/Traits/BenefitFinderTrait.php
@@ -161,6 +161,10 @@ trait BenefitFinderTrait {
   public function getNode($nid, $mode) {
     $node = Node::load($nid);
 
+    if (!$node) {
+      return NULL;
+    }
+
     if ($node->hasField('moderation_state')) {
       $moderation_state = $node->get('moderation_state')->value;
       if ($moderation_state == 'archived') {


### PR DESCRIPTION
## PR Summary

This work fixes Ajax HTTP error in JSON file generating when creating new life event.

## Related Github Issue

- Fixes #1770

## Detailed Testing steps

To test in local development site or in dev site.

- [ ] Pull changes locally
- [ ] Make local development site up at http://localhost
- [ ] Navigate to `add/bears_life_event` to create a new life event
- [ ] Input Title: New Life Event
- [ ] Input ID: new_life_event
- [ ] Save as Draft
- [ ] Navigate to `admin/content?combine=&type=bears_criteria&status=All&langcode=All`
- [ ] Go to criteria "Applicant date of birth" edit page
- [ ] Edit title
- [ ] Save as Draft
- [ ] Verify the system generates JSON files successfully without Ajax HTTP error

<img width="700" src="https://github.com/user-attachments/assets/0e1a15f8-be7d-43ad-9abf-c5feac3b17b0">

