### PR TITLE
Add automation in order to automate test user creation

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -212,6 +212,7 @@ jobs:
           CR_PAT: "${{ secrets.CR_PAT }}"
           CR_USERNAME: "${{ secrets.CR_USERNAME }}"
           PROJECT: "${{ secrets.PROJECT }}"
+          TEST_USER_PASS: "{{ secrets.TEST_USER_PASS }}"
         run: |
           source ./scripts/pipeline/cloud-gov-login.sh
           cd usagov-2021
@@ -221,4 +222,5 @@ jobs:
           cf add-network-policy ${PROJECT}-waf-${BRANCH} ${PROJECT}-cms-${BRANCH} -s ${PROJECT}-${BRANCH} -o ${CF_ORG} --protocol tcp --port 61443
           cf map-route benefit-finder-cms-${BRANCH} apps.internal --hostname benefit-finder-cms-${BRANCH} --app-protocol http1
           cd ..
+          sed -i "sed -i "s/TU_PASS/${TEST_USER_PASS}/g" ./scripts/drush-post-deploy.sh"
           source ./scripts/pipeline/cloud-gov-post-deploy.sh

--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -47,8 +47,10 @@ jobs:
           CF_ORG: "${{ secrets.CF_ORG }}"
           PROJECT: "${{ secrets.PROJECT }}"
           DATABASE_BACKUP_BASTION_NAME: "${{ secrets.DATABASE_BACKUP_BASTION_NAME }}"
+          TEST_USER_PASS: "{{ secrets.TEST_USER_PASS }}"
         run: |
           export S3_FILE_PATH=${{ github.event.inputs.database_file_override }}
+          sed -i "sed -i "s/TU_PASS/${TEST_USER_PASS}/g" ./scripts/drush-post-deploy.sh"
           source ./scripts/pipeline/s3-backup-download.sh
           source ./scripts/pipeline/database-restore.sh
           source ./scripts/pipeline/cloud-gov-post-deploy.sh

--- a/scripts/drush-post-deploy.sh
+++ b/scripts/drush-post-deploy.sh
@@ -3,12 +3,23 @@
 ## Make sure the last line has a new line or the pipeline script won't read it.
 ## It reads lines based on new lines.
 
-echo  "Updating drupal ... "
+echo "Updating Drupal..."
 drush cr
 drush state:set system.maintenance_mode 1 -y
 drush cr
 drush updatedb --no-cache-clear -y
 drush cim --partial --source=modules/custom/usagov_benefit_finder/configuration -y
 drush cr
+
+# Update passwords for existing users
+echo "Updating passwords for test users..."
+drush upwd scott_queen --password="TU_PASS"
+drush upwd nehemia_abuga --password="TU_PASS"
+drush upwd diego_cob --password="TU_PASS"
+drush upwd cindy_fong --password="TU_PASS"
+drush upwd ernie_deeb --password="TU_PASS"
+drush upwd test_test --password="TU_PASS"
+
 drush state:set system.maintenance_mode 0 -y
-echo "Post deploy finished!"
+echo "Post-deploy finished!"
+


### PR DESCRIPTION
## PR Summary

Added some automation to the post deploy script to change the test users passwords to a value kept in github secrets and replaced with the sed command at runtime in the deploy pipeline as well as the database restore pipeline.

## Related Github Issue

- Fixes #(issue)
[1981](https://github.com/GSA/px-benefit-finder/issues/1981)


## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- Need to test with deploy and database restore pipelines runs.
- After run see if users still there and attempt to login user usernames and test user password.
<!--- If there are steps for user testing list them here -->
