### PR TITLE
1850 support only one level nested criteria

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_content/usagov_benefit_finder_content.module
@@ -467,6 +467,81 @@ function _usagov_benefit_finder_content_check_criteria_has_child(int $nid) {
  */
 function usagov_benefit_finder_content_form_node_bears_life_event_form_edit_form_alter(array &$form, FormStateInterface $form_state) {
   $form['#validate'][] = '_usagov_benefit_finder_content_life_event_form_archived';
+  $form['#validate'][] = '_usagov_benefit_finder_content_check_life_event_form_criteria_depth';
+}
+
+/**
+ * It checks criteria depth of life event form.
+ * If criteria depth greater than 1, it gives error message and lists of the criteria.
+ *
+ * @param array $form
+ *   Form array.
+ * @param FormStateInterface $form_state
+ *   Form state object.
+ */
+function _usagov_benefit_finder_content_check_life_event_form_criteria_depth(array &$form, FormStateInterface $form_state) {
+  $error_flag = FALSE;
+  $criteria_depths = [];
+
+  $life_event_form_node = $form_state->getFormObject()->getEntity();
+  $sections = $life_event_form_node->get('field_b_sections_elg_criteria')->referencedEntities();
+
+  foreach ($sections as $section) {
+    $criterias = $section->get('field_b_criterias')->referencedEntities();
+
+    foreach ($criterias as $criteria) {
+      $criteria_fieldset = _usagov_benefit_finder_content_find_life_event_form_criteria_depth($criteria, 0);
+
+      foreach ($criteria_fieldset as $record) {
+        if ($record['depth'] > 1) {
+          $error_flag = TRUE;
+        }
+        $criteria_depths[] = $record;
+      }
+    }
+  }
+
+  if ($error_flag) {
+    $line = 0;
+    $form_state->setErrorByName(++$line, t("Benefit Finder V1 only supports one level nested criteria (depth <= 1)."));
+    foreach ($criteria_depths as $record) {
+      if ($record['depth'] > 1) {
+        $form_state->setErrorByName(++$line, "$record[criteriaKey]  (depth=$record[depth])");
+      }
+    }
+  }
+}
+
+/**
+ * It finds criteria depth of life event form.
+ *
+ * @param $criteria
+ *   The criteria
+ * @param $depth
+ *   The depth
+ * @return array
+ *   An array containing criteria key and depth.
+ */
+function _usagov_benefit_finder_content_find_life_event_form_criteria_depth($criteria, $depth) {
+  $criteria_fieldset = [];
+
+  $criteria_fieldset[] = [
+    "criteriaKey" => current($criteria->get('field_b_criteria_key')->referencedEntities())->get('field_b_id')->value,
+    "depth" => $depth,
+  ];
+
+  $criterias_1 = $criteria->get('field_b_children')->referencedEntities();
+  if (!empty($criterias_1)) {
+    $depth++;
+    foreach ($criterias_1 as $criteria_1) {
+      $results = _usagov_benefit_finder_content_find_life_event_form_criteria_depth($criteria_1, $depth);
+      foreach ($results as $result) {
+        $criteria_fieldset[] = $result;
+      }
+    }
+  }
+
+  return $criteria_fieldset;
 }
 
 /**


### PR DESCRIPTION
## PR Summary

This work validates criteria depth in life event form, and prevents creating criteria with depth greater than 1.

## Related Github Issue

- Fixes #1850

## Detailed Testing steps

To test in local development site or in dev site.

- [ ] Pull changes locally
- [ ] Make local development site up at `http://localhost`
- [ ] Navigate to `node/add`
- [ ] Click `Add Criteria` to add a criteria as following
- [ ] Title: depth 0 criteria
- [ ] Criteria Key: depth_0_criteria
- [ ] ID: depth_0_criteria
- [ ] Type: Boolean
- [ ] Label: Depth 0 criteria
- [ ] Name: Depth 0 criteria
- [ ] Values: 1) Yes 2) No

<img width=700 src=https://github.com/user-attachments/assets/b365f481-c74f-4c8d-ab00-fe0813b4ec62>

- [ ] Follow same steps to create depth 1, depth 2, and depth 3 criteria
- [ ] Navigate to `admin/content?combine=&type=bears_life_event_form&status=All&langcode=All`
- [ ] Go to life event form "Benefit finder: death of a loved one" edit page
- [ ] Go to section "About you" to add criteria "depth 0 criteria"
- [ ] Add criteria "depth 1 criteria" as child of "depth 0 criteria"
- [ ] Add criteria "depth 2 criteria" as child of "depth 1 criteria"
- [ ] Add criteria "depth 3 criteria" as child of "depth 2 criteria"

<img width=700 src=https://github.com/user-attachments/assets/5b0830d0-a736-4053-ade8-5d9e87e094de>

- [ ] Click Save 
- [ ] Verify error message about criteria depth >1

<img width=700 src=https://github.com/user-attachments/assets/1ed80295-42a3-487a-bf84-df6884e06d40>
