### PR TITLE
PXBF-1975-more-info-return-to-form

### DIFF
--- a/benefit-finder/src/Routes/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/Routes/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
@@ -531,6 +531,14 @@ exports[`loads view 1`] = `
                           The deceased worked in the coal mines and their death was due to black lung disease (pneumoconiosis)
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -715,6 +723,14 @@ exports[`loads view 1`] = `
                           One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -961,6 +977,14 @@ exports[`loads view 1`] = `
                           One of the following applies to the deceased: died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -1171,6 +1195,14 @@ exports[`loads view 1`] = `
                           The service status of the deceased is: discharged under conditions other than dishonorable
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -1360,6 +1392,14 @@ exports[`loads view 1`] = `
                           The service status of the deceased is: discharged under conditions other than dishonorable
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -1544,6 +1584,14 @@ exports[`loads view 1`] = `
                           The person is buried in a grave with a privately purchased headstone or an unmarked grave
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -1728,6 +1776,14 @@ exports[`loads view 1`] = `
                           The person is buried in a grave with a privately purchased headstone or an unmarked grave
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -1907,6 +1963,14 @@ exports[`loads view 1`] = `
                           The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, retired from the service, or member of the National Guard/Reserves
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -2091,6 +2155,14 @@ exports[`loads view 1`] = `
                           One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, or died while receiving/eligible for VA compensation
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -2306,6 +2378,14 @@ exports[`loads view 1`] = `
                           One of the following applies to the deceased: died while on active duty or died as a result of a service-related disability/illness
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -2490,6 +2570,14 @@ exports[`loads view 1`] = `
                           One of the following applies to the deceased: died on active duty
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -3273,6 +3361,14 @@ exports[`loads view 1`] = `
                           The service status of the deceased is: retired from the service
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -3457,6 +3553,14 @@ exports[`loads view 1`] = `
                           One of the following applies to the deceased: died while on active duty or died as a result of a service-related disability/illness
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -4426,6 +4530,14 @@ exports[`loads view 1`] = `
                           The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -4641,6 +4753,14 @@ exports[`loads view 1`] = `
                           One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, Died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -5027,6 +5147,14 @@ exports[`loads view 1`] = `
                           One of the following applies to the deceased: died while on active duty or died while on inactive-duty service training
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -5179,6 +5307,14 @@ exports[`loads view 1`] = `
                           One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -5363,6 +5499,14 @@ exports[`loads view 1`] = `
                           One of the following applies to the deceased: died while on active duty or Died while on inactive-duty service training
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -5525,6 +5669,14 @@ exports[`loads view 1`] = `
                           Your service status is: discharged under conditions other than dishonorable
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -6718,6 +6870,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           The deceased worked in the coal mines and their death was due to black lung disease (pneumoconiosis)
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -6902,6 +7062,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -7148,6 +7316,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           One of the following applies to the deceased: died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -7358,6 +7534,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           The service status of the deceased is: discharged under conditions other than dishonorable
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -7547,6 +7731,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           The service status of the deceased is: discharged under conditions other than dishonorable
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -7731,6 +7923,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           The person is buried in a grave with a privately purchased headstone or an unmarked grave
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -7915,6 +8115,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           The person is buried in a grave with a privately purchased headstone or an unmarked grave
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -8094,6 +8302,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, retired from the service, or member of the National Guard/Reserves
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -8278,6 +8494,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, or died while receiving/eligible for VA compensation
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -8493,6 +8717,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           One of the following applies to the deceased: died while on active duty or died as a result of a service-related disability/illness
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -8677,6 +8909,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           One of the following applies to the deceased: died on active duty
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -9460,6 +9700,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           The service status of the deceased is: retired from the service
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -9644,6 +9892,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           One of the following applies to the deceased: died while on active duty or died as a result of a service-related disability/illness
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -10613,6 +10869,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -10828,6 +11092,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, Died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -11214,6 +11486,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           One of the following applies to the deceased: died while on active duty or died while on inactive-duty service training
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -11366,6 +11646,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -11550,6 +11838,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           One of the following applies to the deceased: died while on active duty or Died while on inactive-duty service training
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"
@@ -11712,6 +12008,14 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                           Your service status is: discharged under conditions other than dishonorable
                         </li>
                       </ul>
+                      <button
+                        class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+                        data-test="button"
+                        data-testid="bf-step-back-button"
+                        type="button"
+                      >
+                        Go back to start
+                      </button>
                     </div>
                     <div
                       class="bf-usa-accordion-group-cta-wrapper"

--- a/benefit-finder/src/Routes/ResultsView/components/Results/index.jsx
+++ b/benefit-finder/src/Routes/ResultsView/components/Results/index.jsx
@@ -1,4 +1,7 @@
+import { useContext } from 'react'
 import PropTypes from 'prop-types'
+import { RouteContext } from '@/App'
+import { useNavigate } from 'react-router-dom'
 import {
   BenefitAccordionGroup,
   Button,
@@ -29,6 +32,8 @@ const Results = ({
   relevantBenefits,
   ui,
 }) => {
+  const ROUTES = useContext(RouteContext)
+  const navigate = useNavigate()
   // Results view components
   const ResultsBannerBlock = ({ notEligibleView, zeroBenefitsResult, ui }) => {
     const { eligible, notEligible, zeroBenefits } = ui
@@ -140,12 +145,7 @@ const Results = ({
         >
           {resultsRelativeBenefits?.heading}
         </Heading>
-        {relevantBenefits && (
-          <RelativeBenefitList
-            data={relevantBenefits}
-            carrotType="carrot"
-          ></RelativeBenefitList>
-        )}
+        {relevantBenefits && <RelativeBenefitList data={relevantBenefits} />}
       </div>
     )
   }
@@ -176,6 +176,9 @@ const Results = ({
           }
           isExpandAll={isExpandAll}
           setExpandAll={setExpandAll}
+          returnToForm={() =>
+            navigate(`/${ROUTES.indexPath}/${ROUTES.formPaths[0]}`)
+          }
           ui={ui}
         />
       </div>

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/__snapshots__/index.spec.jsx.snap
@@ -133,6 +133,14 @@ exports[`BenefitAccordionGroup > renders a match to the previous snapshot 1`] = 
                 You paid for funeral or burial expenses and were not reimbursed
               </li>
             </ul>
+            <button
+              class="bf-step-back-button bf-usa-button usa-button bf-usa-button--unstyled usa-button--unstyled"
+              data-test="button"
+              data-testid="bf-step-back-button"
+              type="button"
+            >
+              Go back to start
+            </button>
           </div>
           <div
             class="bf-usa-accordion-group-cta-wrapper"

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/index.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/index.jsx
@@ -5,6 +5,7 @@ import {
   Button,
   Heading,
   KeyElegibilityCrieriaList,
+  StepBackButton,
   ObfuscatedLink,
 } from '@components'
 import './_index.scss'
@@ -18,6 +19,7 @@ import './_index.scss'
  * @param {bool} isExpandAll - determines if all the accordions in the group are expanded
  * @param {function} setExpandAll - inherited useState function
  * @param {function} notEligibleView - inherited bolean state
+ * @param {object} returnToForm - inherited object for more info cta
  * @param {object} ui - inherited ui content
  * @return {html} returns html
  */
@@ -28,6 +30,7 @@ const BenefitAccordionGroup = ({
   isExpandAll,
   setExpandAll,
   notEligibleView,
+  returnToForm,
   ui,
 }) => {
   const { benefitAccordion, benefitAccordionGroup } = ui
@@ -37,6 +40,7 @@ const BenefitAccordionGroup = ({
     visitLabel,
     unmetLabel,
     sourceIsEnglish,
+    backcta,
   } = benefitAccordion
   const { closedState, openState } = benefitAccordionGroup
   const { benefitLink, openAllBenefitAccordions } =
@@ -151,6 +155,9 @@ const BenefitAccordionGroup = ({
             )
           })}
         </ul>
+        <StepBackButton onClick={() => returnToForm()}>
+          {backcta?.link}
+        </StepBackButton>
       </div>
     )
   }
@@ -236,7 +243,9 @@ const BenefitAccordionGroup = ({
                 <NotEligibleList items={notEligibleBenefits} />
               )}
               {moreInformationNeeded.length > 0 && (
-                <MoreInfoList items={moreInformationNeeded} />
+                <>
+                  <MoreInfoList items={moreInformationNeeded} />
+                </>
               )}
               <div className="bf-usa-accordion-group-cta-wrapper">
                 <ObfuscatedLink

--- a/benefit-finder/src/shared/locales/en/en.json
+++ b/benefit-finder/src/shared/locales/en/en.json
@@ -139,6 +139,10 @@
         "More information needed",
         "Not eligible"
       ],
+      "backcta": {
+        "text": "",
+        "link": "Go back to start"
+      },
       "agencyPrefix": "By",
       "benefitSummary": "Key eligibility criteria",
       "benefitSummaryPrefix": "Met ",

--- a/benefit-finder/src/shared/locales/es/es.json
+++ b/benefit-finder/src/shared/locales/es/es.json
@@ -139,6 +139,10 @@
         "Más información requerida",
         "No elegible"
       ],
+      "backcta": {
+        "text": "",
+        "link": "Volver al inicio"
+      },
       "agencyPrefix": "",
       "benefitSummary": "Criterios de elegibilidad",
       "benefitSummaryPrefix": "Cumple ",


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
new logic to include "Go back to start" functionality for more-info needed lists

## Related Github Issue

- Fixes #1975 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [x] navigate to `/death`

<!--- If there are steps for user testing list them here -->
- [x] provide required values
- [x] navigate to list of benefit accordions
- [x] ensure that any of the following conditionals results in rendering the "Go back to start" cta

1. not-eligible view in the more info needed accordions
2. not-eligible view in the not-eligible accordions that also have more info needed listed

- [x] when clicked the user should be navigated back to the first step of the form with the previous selections still in value

