### PR TITLE
PXBF-1928-cypress-page-objects-alpha-order: organize page object methods in alpha order

### DIFF
--- a/benefit-finder/cypress/support/pageObjects.js
+++ b/benefit-finder/cypress/support/pageObjects.js
@@ -1,8 +1,16 @@
 /// <reference types="Cypress" />
 
 class PageObjects {
-  button() {
-    return cy.get('.usa-button')
+  accordionByTitle(title) {
+    return this.accordionHeading().contains(new RegExp(`^${title}$`))
+  }
+
+  accordionHeading() {
+    return cy.get('[data-testid="accordion-heading"]')
+  }
+
+  alertHeading() {
+    return cy.get('[data-testid="bf-alert-heading"]')
   }
 
   benefitMemorableDate() {
@@ -13,40 +21,12 @@ class PageObjects {
     return this.benefitMemorableDate().find(`[id$="${id}"]`)
   }
 
+  benefitResultsView() {
+    return cy.get('[data-testid="bf-result-view"]')
+  }
+
   benefitSectionAlert() {
     return cy.get('[data-testid="alert"]')
-  }
-
-  alertHeading() {
-    return cy.get('[data-testid="bf-alert-heading"]')
-  }
-
-  bfAlertList() {
-    return cy.get('[data-testid="bf-errors-list"]')
-  }
-
-  bfAlertListItem() {
-    return cy.get('[data-testid="bf-errors-list-item"]')
-  }
-
-  fieldset() {
-    return cy.get('[data-testid="fieldset"]')
-  }
-
-  fieldsetById(id) {
-    return this.fieldset().find(`[id^="${id}"]`)
-  }
-
-  modalButtonGroup() {
-    return cy.get('[data-testid="modal-button-group"]')
-  }
-
-  accordionHeading() {
-    return cy.get('[data-testid="accordion-heading"]')
-  }
-
-  accordionByTitle(title) {
-    return this.accordionHeading().contains(new RegExp(`^${title}$`))
   }
 
   benefitsAccordionLink(title) {
@@ -58,6 +38,58 @@ class PageObjects {
       .find('a[data-testid="bf-benefit-link"]')
   }
 
+  bfAlertList() {
+    return cy.get('[data-testid="bf-errors-list"]')
+  }
+
+  bfAlertListItem() {
+    return cy.get('[data-testid="bf-errors-list-item"]')
+  }
+
+  breadCrumbList() {
+    return cy.get('.usa-breadcrumb__list')
+  }
+
+  button() {
+    return cy.get('.usa-button')
+  }
+
+  cardGroup() {
+    return cy.get('.usa-card-group li')
+  }
+
+  dateOfBirthDayError() {
+    return cy.get('[data-testid="day-error-description"]')
+  }
+
+  dateOfBirthMonthError() {
+    return cy.get('[data-testid="month-error-description"]')
+  }
+
+  dateOfBirthYearError() {
+    return cy.get('[data-testid="year-error-description"]')
+  }
+
+  errorDescription() {
+    return cy.get('[data-testid="error-description"]')
+  }
+
+  expandAll() {
+    return cy.get('[data-testid="bf-expand-all"]')
+  }
+
+  fieldset() {
+    return cy.get('[data-testid="fieldset"]')
+  }
+
+  fieldsetById(id) {
+    return this.fieldset().find(`[id^="${id}"]`)
+  }
+
+  iconGreenCheck() {
+    return cy.get('[data-testid="icon-green-check"]')
+  }
+
   menuButton() {
     return cy.get('.usa-menu-btn')
   }
@@ -66,56 +98,24 @@ class PageObjects {
     return cy.get('.usagov-mobile-menu')
   }
 
-  breadCrumbList() {
-    return cy.get('.usa-breadcrumb__list')
-  }
-
-  cardGroup() {
-    return cy.get('.usa-card-group li')
-  }
-
-  radioGroup() {
-    return cy.get('[data-testid="radio-group"]')
-  }
-
-  expandAll() {
-    return cy.get('[data-testid="bf-expand-all"]')
-  }
-
-  iconGreenCheck() {
-    return cy.get('[data-testid="icon-green-check"]')
-  }
-
-  benefitResultsView() {
-    return cy.get('[data-testid="bf-result-view"]')
+  modalButtonGroup() {
+    return cy.get('[data-testid="modal-button-group"]')
   }
 
   notEligibleResultsButton() {
     return cy.get('[data-testid="bf-result-view-unmet-button"]')
   }
 
-  errorDescription() {
-    return cy.get('[data-testid="error-description"]')
-  }
-
-  dateOfBirthMonthError() {
-    return cy.get('[data-testid="month-error-description"]')
-  }
-
-  dateOfBirthDayError() {
-    return cy.get('[data-testid="day-error-description"]')
-  }
-
-  dateOfBirthYearError() {
-    return cy.get('[data-testid="year-error-description"]')
-  }
-
-  zeroBenefitsViewHeading() {
-    return cy.get('[data-testid="zero-benefits-view-heading"]')
+  radioGroup() {
+    return cy.get('[data-testid="radio-group"]')
   }
 
   seeAllBenefitsButton() {
     return cy.get('[data-testid="zero-benefits-view-cta-button"]')
+  }
+
+  zeroBenefitsViewHeading() {
+    return cy.get('[data-testid="zero-benefits-view-heading"]')
   }
 }
 


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This PR organizes he methods in the pageObjects.js file So that I can quickly locate and manage individual page object methods, making the file easier to read and maintain.

## Related Github Issue

- Fixes #1928

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ]  `cd benefit finder`
- [ ] `npm run dev:storybook`
- [ ]  `cy:run:e2e` and verify all test pass
<!--- If there are steps for user testing list them here -->
