### PR TITLE
PXBF-1598-enhance-cypress-tests-custom-commands

### DIFF
--- a/benefit-finder/cypress.config.js
+++ b/benefit-finder/cypress.config.js
@@ -1,4 +1,4 @@
-const { defineConfig } = require('Cypress')
+const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
   experimentalWebKitSupport: true,

--- a/benefit-finder/cypress.config.js
+++ b/benefit-finder/cypress.config.js
@@ -1,5 +1,4 @@
- 
-const { defineConfig } = require('cypress')
+const { defineConfig } = require('Cypress')
 
 module.exports = defineConfig({
   experimentalWebKitSupport: true,

--- a/benefit-finder/cypress/e2e/storybook/aria-attribute-state.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/aria-attribute-state.cy.js
@@ -3,78 +3,49 @@
 import * as utils from '../../support/utils.js'
 import * as EN_LOCALE_DATA from '../../../src/shared/locales/en/en.json'
 import * as EN_DOLO_MOCK_DATA from '../../../src/shared/api/mock-data/current.json'
-import { pageObjects } from '../../support/pageObjects.js'
 
-const dob = utils.getDateByOffset(-(18 * 365.2425 - 1))
-const relation =
+const dateOfBirth = utils.getDateByOffset(-(18 * 365.2425 - 1))
+const relationship =
   EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0].section
     .fieldsets[1].fieldset.inputs[0].inputCriteria.values[1].value
 const relationshipId =
   EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0].section
     .fieldsets[1].fieldset.inputs[0].inputCriteria.id
-const status =
+const maritalStatus =
   EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0].section
     .fieldsets[2].fieldset.inputs[0].inputCriteria.values[1].value
 
 describe('Validate state of aria-invalid attribute', () => {
   beforeEach(() => {
     cy.visit(utils.storybookUri)
-    pageObjects.button().contains(EN_LOCALE_DATA.intro.button).click()
+    cy.navigateToAboutTheApplicantPage()
   })
 
   it('Should have default state of "false" for select, input, and radio', () => {
-    pageObjects
-      .fieldsetById(relationshipId)
-      .invoke('attr', 'aria-invalid')
-      .should('eq', 'false')
-
-    pageObjects
-      .benefitMemorableDateById('day')
-      .invoke('attr', 'aria-invalid')
-      .should('eq', 'false')
-
-    pageObjects
-      .radioGroup()
-      .invoke('attr', 'aria-invalid')
-      .should('eq', 'false')
+    cy.validateAriaInvalid('fieldsetById', 'false', relationshipId)
+    cy.validateAriaInvalid('benefitMemorableDateById', 'false', 'day')
+    cy.validateAriaInvalid('radioGroup', 'false')
   })
 
   it('Should have state of "true" when a required field has no value', () => {
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
-
-    pageObjects
-      .fieldsetById(relationshipId)
-      .invoke('attr', 'aria-invalid')
-      .should('eq', 'true')
-
-    pageObjects
-      .benefitMemorableDateById('day')
-      .invoke('attr', 'aria-invalid')
-      .should('eq', 'true')
+    cy.clickButton(EN_LOCALE_DATA.buttonGroup[1].value)
+    cy.validateAriaInvalid('fieldsetById', 'true', relationshipId)
+    cy.validateAriaInvalid('benefitMemorableDateById', 'true', 'day')
   })
 
   it('Should have state of "false" when previous was true but error has been resolved', () => {
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
+    cy.clickButton(EN_LOCALE_DATA.buttonGroup[1].value)
 
-    pageObjects
-      .fieldsetById(relationshipId)
-      .invoke('attr', 'aria-invalid')
-      .should('eq', 'true')
-    pageObjects
-      .benefitMemorableDateById('day')
-      .invoke('attr', 'aria-invalid')
-      .should('eq', 'true')
+    cy.validateAriaInvalid('fieldsetById', 'true', relationshipId)
+    cy.validateAriaInvalid('benefitMemorableDateById', 'true', 'day')
 
-    utils.dataInputs({ dob, relation, status })
+    cy.fillDetailsAboutTheApplicant({
+      dateOfBirth,
+      relationship,
+      maritalStatus,
+    })
 
-    pageObjects
-      .fieldsetById(relationshipId)
-      .invoke('attr', 'aria-invalid')
-      .should('eq', 'false')
-
-    pageObjects
-      .benefitMemorableDateById('day')
-      .invoke('attr', 'aria-invalid')
-      .should('eq', 'false')
+    cy.validateAriaInvalid('fieldsetById', 'false', relationshipId)
+    cy.validateAriaInvalid('benefitMemorableDateById', 'false', 'day')
   })
 })

--- a/benefit-finder/cypress/e2e/storybook/axe-a11y.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/axe-a11y.cy.js
@@ -26,12 +26,12 @@ function terminalLog(violations) {
   cy.task('table', violationData)
 }
 
-const dob = utils.getDateByOffset(-(18 * 365.2425 - 1))
-const dod = utils.getDateByOffset(-(18 * 365.2425 - 1))
-const relation =
+const dateOfBirth = utils.getDateByOffset(-(18 * 365.2425 - 1))
+const dateOfDeath = utils.getDateByOffset(-30)
+const relationship =
   EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0].section
     .fieldsets[1].fieldset.inputs[0].inputCriteria.values[1].value
