### PR TITLE
1492 remove criteria group

### DIFF
--- a/usagov_benefit_finder/configuration/field.field.paragraph.b_levent_elg_criteria.field_b_children.yml
+++ b/usagov_benefit_finder/configuration/field.field.paragraph.b_levent_elg_criteria.field_b_children.yml
@@ -1,0 +1,117 @@
+uuid: 1f1bb68b-7d0e-4a85-b33c-e61e6c724214
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_b_children
+    - paragraphs.paragraphs_type.b_levent_elg_criteria
+  module:
+    - entity_reference_revisions
+id: paragraph.b_levent_elg_criteria.field_b_children
+field_name: field_b_children
+entity_type: paragraph
+bundle: b_levent_elg_criteria
+label: Children
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      b_levent_elg_criteria: b_levent_elg_criteria
+    negate: 0
+    target_bundles_drag_drop:
+      b_benefit_eligibility:
+        weight: 30
+        enabled: false
+      b_levent_elg_criteria:
+        weight: 31
+        enabled: true
+      b_levent_elg_criteria_group:
+        weight: 32
+        enabled: false
+      b_levent_elg_section:
+        weight: 33
+        enabled: false
+      b_levent_relevant_benefit:
+        weight: 35
+        enabled: false
+      faq:
+        weight: 34
+        enabled: false
+      text_field:
+        weight: 35
+        enabled: false
+      uswds_2_column_breakpoints:
+        weight: 37
+        enabled: false
+      uswds_2_columns:
+        weight: 36
+        enabled: false
+      uswds_3_column_breakpoints:
+        weight: 39
+        enabled: false
+      uswds_3_columns:
+        weight: 38
+        enabled: false
+      uswds_accordion:
+        weight: 40
+        enabled: false
+      uswds_accordion_section:
+        weight: 41
+        enabled: false
+      uswds_alert:
+        weight: 42
+        enabled: false
+      uswds_card_breakpoints:
+        weight: 44
+        enabled: false
+      uswds_card_group_flag:
+        weight: 45
+        enabled: false
+      uswds_card_group_regular:
+        weight: 46
+        enabled: false
+      uswds_card_regular:
+        weight: 47
+        enabled: false
+      uswds_cards_flag:
+        weight: 43
+        enabled: false
+      uswds_column_equal_size:
+        weight: 50
+        enabled: false
+      uswds_columns_2_uneven:
+        weight: 48
+        enabled: false
+      uswds_columns_3_uneven:
+        weight: 49
+        enabled: false
+      uswds_icon_list:
+        weight: 51
+        enabled: false
+      uswds_icon_list_item:
+        weight: 52
+        enabled: false
+      uswds_modal:
+        weight: 53
+        enabled: false
+      uswds_process_item:
+        weight: 54
+        enabled: false
+      uswds_process_list:
+        weight: 55
+        enabled: false
+      uswds_step_indicator_item:
+        weight: 56
+        enabled: false
+      uswds_step_indicator_list:
+        weight: 57
+        enabled: false
+      uswds_summary_box:
+        weight: 58
+        enabled: false
+field_type: entity_reference_revisions

--- a/usagov_benefit_finder/configuration/field.field.paragraph.b_levent_elg_section.field_b_criterias.yml
+++ b/usagov_benefit_finder/configuration/field.field.paragraph.b_levent_elg_section.field_b_criterias.yml
@@ -1,0 +1,118 @@
+uuid: 2f464066-4e85-4919-aaa6-3b0fc7fb0785
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_b_criterias
+    - paragraphs.paragraphs_type.b_levent_elg_criteria
+    - paragraphs.paragraphs_type.b_levent_elg_section
+  module:
+    - entity_reference_revisions
+id: paragraph.b_levent_elg_section.field_b_criterias
+field_name: field_b_criterias
+entity_type: paragraph
+bundle: b_levent_elg_section
+label: Criterias
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      b_levent_elg_criteria: b_levent_elg_criteria
+    negate: 0
+    target_bundles_drag_drop:
+      b_benefit_eligibility:
+        weight: 5
+        enabled: false
+      b_levent_elg_criteria:
+        weight: 5
+        enabled: true
+      b_levent_elg_criteria_group:
+        weight: 32
+        enabled: false
+      b_levent_elg_section:
+        weight: 6
+        enabled: false
+      b_levent_relevant_benefit:
+        weight: 35
+        enabled: false
+      faq:
+        weight: 34
+        enabled: false
+      text_field:
+        weight: 35
+        enabled: false
+      uswds_2_column_breakpoints:
+        weight: 37
+        enabled: false
+      uswds_2_columns:
+        weight: 36
+        enabled: false
+      uswds_3_column_breakpoints:
+        weight: 39
+        enabled: false
+      uswds_3_columns:
+        weight: 38
+        enabled: false
+      uswds_accordion:
+        weight: 40
+        enabled: false
+      uswds_accordion_section:
+        weight: 41
+        enabled: false
+      uswds_alert:
+        weight: 42
+        enabled: false
+      uswds_card_breakpoints:
+        weight: 44
+        enabled: false
+      uswds_card_group_flag:
+        weight: 45
+        enabled: false
+      uswds_card_group_regular:
+        weight: 46
+        enabled: false
+      uswds_card_regular:
+        weight: 47
+        enabled: false
+      uswds_cards_flag:
+        weight: 43
+        enabled: false
+      uswds_column_equal_size:
+        weight: 50
+        enabled: false
+      uswds_columns_2_uneven:
+        weight: 48
+        enabled: false
+      uswds_columns_3_uneven:
+        weight: 49
+        enabled: false
+      uswds_icon_list:
+        weight: 51
+        enabled: false
+      uswds_icon_list_item:
+        weight: 52
+        enabled: false
+      uswds_modal:
+        weight: 53
+        enabled: false
+      uswds_process_item:
+        weight: 54
+        enabled: false
+      uswds_process_list:
+        weight: 55
+        enabled: false
+      uswds_step_indicator_item:
+        weight: 56
+        enabled: false
+      uswds_step_indicator_list:
+        weight: 57
+        enabled: false
+      uswds_summary_box:
+        weight: 58
+        enabled: false
+field_type: entity_reference_revisions


### PR DESCRIPTION
## PR Summary

This work removes criteria group.
- removes criteria group in children field of paragraph criteria
- removes criteria group in criteria field of paragraph section
- removes `Add criteria group` button in life event form


## Related Github Issue

- Fixes #1492

## Detailed Testing steps

To test in local development site or in dev site.

- [ ] Pull changes locally
- [ ] Make local development site up at http://localhost
- [ ] If in local, `bin/drush cim --partial --source=modules/custom/usagov_benefit_finder/configuration -y`
- [ ] Navigate to `admin/content?combine=&type=bears_life_event_form&status=All&langcode=All`
- [ ] Go to life event form "Benefit finder: death of a loved one" edit page
- [ ] Go to criteria "Applicant date of birth"
- [ ] Verify no `Add criteria group` button in criteria

<img width=700 src=https://github.com/user-attachments/assets/c52779cc-7cc4-4311-9442-799932c3a6da>

- [ ] Go to "Deceased service status"
- [ ] Verify no `Add criteria group` button in children of criteria

<img width=700 src=https://github.com/user-attachments/assets/4b0ccd6c-1d32-4b5a-b8eb-9a6968e188cc>
