### PR TITLE
2014 design qa tweaks

### DIFF
--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
@@ -166,7 +166,10 @@ exports[`loads intro 1`] = `
                            with each agency.
                         </p>
                         <p>
-                          We do not share, save, or submit your information.
+                          <strong>
+                            We do not share, save, or submit
+                          </strong>
+                           your information.
                         </p>
                       </div>
                     </div>

--- a/benefit-finder/src/Routes/Intro/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/Routes/Intro/__tests__/__snapshots__/index.spec.jsx.snap
@@ -151,7 +151,10 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                        with each agency.
                     </p>
                     <p>
-                      We do not share, save, or submit your information.
+                      <strong>
+                        We do not share, save, or submit
+                      </strong>
+                       your information.
                     </p>
                   </div>
                 </div>

--- a/benefit-finder/src/Routes/Intro/_index.scss
+++ b/benefit-finder/src/Routes/Intro/_index.scss
@@ -12,7 +12,7 @@
   .bf-cta-wrapper {
     display: flex;
     justify-content: center;
-    margin: rem(20px) 0 rem(56px);
+    margin: rem(20px) 0 rem(24px);
 
     @media (width >= $desktop) {
       margin: rem(32px) rem(32px) rem(64px);
@@ -32,7 +32,7 @@
       margin-left: rem(16px);
     }
 
-    .bf-intro-process-notices-heading  {
+    .bf-intro-process-notices-heading {
       width: 100;
       margin-bottom: rem(30px);
     }
@@ -59,14 +59,14 @@
     .bf-usa-process-list {
       margin-left: 0;
       margin-right: 0;
-      padding-top:rem(8px);
+      padding-top: rem(8px);
 
       .bf-usa-process-list__heading {
         font-size: rem(16px);
 
-          @media (width >= $desktop) {
-           font-size: rem(21px);
-          }
+        @media (width >= $desktop) {
+          font-size: rem(21px);
+        }
       }
     }
   }

--- a/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.jsx.snap
@@ -43,7 +43,10 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
                with each agency.
             </p>
             <p>
-              We do not share, save, or submit your information.
+              <strong>
+                We do not share, save, or submit
+              </strong>
+               your information.
             </p>
           </div>
         </div>

--- a/benefit-finder/src/shared/locales/en/en.json
+++ b/benefit-finder/src/shared/locales/en/en.json
@@ -20,7 +20,7 @@
       "iconAlt": "Important",
       "list": [
         {
-          "notice": "<div><p><strong>This is not an application. You will need to apply for benefits</strong> with each agency.</p><p>We do not share, save, or submit your information.</p></div>"
+          "notice": "<div><p><strong>This is not an application. You will need to apply for benefits</strong> with each agency.</p><p><strong>We do not share, save, or submit</strong> your information.</p></div>"
         }
       ]
     },

--- a/benefit-finder/src/shared/locales/es/es.json
+++ b/benefit-finder/src/shared/locales/es/es.json
@@ -20,7 +20,7 @@
       "iconAlt": "Importante",
       "list": [
         {
-          "notice": "<div><p><strong>Esto no es una aplicación. Necesita presentar una solicitud</strong> con cada agencia.</p><p>No guardamos ni compartimos sus respuestas con ninguna agencia.</p></div>"
+          "notice": "<div><p><strong>Esto no es una aplicación. Necesita presentar una solicitud</strong> con cada agencia.</p><p><strong>No guardamos ni compartimos sus respuestas</strong> con ninguna agencia.</p></div>"
         }
       ]
     },


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

## Related Github Issue

- Fixes #2014 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] navigate to `/<life-event`

<!--- If there are steps for user testing list them here -->
### Related Issue(s)

Bolding of text "We do not share, save, or submit" 

Previous: 
![image](https://github.com/user-attachments/assets/c84c6edc-ccd0-4a51-a855-9d48b32f14a5)

Expected: 
![image](https://github.com/user-attachments/assets/5391ec2e-0755-4b62-a361-73d83a92c504)


Extra space between the CTA and footer section. This space should calculate out to ~56px

Previous:
![image](https://github.com/user-attachments/assets/6f39a149-566d-4282-9665-6dd86cd84fc1)

Expected:
![image](https://github.com/user-attachments/assets/e4d4343e-fa21-4477-b542-17689fc43667)