-const status =
+const maritalStatus =
   EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0].section
     .fieldsets[2].fieldset.inputs[0].inputCriteria.values[1].value
 
@@ -60,57 +60,62 @@ describe(`Validate code passes axe scanning`, () => {
 
   // go to first step
   it('Has no detectable a11y violations on step 1', () => {
-    pageObjects.button().contains(EN_LOCALE_DATA.intro.button).click()
+    cy.clickButton(EN_LOCALE_DATA.intro.button)
     runA11y()
   })
 
   // create an error
   it('Has no detectable a11y violations on error state', () => {
-    pageObjects.button().contains(EN_LOCALE_DATA.intro.button).click()
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
+    cy.clickButton(EN_LOCALE_DATA.intro.button)
+    cy.clickButton(EN_LOCALE_DATA.buttonGroup[1].value) // Click 'Next' without filling details about the applicant
     runA11y()
   })
 
   it('Has no detectable a11y violations on error state resolved', () => {
-    pageObjects.button().contains(EN_LOCALE_DATA.intro.button).click()
-    utils.dataInputs({ dob, relation, status })
+    cy.clickButton(EN_LOCALE_DATA.intro.button)
+    cy.fillDetailsAboutTheApplicant({
+      dateOfBirth,
+      relationship,
+      maritalStatus,
+    })
     runA11y()
   })
 
   it('Has no detectable a11y violations on step 2', () => {
-    pageObjects.button().contains(EN_LOCALE_DATA.intro.button).click()
-    utils.dataInputs({ dob, relation, status })
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
+    cy.navigateToAboutTheDeceasedPage({
+      dateOfBirth,
+      relationship,
+      maritalStatus,
+    })
+    cy.clickButton(EN_LOCALE_DATA.buttonGroup[1].value)
     runA11y()
   })
 
   it('Has no detectable a11y violations on modal launch', () => {
-    pageObjects.button().contains(EN_LOCALE_DATA.intro.button).click()
-    utils.dataInputs({ dob, relation, status })
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
-    utils.dataInputs({ dod })
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
+    cy.navigateToModal({
+      dateOfBirth,
+      relationship,
+      maritalStatus,
+      dateOfDeath,
+    })
     cy.injectAxe()
     cy.checkA11y('#benefit-finder-modal')
   })
 
   it('Has no detectable a11y violations on modal close review selections', () => {
-    pageObjects.button().contains(EN_LOCALE_DATA.intro.button).click()
-    utils.dataInputs({ dob, relation, status })
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
-    utils.dataInputs({ dod })
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
-    pageObjects
-      .button()
-      .contains(EN_LOCALE_DATA.reviewSelectionModal.buttonGroup[0].value)
-      .click()
+    cy.navigateToModal({
+      dateOfBirth,
+      relationship,
+      maritalStatus,
+      dateOfDeath,
+    })
+    cy.clickButton(EN_LOCALE_DATA.reviewSelectionModal.buttonGroup[0].value) // Close modal
     runA11y()
   })
 
   it('Has no detectable a11y violations on see benefits', () => {
     const selectedData = BENEFITS_ELIBILITY_DATA.scenario_1_covid.en.param
     const scenario = utils.encodeURIFromObject(selectedData)
-    delete selectedData.shared // We don't want to include the "shared" param
 
     cy.visit(`${utils.storybookUri}${scenario}`)
     cy.injectAxe() // we inject axe again because of the reload -> visit
@@ -132,19 +137,17 @@ describe(`Validate code passes axe scanning`, () => {
   })
 
   it('Has no detectable a11y violations on see benefits you did not qualify for', () => {
-    pageObjects.button().contains(EN_LOCALE_DATA.intro.button).click()
-    utils.dataInputs({ dob, relation, status })
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
-    utils.dataInputs({ dod })
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
-    pageObjects
-      .button()
-      .contains(EN_LOCALE_DATA.reviewSelectionModal.buttonGroup[1].value)
-      .click()
-    pageObjects
-      .button()
-      .contains(EN_LOCALE_DATA.resultsView.zeroBenefits.cta)
-      .click()
+    cy.navigateToBenefitResultsPage({
+      dateOfBirth,
+      relationship,
+      maritalStatus,
+      dateOfDeath,
+    })
+    pageObjects.accordionHeading().should('exist')
+
+    cy.clickButton(EN_LOCALE_DATA.resultsView.zeroBenefits.cta)
+    pageObjects.accordionHeading().should('exist')
+
     // get a node list of all accordions
     // get the heading of the first in the list
     cy.get(`[data-testid="bf-usa-accordion"]`).then(accordionItems => {

--- a/benefit-finder/cypress/e2e/storybook/error-message-display.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/error-message-display.cy.js
@@ -6,11 +6,11 @@ import * as EN_DOLO_MOCK_DATA from '../../../../benefit-finder/src/shared/api/mo
 import * as EN_LOCALE_DATA from '../../../../benefit-finder/src/shared/locales/en/en.json'
 import 'cypress-plugin-tab'
 
-const dob = utils.getDateByOffset(-(18 * 365.2425 - 1))
-const relation =
+const dateOfBirth = utils.getDateByOffset(-(18 * 365.2425 - 1))
+const relationship =
   EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0].section
     .fieldsets[1].fieldset.inputs[0].inputCriteria.values[1].value
-const status =
+const maritalStatus =
   EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0].section
     .fieldsets[2].fieldset.inputs[0].inputCriteria.values[1].value
 
@@ -30,7 +30,7 @@ const alertDisplayState = {
 
 beforeEach(() => {
   cy.visit(utils.storybookUri)
-  pageObjects.button().contains(EN_LOCALE_DATA.intro.button).click()
+  cy.clickButton(EN_LOCALE_DATA.intro.button)
 })
 
 describe('Validate correct error messages display for negative scenarios', () => {
@@ -48,7 +48,7 @@ describe('Validate correct error messages display for negative scenarios', () =>
 
   it('Should display error message when user attempts to move forward without completing required field', () => {
     // expect when a user selects continue the focus is made on the error notice at the top
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
+    cy.clickButton(EN_LOCALE_DATA.buttonGroup[1].value)
     cy.focused().should('have.class', 'usa-alert--error')
 
     // expect the error notice to be visible if errors are present
@@ -63,7 +63,7 @@ describe('Validate correct error messages display for negative scenarios', () =>
   })
 
   it('Should have a list of errors', () => {
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
+    cy.clickButton(EN_LOCALE_DATA.buttonGroup[1].value)
     cy.focused().should('have.class', 'usa-alert--error').tab()
     pageObjects.bfAlertList().then(() => {
       pageObjects.bfAlertListItem().should('have.length.above', 0)
@@ -71,7 +71,7 @@ describe('Validate correct error messages display for negative scenarios', () =>
   })
 
   it('Should have a list of errors that link to the invalid fields', () => {
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
+    cy.clickButton(EN_LOCALE_DATA.buttonGroup[1].value)
     cy.focused().should('have.class', 'usa-alert--error').tab()
     // expect the first tabbable item in the list to be the first error link
     pageObjects.bfAlertList().then(() => {
@@ -88,7 +88,7 @@ describe('Validate correct error messages display for negative scenarios', () =>
 
   it('Should allow tabbing to the next error message', () => {
     // expect when a user tabs from the focus error they can tab any other error notices in the form
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
+    cy.clickButton(EN_LOCALE_DATA.buttonGroup[1].value)
     cy.focused().should('have.class', 'usa-alert--error').tab()
     pageObjects.bfAlertList().then(() => {
       pageObjects.bfAlertListItem().then(errors => {
@@ -101,7 +101,7 @@ describe('Validate correct error messages display for negative scenarios', () =>
 
   it('Should hide the error message if field error is resolved', () => {
     // expect when a user tabs from the focus error they can tab any other error notices in the form
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
+    cy.clickButton(EN_LOCALE_DATA.buttonGroup[1].value)
     cy.focused().should('have.class', 'usa-alert--error').tab()
     pageObjects.bfAlertList().then(() => {
       pageObjects.bfAlertListItem().then(errors => {
@@ -109,8 +109,11 @@ describe('Validate correct error messages display for negative scenarios', () =>
         errorsArray.forEach(() => cy.focused().tab())
         cy.focused().should('have.class', 'usa-input--error')
         // expect when a user has resolved all errors the top level error notices is not visible or accessible
-        utils.dataInputs({ dob, relation, status })
-
+        cy.fillDetailsAboutTheApplicant({
+          dateOfBirth,
+          relationship,
+          maritalStatus,
+        })
         // expect the error notice to be hidden if errors are present
         pageObjects.benefitSectionAlert().should('have.class', 'display-none')
       })
@@ -119,7 +122,7 @@ describe('Validate correct error messages display for negative scenarios', () =>
 
   it('Should not allow moving forward by clicking continue when error banner is present', () => {
     // expect when a user tabs from the focus error they can tab any other error notices in the form
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
+    cy.clickButton(EN_LOCALE_DATA.buttonGroup[1].value)
     cy.focused().should('have.class', 'usa-alert--error').tab()
     pageObjects.bfAlertList().then(() => {
       pageObjects.bfAlertListItem().then(errors => {
@@ -136,16 +139,15 @@ describe('Validate correct error messages display for negative scenarios', () =>
         }
 
         // expect when a user has resolved all errors the top level error notices is not visible or accessible
-        utils.dataInputs({ relation })
+        cy.fillDetailsAboutTheApplicant({
+          relationship,
+        })
 
         // expect the error notice to be visible if errors are present
         pageObjects
           .benefitSectionAlert()
           .should('not.have.class', 'display-none')
-        pageObjects
-          .button()
-          .contains(EN_LOCALE_DATA.buttonGroup[1].value)
-          .click()
+        cy.clickButton(EN_LOCALE_DATA.buttonGroup[1].value)
         cy.focused().should('have.class', 'usa-alert--error')
         // expect date DOM structure alert to be accessible
         for (const attr in alertDisplayState) {
@@ -159,7 +161,7 @@ describe('Validate correct error messages display for negative scenarios', () =>
   })
 
   it('Should include error count in alert', () => {
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
+    cy.clickButton(EN_LOCALE_DATA.buttonGroup[1].value)
     pageObjects
       .bfAlertList()
       .find('li')
@@ -171,7 +173,7 @@ describe('Validate correct error messages display for negative scenarios', () =>
   })
 
   it('Should include list of error links and clicking on a link navigates to a specific field', () => {
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
+    cy.clickButton(EN_LOCALE_DATA.buttonGroup[1].value)
 
     pageObjects
       .bfAlertList()
@@ -195,7 +197,7 @@ describe('Validate correct error messages display for negative scenarios', () =>
   })
 
   it('Should validate error label content overrides', () => {
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
+    cy.clickButton(EN_LOCALE_DATA.buttonGroup[1].value)
 
     const relationErrorMessageOvveride =
       EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0]

--- a/benefit-finder/cypress/e2e/storybook/modal.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/modal.cy.js
@@ -1,30 +1,30 @@
-/// <reference types="cypress" />
+/// <reference types="Cypress" />
 
 import * as utils from '../../support/utils.js'
 import * as EN_LOCALE_DATA from '../../../src/shared/locales/en/en.json'
 import * as EN_DOLO_MOCK_DATA from '../../../src/shared/api/mock-data/current.json'
 import { pageObjects } from '../../support/pageObjects.js'
 
-const dob = utils.getDateByOffset(-(18 * 365.2425 - 1))
-const dod = utils.getDateByOffset(-30)
+const dateOfBirth = utils.getDateByOffset(-(18 * 365.2425 - 1))
+const dateOfDeath = utils.getDateByOffset(-30)
 
-const relation =
+const relationship =
   EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0].section
     .fieldsets[1].fieldset.inputs[0].inputCriteria.values[1].value
-const status =
+const maritalStatus =
   EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0].section
     .fieldsets[2].fieldset.inputs[0].inputCriteria.values[1].value
 
 describe('Validate scrolling when modal is open', () => {
   it('Should disable body from scrolling when model is open', () => {
     cy.visit(utils.storybookUri)
-    pageObjects.button().contains(EN_LOCALE_DATA.intro.button).click()
-    utils.dataInputs({ dob, relation, status })
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
-    utils.dataInputs({ dod })
 
-    // open modal
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
+    cy.navigateToModal({
+      dateOfBirth,
+      relationship,
+      maritalStatus,
+      dateOfDeath,
+    })
 
     // close when clicked off modal
     cy.get('.ReactModal__Overlay').click('topRight')
@@ -35,7 +35,7 @@ describe('Validate scrolling when modal is open', () => {
     ) // these types run successfully but do not trigger movement in the window
 
     // open modal
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
+    cy.clickButton(EN_LOCALE_DATA.buttonGroup[1].value)
 
     // confirm type works for modal
     cy.get('#benefit-finder-modal').type(
@@ -77,7 +77,7 @@ describe('Validate scrolling when modal is open', () => {
       expect($w.scrollY).to.be.greaterThan(scrollYPosition)
     })
 
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
+    cy.clickButton(EN_LOCALE_DATA.buttonGroup[1].value)
 
     // confirm we are back at the top
     cy.window().then($w => {

--- a/benefit-finder/cypress/e2e/storybook/modal.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/modal.cy.js
@@ -3,7 +3,6 @@
 import * as utils from '../../support/utils.js'
 import * as EN_LOCALE_DATA from '../../../src/shared/locales/en/en.json'
 import * as EN_DOLO_MOCK_DATA from '../../../src/shared/api/mock-data/current.json'
-import { pageObjects } from '../../support/pageObjects.js'
 
 const dateOfBirth = utils.getDateByOffset(-(18 * 365.2425 - 1))
 const dateOfDeath = utils.getDateByOffset(-30)

--- a/benefit-finder/cypress/e2e/storybook/selected-criteria-eligibility-benefits.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/selected-criteria-eligibility-benefits.cy.js
@@ -1,6 +1,5 @@
 /// <reference types="Cypress" />
 
-import { pageObjects } from '../../support/pageObjects'
 import * as utils from '../../support/utils'
 import * as EN_DOLO_MOCK_DATA from '../../../../benefit-finder/src/shared/api/mock-data/current.json'
 import * as BENEFITS_ELIBILITY_DATA from '../../fixtures/benefits-eligibility.json'
@@ -8,16 +7,17 @@ import content from '../../../../benefit-finder/src/shared/api/mock-data/current
 import * as EN_LOCALE_DATA from '../../../../benefit-finder/src/shared/locales/en/en.json'
 const { data } = JSON.parse(content)
 
-const relationshipId =
-  EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0].section
-    .fieldsets[1].fieldset.inputs[0].inputCriteria.id
-const relationshipValue =
+// 18 years ago minus one day - applicant under 18 years old
+// 1 day = 365.2425 (accounts for leap year)
+const dateOfBirth = utils.getDateByOffset(-(18 * 365.2425 - 1))
+// Date of death - 30 days ago
+const dateOfDeath = utils.getDateByOffset(-30)
+
+const relationship =
   EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0].section
     .fieldsets[1].fieldset.inputs[0].inputCriteria.values[1].value
-const maritalStatusId =
-  EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0].section
-    .fieldsets[2].fieldset.inputs[0].inputCriteria.id
-const maritalStatusValue =
+
+const maritalStatus =
   EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0].section
     .fieldsets[2].fieldset.inputs[0].inputCriteria.values[1].value
 const citizenshipStatusId =
@@ -32,65 +32,27 @@ const publicSafetyOfficerId =
 
 describe('Validate correct eligibility benefits display based on selected criteria/options', () => {
   it('Should render Survivor Benefits for Child benefit accordion correctly based on selected cretiria options', () => {
-    // 18 years ago minus one day - applicant under 18 years old
-    // 1 day = 365.2425 (accounts for leap year)
-    const dateOfBirth = utils.getDateByOffset(-(18 * 365.2425 - 1))
-    cy.visit('/iframe.html?args=&id=app--primary&viewMode=story')
+    cy.visit(utils.storybookUri)
 
-    pageObjects.button().contains(EN_LOCALE_DATA.intro.button).click()
-    cy.enterDate(dateOfBirth.month, dateOfBirth.day, dateOfBirth.year)
-    pageObjects.fieldsetById(relationshipId).select(relationshipValue)
-    pageObjects.fieldsetById(maritalStatusId).select(maritalStatusValue)
+    cy.navigateToBenefitResultsPage({
+      dateOfBirth,
+      relationship,
+      maritalStatus,
+      optionalApplicantFields: {
+        [citizenshipStatusId]: 0, // Select "Yes" for citizenship
+      },
+      dateOfDeath,
+      optionalDeceasedFields: {
+        [paidIntoSocialSecurityId]: 0, // Select "Yes" for "Did deceased ever work and pay U.S. Social Security taxes?"
+        [publicSafetyOfficerId]: 0, // Select "Yes" for "Was the deceased a public safety officer who died in the line of duty"
+      },
+    })
 
-    pageObjects.fieldsetById(citizenshipStatusId).eq(0).click({ force: true })
+    const accordionTitle = EN_DOLO_MOCK_DATA.data.benefits[23].benefit.title
+    const eligibilityLabels =
+      EN_DOLO_MOCK_DATA.data.benefits[23].benefit.eligibility.map(e => e.label)
 
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
-
-    // Date of death - 30 days ago
-    const dateOfDeath = utils.getDateByOffset(-30)
-    cy.enterDate(dateOfDeath.month, dateOfDeath.day, dateOfDeath.year)
-
-    pageObjects
-      .fieldsetById(paidIntoSocialSecurityId)
-      .eq(0)
-      .click({ force: true })
-
-    pageObjects.fieldsetById(publicSafetyOfficerId).eq(0).click({ force: true })
-
-    pageObjects.button().contains(EN_LOCALE_DATA.buttonGroup[1].value).click()
-
-    pageObjects
-      .modalButtonGroup()
-      .contains(EN_LOCALE_DATA.reviewSelectionModal.buttonGroup[1].value)
-      .click()
-
-    pageObjects
-      .accordionByTitle(EN_DOLO_MOCK_DATA.data.benefits[23].benefit.title)
-      .click()
-      .parent()
-      .parent()
-      .parent()
-      .find('.bf-key-eligibility-criteria-list li')
-      .should(
-        'contain',
-        EN_DOLO_MOCK_DATA.data.benefits[23].benefit.eligibility[0].label
-      )
-      .and(
-        'contain',
-        EN_DOLO_MOCK_DATA.data.benefits[23].benefit.eligibility[1].label
-      )
-      .and(
-        'contain',
-        EN_DOLO_MOCK_DATA.data.benefits[23].benefit.eligibility[2].label
-      )
-      .and(
-        'contain',
-        EN_DOLO_MOCK_DATA.data.benefits[23].benefit.eligibility[3].label
-      )
-      .and(
-        'contain',
-        EN_DOLO_MOCK_DATA.data.benefits[23].benefit.eligibility[4].label
-      )
+    cy.validateAccordionContent(accordionTitle, eligibilityLabels)
   })
 
   it('qa scenario 1 Covid EN - Verify correct benefit results for query values that includes covid in search parameter of URL', () => {
@@ -103,55 +65,20 @@ describe('Validate correct eligibility benefits display based on selected criter
 
     cy.visit(`${utils.storybookUri}${scenario}`)
 
-    pageObjects
-      .accordionHeading()
-      .filter(':visible')
-      .should('have.length', enResults.eligible.length)
-      .and(
-        'contain',
-        EN_LOCALE_DATA.resultsView.benefitAccordion.eligibleStatusLabels[0]
-      )
-      .and('contain', enResults.eligible.eligible_benefits[0])
-      .and('contain', enResults.eligible.eligible_benefits[1])
-      .and('contain', enResults.eligible.eligible_benefits[2])
+    // Validate accordion headings
+    cy.validateAccordionHeadings(
+      enResults.eligible.length,
+      enResults.eligible.eligible_benefits,
+      EN_LOCALE_DATA.resultsView.benefitAccordion.eligibleStatusLabels[0]
+    )
 
-    pageObjects
-      .benefitResultsView()
-      .invoke('attr', 'data-testid')
-      .should('eq', 'bf-result-view')
-
-    pageObjects
-      .benefitResultsView()
-      .invoke('attr', 'data-test-results-view')
-      .should('eq', 'bf-eligible-view')
-
-    pageObjects
-      .benefitResultsView()
-      .invoke('attr', 'data-test-results-view-criteria-values')
-      .should('eq', `${selectDataLength}`)
-
-    pageObjects
-      .benefitResultsView()
-      .invoke('attr', 'data-test-results-view-benefits')
-      .should('eq', `${benefitsCount}`)
-
-    pageObjects
-      .benefitResultsView()
-      .invoke('attr', 'data-test-results-view-eligible')
-      .should('eq', `${enResults.eligible.length}`)
-
-    pageObjects
-      .benefitResultsView()
-      .invoke('attr', 'data-test-results-view-more-info')
-      .should('eq', `${enResults.moreInformationNeeded.length}`)
-
-    pageObjects
-      .benefitResultsView()
-      .invoke('attr', 'data-test-results-view-not-eligible')
-      .should(
-        'eq',
-        `${benefitsCount - enResults.eligible.length - enResults.moreInformationNeeded.length}`
-      )
+    // Validate results view attributes
+    cy.validateResultsViewAttributes(
+      selectDataLength,
+      benefitsCount,
+      enResults.eligible.length,
+      enResults.moreInformationNeeded.length
+    )
   })
 
   it('QA scenario 2 Veteran EN - Verify correct benefit results for query values that includes veteran in search parameter of URL', () => {
@@ -161,15 +88,12 @@ describe('Validate correct eligibility benefits display based on selected criter
 
     cy.visit(`${utils.storybookUri}${scenario}`)
 
-    pageObjects
-      .accordionHeading()
-      .filter(':visible')
-      .should('have.length', enResults.eligible.length)
-      .and(
-        'contain',
-        EN_LOCALE_DATA.resultsView.benefitAccordion.eligibleStatusLabels[0]
-      )
-      .and('contain', enResults.eligible.eligible_benefits[0])
+    // Validate accordion headings
+    cy.validateAccordionHeadings(
+      enResults.eligible.length,
+      enResults.eligible.eligible_benefits,
+      EN_LOCALE_DATA.resultsView.benefitAccordion.eligibleStatusLabels[0]
+    )
   })
 
   it('QA scenario 3 Coal Miner EN - Verify correct benefit results for query values that includes Coal Miner in search parameter of URL', () => {
@@ -179,23 +103,18 @@ describe('Validate correct eligibility benefits display based on selected criter
 
     cy.visit(`${utils.storybookUri}${scenario}`)
 
-    pageObjects
-      .accordionHeading()
-      .filter(':visible')
-      .should('have.length', enResults.eligible.length)
-      .and(
-        'contain',
-        EN_LOCALE_DATA.resultsView.benefitAccordion.eligibleStatusLabels[0]
-      )
-      .and('contain', enResults.eligible.eligible_benefits[0])
+    cy.validateAccordionHeadings(
+      enResults.eligible.length,
+      enResults.eligible.eligible_benefits,
+      EN_LOCALE_DATA.resultsView.benefitAccordion.eligibleStatusLabels[0]
+    )
   })
 
   it('Should display green check icons on eligible benefits', () => {
     const selectedData = BENEFITS_ELIBILITY_DATA.scenario_2_veteran.en.param
     const scenario = utils.encodeURIFromObject(selectedData)
     cy.visit(`${utils.storybookUri}${scenario}`)
-    pageObjects.expandAll().click()
-    pageObjects.iconGreenCheck().should('exist')
+    cy.validateGreenCheckIcons(selectedData)
   })
 
   it('Should display Zero benefit view when no benefit are eligible', () => {
@@ -204,17 +123,10 @@ describe('Validate correct eligibility benefits display based on selected criter
     const scenario = utils.encodeURIFromObject(selectedData)
     cy.visit(`${utils.storybookUri}${scenario}`)
 
-    pageObjects
-      .zeroBenefitsViewHeading()
-      .should('contain', EN_LOCALE_DATA.resultsView.zeroBenefits.heading)
-
-    pageObjects
-      .accordionHeading()
-      .filter(':visible')
-      .should('have.length', enResults.eligible.length)
-
-    pageObjects
-      .seeAllBenefitsButton()
-      .should('contain', EN_LOCALE_DATA.resultsView.zeroBenefits.cta)
+    cy.validateZeroBenefitsView(
+      enResults,
+      EN_LOCALE_DATA.resultsView.zeroBenefits.heading,
+      EN_LOCALE_DATA.resultsView.zeroBenefits.cta
+    )
   })
 })

--- a/benefit-finder/cypress/support/commands.js
+++ b/benefit-finder/cypress/support/commands.js
@@ -25,9 +25,250 @@
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
 import { pageObjects } from './pageObjects'
+import * as EN_DOLO_MOCK_DATA from '../../../benefit-finder/src/shared/api/mock-data/current.json'
+import * as EN_LOCALE_DATA from '../../../benefit-finder/src/shared/locales/en/en.json'
+
+const maritalStatusId =
+  EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0].section
+    .fieldsets[2].fieldset.inputs[0].inputCriteria.id
+const relationshipId =
+  EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0].section
+    .fieldsets[1].fieldset.inputs[0].inputCriteria.id
+const startFindingBenefitsButton = EN_LOCALE_DATA.intro.button
+const nextButtonGroup = EN_LOCALE_DATA.buttonGroup[1].value
+const getYourResultsButton =
+  EN_LOCALE_DATA.reviewSelectionModal.buttonGroup[1].value
 
 Cypress.Commands.add('enterDate', (month, day, year) => {
   pageObjects.benefitMemorableDateById('month').select(month)
   pageObjects.benefitMemorableDateById('day').type(day)
   pageObjects.benefitMemorableDateById('year').type(year)
 })
+
+Cypress.Commands.add('clickButton', buttonText => {
+  pageObjects.button().contains(buttonText).click()
+})
+
+Cypress.Commands.add('fillDetailsAboutTheApplicant', data => {
+  const { dateOfBirth, relationship, maritalStatus, optionalFields = {} } = data
+
+  // Fill mandatory fields if provided
+  if (dateOfBirth) {
+    cy.enterDate(dateOfBirth.month, dateOfBirth.day, dateOfBirth.year)
+  }
+
+  if (relationship) {
+    cy.selectDropdownValue(relationshipId, relationship)
+  }
+
+  if (maritalStatus) {
+    cy.selectDropdownValue(maritalStatusId, maritalStatus)
+  }
+
+  // Fill optional fields dynamically
+  Object.entries(optionalFields).forEach(([fieldId, optionIndex]) => {
+    cy.selectRadioByIdAndIndex(fieldId, optionIndex)
+  })
+})
+
+Cypress.Commands.add('fillDetailsAboutTheDeceased', data => {
+  const { dateOfDeath, optionalFields = {}, additionalFields = {} } = data
+
+  // Fill mandatory fields if provided
+  if (dateOfDeath) {
+    cy.enterDate(dateOfDeath.month, dateOfDeath.day, dateOfDeath.year)
+  }
+
+  // Fill optional "Yes/No" fields dynamically
+  Object.entries(optionalFields).forEach(([fieldId, optionIndex]) => {
+    cy.selectRadioByIdAndIndex(fieldId, optionIndex)
+  })
+
+  // Fill additional dropdown fields displayed on certain conditions
+  Object.entries(additionalFields).forEach(([fieldId, value]) => {
+    cy.selectDropdownValue(fieldId, value)
+  })
+})
+
+Cypress.Commands.add('navigateToAboutTheApplicantPage', () => {
+  cy.clickButton(startFindingBenefitsButton)
+  pageObjects.benefitMemorableDateById('month').should('exist')
+})
+
+Cypress.Commands.add(
+  'navigateToAboutTheDeceasedPage',
+  ({ dateOfBirth, relationship, maritalStatus, optionalFields = {} }) => {
+    cy.navigateToAboutTheApplicantPage()
+    cy.fillDetailsAboutTheApplicant({
+      dateOfBirth,
+      relationship,
+      maritalStatus,
+      optionalFields,
+    })
+    cy.clickButton(nextButtonGroup) // Navigate to the next step
+  }
+)
+
+Cypress.Commands.add(
+  'navigateToModal',
+  ({
+    dateOfBirth,
+    relationship,
+    maritalStatus,
+    optionalApplicantFields = {},
+    dateOfDeath,
+    optionalDeceasedFields = {},
+    additionalDeceasedFields = {},
+  }) => {
+    cy.navigateToAboutTheDeceasedPage({
+      dateOfBirth,
+      relationship,
+      maritalStatus,
+      optionalFields: optionalApplicantFields,
+    })
+    cy.fillDetailsAboutTheDeceased({
+      dateOfDeath,
+      optionalFields: optionalDeceasedFields,
+      additionalFields: additionalDeceasedFields,
+    })
+    cy.clickButton(nextButtonGroup) // Proceed to open modal
+    pageObjects
+      .button(EN_LOCALE_DATA.reviewSelectionModal.buttonGroup[0].value)
+      .should('exist')
+  }
+)
+
+Cypress.Commands.add(
+  'navigateToBenefitResultsPage',
+  ({
+    dateOfBirth,
+    relationship,
+    maritalStatus,
+    optionalApplicantFields = {},
+    dateOfDeath,
+    optionalDeceasedFields = {},
+    additionalDeceasedFields = {},
+  }) => {
+    cy.navigateToAboutTheDeceasedPage({
+      dateOfBirth,
+      relationship,
+      maritalStatus,
+      optionalFields: optionalApplicantFields,
+    })
+    cy.fillDetailsAboutTheDeceased({
+      dateOfDeath,
+      optionalFields: optionalDeceasedFields,
+      additionalFields: additionalDeceasedFields,
+    })
+    cy.clickButton(nextButtonGroup) // Open modal
+    cy.clickButton(getYourResultsButton)
+  }
+)
+
+Cypress.Commands.add('selectDropdownValue', (fieldId, value) => {
+  pageObjects.fieldsetById(fieldId).select(value)
+})
+
+Cypress.Commands.add('selectRadioByIdAndIndex', (fieldId, optionIndex = 0) => {
+  pageObjects.fieldsetById(fieldId).eq(optionIndex).click({ force: true })
+})
+
+Cypress.Commands.add('validateAccordionContent', (accordionTitle, labels) => {
+  pageObjects
+    .accordionByTitle(accordionTitle)
+    .click()
+    .parent()
+    .parent()
+    .parent()
+    .find('.bf-key-eligibility-criteria-list li')
+    .each(($li, index) => {
+      cy.wrap($li).should('contain', labels[index])
+    })
+})
+
+// Validate accordion headings
+Cypress.Commands.add(
+  'validateAccordionHeadings',
+  (visibleHeadingsLength, eligibleBenefits, eligibleLabel) => {
+    pageObjects
+      .accordionHeading()
+      .filter(':visible')
+      .should('have.length', visibleHeadingsLength)
+      .and('contain', eligibleLabel)
+    // Dynamically validate each eligible benefit
+    eligibleBenefits.forEach(benefit => {
+      pageObjects
+        .accordionHeading()
+        .filter(':visible')
+        .should('contain', benefit)
+    })
+  }
+)
+
+Cypress.Commands.add(
+  'validateAriaInvalid',
+  (methodName, expectedValue, ...args) => {
+    // Dynamically call the pageObjects method and retrieve the element
+    pageObjects[methodName](...args)
+      .invoke('attr', 'aria-invalid')
+      .should('eq', expectedValue)
+  }
+)
+
+// Validate benefit results view attributes
+Cypress.Commands.add(
+  'validateResultsViewAttributes',
+  (selectDataLength, benefitsCount, eligibleCount, moreInfoCount) => {
+    pageObjects
+      .benefitResultsView()
+      .should('exist') // Ensure the element exists
+      .then(resultsView => {
+        cy.wrap(resultsView)
+          .invoke('attr', 'data-testid')
+          .should('eq', 'bf-result-view')
+
+        cy.wrap(resultsView)
+          .invoke('attr', 'data-test-results-view')
+          .should('eq', 'bf-eligible-view')
+
+        cy.wrap(resultsView)
+          .invoke('attr', 'data-test-results-view-criteria-values')
+          .should('eq', `${selectDataLength}`)
+
+        cy.wrap(resultsView)
+          .invoke('attr', 'data-test-results-view-benefits')
+          .should('eq', `${benefitsCount}`)
+
+        cy.wrap(resultsView)
+          .invoke('attr', 'data-test-results-view-eligible')
+          .should('eq', `${eligibleCount}`)
+
+        cy.wrap(resultsView)
+          .invoke('attr', 'data-test-results-view-more-info')
+          .should('eq', `${moreInfoCount}`)
+
+        cy.wrap(resultsView)
+          .invoke('attr', 'data-test-results-view-not-eligible')
+          .should('eq', `${benefitsCount - eligibleCount - moreInfoCount}`)
+      })
+  }
+)
+
+Cypress.Commands.add('validateGreenCheckIcons', () => {
+  pageObjects.expandAll().click()
+  pageObjects.iconGreenCheck().should('exist')
+})
+
+Cypress.Commands.add(
+  'validateZeroBenefitsView',
+  (enResults, zeroBenefitsHeading, zeroBenefitsCTA) => {
+    pageObjects.zeroBenefitsViewHeading().should('contain', zeroBenefitsHeading)
+
+    pageObjects
+      .accordionHeading()
+      .filter(':visible')
+      .should('have.length', enResults.eligible.length)
+
+    pageObjects.seeAllBenefitsButton().should('contain', zeroBenefitsCTA)
+  }
+)

--- a/benefit-finder/cypress/support/utils.js
+++ b/benefit-finder/cypress/support/utils.js
@@ -1,6 +1,3 @@
-import { pageObjects } from '../support/pageObjects'
-import * as EN_DOLO_MOCK_DATA from '../../../benefit-finder/src/shared/api/mock-data/current.json'
-
 export function getDateByOffset(offset) {
   const date = new Date(Date.now())
   const n = Number(offset)
@@ -30,26 +27,3 @@ export const encodeURIFromObject = obj => {
 
 // can be used by all the test that are visiting in storymode
 export const storybookUri = `/iframe.html?args=&id=app--primary&viewMode=story&`
-
-export const dataInputs = ({ dob, relation, status, dod }) => {
-  // input date of birth
-  dob && cy.enterDate(dob.month, dob.day, dob.year)
-  // input relation to deceased
-  relation &&
-    pageObjects
-      .fieldsetById(
-        EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0]
-          .section.fieldsets[1].fieldset.inputs[0].inputCriteria.id
-      )
-      .select(relation)
-  // input marital status
-  status &&
-    pageObjects
-      .fieldsetById(
-        EN_DOLO_MOCK_DATA.data.lifeEventForm.sectionsEligibilityCriteria[0]
-          .section.fieldsets[2].fieldset.inputs[0].inputCriteria.id
-      )
-      .select(status)
-  // input date of death
-  dod && cy.enterDate(dod.month, dod.day, dod.year)
-}


### PR DESCRIPTION
 Enhance Cypress Tests for Readability, Maintainability, and Dynamism

## PR Summary
This PR introduces enhancements to existing Cypress test automation by improving readability, maintainability, and flexibility. Key changes include the addition of reusable custom commands, better handling of optional fields, and streamlined navigation across test scenarios.

**1. New Commands for Modularity and Reusability**
- fillDetailsAboutTheApplicant: Dynamically fills both mandatory and optional fields for the "About the Applicant" page.
- fillDetailsAboutTheDeceased: Handles mandatory and optional fields, including dropdowns displayed conditionally.
- clickButton: Simplified button-clicking by text.
- navigateToAboutTheDeceasedPage: Groups steps to fill applicant details and navigate to the "About the Deceased" page.
- navigateToModal: Groups steps to navigate from the applicant page to the modal launch step.
- navigateToBenefitResultsPage: Combines navigation, applicant/deceased details filling, and modal interaction into one reusable command.

**2.  Improved Field Handling**
- Optional fields for both the applicant and deceased are dynamically handled via the optionalFields parameter in the respective commands.
- Ensures only fields supplied are filled, reducing unnecessary logic.

**3. Refactoring Existing Tests**
- Consolidated repetitive steps into newly created commands for better abstraction.
- Updated existing test flows like accessibility checks and results validation to use the new commands.

**4. Enhanced Readability**
- Simplified test case logic by abstracting complex flows into commands.
- Improved naming conventions for better understanding


<!--- Include a summary of the change, relevant motivation, and context. -->

## Related Github Issue

- Fixes #1598 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ]  `cd benefit finder`
- [ ] `npm run dev:storybook`
- [ ]  `cy:run:e2e` and verify all test pass
<!--- If there are steps for user testing list them here -->
