### PR TITLE
2015 design qa tweaks

### DIFF
--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
@@ -166,7 +166,10 @@ exports[`loads intro 1`] = `
                            with each agency.
                         </p>
                         <p>
-                          We do not share, save, or submit your information.
+                          <strong>
+                            We do not share, save, or submit
+                          </strong>
+                           your information.
                         </p>
                       </div>
                     </div>

--- a/benefit-finder/src/Routes/Intro/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/Routes/Intro/__tests__/__snapshots__/index.spec.jsx.snap
@@ -151,7 +151,10 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                        with each agency.
                     </p>
                     <p>
-                      We do not share, save, or submit your information.
+                      <strong>
+                        We do not share, save, or submit
+                      </strong>
+                       your information.
                     </p>
                   </div>
                 </div>

--- a/benefit-finder/src/Routes/Intro/_index.scss
+++ b/benefit-finder/src/Routes/Intro/_index.scss
@@ -12,7 +12,7 @@
   .bf-cta-wrapper {
     display: flex;
     justify-content: center;
-    margin: rem(20px) 0 rem(56px);
+    margin: rem(20px) 0 rem(24px);
 
     @media (width >= $desktop) {
       margin: rem(32px) rem(32px) rem(64px);
@@ -32,7 +32,7 @@
       margin-left: rem(16px);
     }
 
-    .bf-intro-process-notices-heading  {
+    .bf-intro-process-notices-heading {
       width: 100;
       margin-bottom: rem(30px);
     }
@@ -59,14 +59,14 @@
     .bf-usa-process-list {
       margin-left: 0;
       margin-right: 0;
-      padding-top:rem(8px);
+      padding-top: rem(8px);
 
       .bf-usa-process-list__heading {
         font-size: rem(16px);
 
-          @media (width >= $desktop) {
-           font-size: rem(21px);
-          }
+        @media (width >= $desktop) {
+          font-size: rem(21px);
+        }
       }
     }
   }

--- a/benefit-finder/src/Routes/LifeEventSection/_index.scss
+++ b/benefit-finder/src/Routes/LifeEventSection/_index.scss
@@ -11,7 +11,7 @@
 
   .bf-grid-container.grid-container {
     max-width: $form-container-max-width;
-    padding: 0 rem(36px);
+    padding: 0 rem(20px);
 
     @media (width >= calc($form-container-max-width + rem(24px))) {
       padding-left: 0;

--- a/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.jsx.snap
@@ -43,7 +43,10 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
                with each agency.
             </p>
             <p>
-              We do not share, save, or submit your information.
+              <strong>
+                We do not share, save, or submit
+              </strong>
+               your information.
             </p>
           </div>
         </div>

--- a/benefit-finder/src/shared/locales/en/en.json
+++ b/benefit-finder/src/shared/locales/en/en.json
@@ -20,7 +20,7 @@
       "iconAlt": "Important",
       "list": [
         {
-          "notice": "<div><p><strong>This is not an application. You will need to apply for benefits</strong> with each agency.</p><p>We do not share, save, or submit your information.</p></div>"
+          "notice": "<div><p><strong>This is not an application. You will need to apply for benefits</strong> with each agency.</p><p><strong>We do not share, save, or submit</strong> your information.</p></div>"
         }
       ]
     },

--- a/benefit-finder/src/shared/locales/es/es.json
+++ b/benefit-finder/src/shared/locales/es/es.json
@@ -20,7 +20,7 @@
       "iconAlt": "Importante",
       "list": [
         {
-          "notice": "<div><p><strong>Esto no es una aplicación. Necesita presentar una solicitud</strong> con cada agencia.</p><p>No guardamos ni compartimos sus respuestas con ninguna agencia.</p></div>"
+          "notice": "<div><p><strong>Esto no es una aplicación. Necesita presentar una solicitud</strong> con cada agencia.</p><p><strong>No guardamos ni compartimos sus respuestas</strong> con ninguna agencia.</p></div>"
         }
       ]
     },


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

## Related Github Issue

- Fixes #2015 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] navigate to `/life-event/verify-selections`

<!--- If there are steps for user testing list them here -->
On confirmation page, the container width should match the size as the previous screens, the container width is 335px for the 375px screen view.

Previous:
![image](https://github.com/user-attachments/assets/893d157a-a509-4b08-96f9-f8dc292d8daa)

Expected:
![image](https://github.com/user-attachments/assets/211a464a-7725-44b6-a2c6-9a9c59102941)
