### PR TITLE
2016 design qa tweaks

### DIFF
--- a/benefit-finder/cypress.config.js
+++ b/benefit-finder/cypress.config.js
@@ -6,6 +6,7 @@ module.exports = defineConfig({
     runMode: 2,
     openMode: 0,
   },
+  viewportWidth: 1050,
   e2e: {
     baseUrl: 'http://localhost:6006',
     excludeSpecPattern: 'cypress/e2e/usagov-public-site/*.cy.js',

--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.jsx.snap
@@ -166,7 +166,10 @@ exports[`loads intro 1`] = `
                            with each agency.
                         </p>
                         <p>
-                          We do not share, save, or submit your information.
+                          <strong>
+                            We do not share, save, or submit
+                          </strong>
+                           your information.
                         </p>
                       </div>
                     </div>

--- a/benefit-finder/src/Routes/Intro/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/Routes/Intro/__tests__/__snapshots__/index.spec.jsx.snap
@@ -151,7 +151,10 @@ exports[`Intro > renders a match to the previous snapshot 1`] = `
                        with each agency.
                     </p>
                     <p>
-                      We do not share, save, or submit your information.
+                      <strong>
+                        We do not share, save, or submit
+                      </strong>
+                       your information.
                     </p>
                   </div>
                 </div>

--- a/benefit-finder/src/Routes/Intro/_index.scss
+++ b/benefit-finder/src/Routes/Intro/_index.scss
@@ -12,7 +12,7 @@
   .bf-cta-wrapper {
     display: flex;
     justify-content: center;
-    margin: rem(20px) 0 rem(56px);
+    margin: rem(20px) 0 rem(24px);
 
     @media (width >= $desktop) {
       margin: rem(32px) rem(32px) rem(64px);
@@ -32,7 +32,7 @@
       margin-left: rem(16px);
     }
 
-    .bf-intro-process-notices-heading  {
+    .bf-intro-process-notices-heading {
       width: 100;
       margin-bottom: rem(30px);
     }
@@ -59,14 +59,14 @@
     .bf-usa-process-list {
       margin-left: 0;
       margin-right: 0;
-      padding-top:rem(8px);
+      padding-top: rem(8px);
 
       .bf-usa-process-list__heading {
         font-size: rem(16px);
 
-          @media (width >= $desktop) {
-           font-size: rem(21px);
-          }
+        @media (width >= $desktop) {
+          font-size: rem(21px);
+        }
       }
     }
   }

--- a/benefit-finder/src/Routes/LifeEventSection/_index.scss
+++ b/benefit-finder/src/Routes/LifeEventSection/_index.scss
@@ -11,7 +11,7 @@
 
   .bf-grid-container.grid-container {
     max-width: $form-container-max-width;
-    padding: 0 rem(36px);
+    padding: 0 rem(20px);
 
     @media (width >= calc($form-container-max-width + rem(24px))) {
       padding-left: 0;

--- a/benefit-finder/src/Routes/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/Routes/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
@@ -6318,7 +6318,8 @@ exports[`loads view 1`] = `
                 <a
                   class="bf-share-trigger bf-usa-link usa-link"
                   data-testid="bf-share-trigger"
-                  href=""
+                  role="link"
+                  tabindex="0"
                 >
                   Share link
                 </a>
@@ -6327,7 +6328,8 @@ exports[`loads view 1`] = `
                  
                 <a
                   class="bf-email-trigger bf-usa-link usa-link"
-                  href=""
+                  role="link"
+                  tabindex="0"
                 >
                   Email results
                 </a>
@@ -12662,7 +12664,8 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 <a
                   class="bf-share-trigger bf-usa-link usa-link"
                   data-testid="bf-share-trigger"
-                  href=""
+                  role="link"
+                  tabindex="0"
                 >
                   Share link
                 </a>
@@ -12671,7 +12674,8 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                  
                 <a
                   class="bf-email-trigger bf-usa-link usa-link"
-                  href=""
+                  role="link"
+                  tabindex="0"
                 >
                   Email results
                 </a>

--- a/benefit-finder/src/Routes/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/Routes/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
@@ -6215,7 +6215,7 @@ exports[`loads view 1`] = `
                 data-testid="bf-result-view-unmet-button"
                 type="button"
               >
-                Explore benefits you did not qualify for
+                See benefits you didn't qualify for
               </button>
             </div>
           </div>
@@ -12554,7 +12554,7 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
                 data-testid="bf-result-view-unmet-button"
                 type="button"
               >
-                Explore benefits you did not qualify for
+                See benefits you didn't qualify for
               </button>
             </div>
           </div>

--- a/benefit-finder/src/Routes/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/Routes/ResultsView/__tests__/__snapshots__/index.spec.jsx.snap
@@ -6303,7 +6303,12 @@ exports[`loads view 1`] = `
               Share results
             </h3>
             <p>
-              Copy or email these results. Your answers will be visible. Only share with those you trust.
+              Copy or email these results. Your answers will be visible. 
+              <strong>
+                Only share with those you trust
+                <!--&lt;strong-->
+                .
+              </strong>
             </p>
             <ul
               class="bf-result-view-share-results-button-group"
@@ -12642,7 +12647,12 @@ exports[`scenario 1 loads in view with the correct amount of likely eligible ite
               Share results
             </h3>
             <p>
-              Copy or email these results. Your answers will be visible. Only share with those you trust.
+              Copy or email these results. Your answers will be visible. 
+              <strong>
+                Only share with those you trust
+                <!--&lt;strong-->
+                .
+              </strong>
             </p>
             <ul
               class="bf-result-view-share-results-button-group"

--- a/benefit-finder/src/Routes/ResultsView/components/Results/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/Routes/ResultsView/components/Results/__tests__/__snapshots__/index.spec.jsx.snap
@@ -111,7 +111,12 @@ exports[`Results > renders a match to the previous snapshot 1`] = `
           Share results
         </h3>
         <p>
-          Copy or email these results. Your answers will be visible. Only share with those you trust.
+          Copy or email these results. Your answers will be visible. 
+          <strong>
+            Only share with those you trust
+            <!--&lt;strong-->
+            .
+          </strong>
         </p>
         <ul
           class="bf-result-view-share-results-button-group"

--- a/benefit-finder/src/Routes/ResultsView/components/Results/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/Routes/ResultsView/components/Results/__tests__/__snapshots__/index.spec.jsx.snap
@@ -126,7 +126,8 @@ exports[`Results > renders a match to the previous snapshot 1`] = `
             <a
               class="bf-share-trigger bf-usa-link usa-link"
               data-testid="bf-share-trigger"
-              href=""
+              role="link"
+              tabindex="0"
             >
               Share link
             </a>
@@ -135,7 +136,8 @@ exports[`Results > renders a match to the previous snapshot 1`] = `
              
             <a
               class="bf-email-trigger bf-usa-link usa-link"
-              href=""
+              role="link"
+              tabindex="0"
             >
               Email results
             </a>

--- a/benefit-finder/src/Routes/ResultsView/components/Results/_index.scss
+++ b/benefit-finder/src/Routes/ResultsView/components/Results/_index.scss
@@ -20,6 +20,20 @@
   .bf-result-view-relevant-benefits-heading,
   .bf-result-view-share-results-heading {
     @include h3;
+
+    margin-left: rem(15px);
+
+    @media (width > $desktop) {
+      margin-left: 0;
+    }
+  }
+
+  p {
+    margin-left: rem(15px);
+
+    @media (width > $desktop) {
+      margin-left: 0;
+    }
   }
 
   .bf-expand-all {
@@ -35,6 +49,10 @@
   .bf-result-view-cta-wrapper {
     display: flex;
     justify-content: center;
+  }
+
+  @media (width > $desktop) {
+    margin-left: 0;
   }
 }
 

--- a/benefit-finder/src/Routes/ResultsView/components/Results/_index.scss
+++ b/benefit-finder/src/Routes/ResultsView/components/Results/_index.scss
@@ -28,7 +28,7 @@
     }
   }
 
-  p {
+  > p {
     margin-left: rem(15px);
 
     @media (width > $desktop) {

--- a/benefit-finder/src/Routes/ResultsView/components/Results/_index.scss
+++ b/benefit-finder/src/Routes/ResultsView/components/Results/_index.scss
@@ -4,9 +4,9 @@
 @use '@styles/functions' as *;
 
 .bf-result-view {
- .bf-grid-container.grid-container {
-  padding: rem(20px);
- }
+  .bf-grid-container.grid-container {
+    padding: rem(20px);
+  }
 }
 
 .bf-result-view-benefits,
@@ -20,6 +20,10 @@
   .bf-result-view-relevant-benefits-heading,
   .bf-result-view-share-results-heading {
     @include h3;
+  }
+
+  .bf-expand-all {
+    display: none;
   }
 }
 
@@ -47,5 +51,9 @@
 @media (width >= $desktop) {
   .bf-result-view-details {
     padding: rem(24px) 5.4rem;
+  }
+
+  .bf-result-view-benefits .bf-expand-all {
+    display: block;
   }
 }

--- a/benefit-finder/src/Routes/ResultsView/components/Results/index.jsx
+++ b/benefit-finder/src/Routes/ResultsView/components/Results/index.jsx
@@ -110,7 +110,7 @@ const Results = ({
         >
           {shareResults?.heading}
         </Heading>
-        <p>{shareResults?.description}</p>
+        <p dangerouslySetInnerHTML={createMarkup(shareResults?.description)} />
         <ul className="bf-result-view-share-results-button-group">
           <li>
             {' '}

--- a/benefit-finder/src/Routes/ResultsView/components/blocks/EligibleBenefitsHeading/_index.scss
+++ b/benefit-finder/src/Routes/ResultsView/components/blocks/EligibleBenefitsHeading/_index.scss
@@ -1,9 +1,23 @@
 @use '@styles/mixins' as *;
+@use '@styles/functions' as *;
+@use '@styles/breakpoints' as *;
 
 .bf-eligible-view-heading {
   @include h2;
+
+  margin-left: rem(15px);
+
+  @media (width > $desktop) {
+    margin-left: 0;
+  }
 }
 
 .bf-eligible-view-description {
   @include h6;
+
+  margin-left: rem(15px);
+
+  @media (width > $desktop) {
+    margin-left: 0;
+  }
 }

--- a/benefit-finder/src/shared/components/Alert/_index.scss
+++ b/benefit-finder/src/shared/components/Alert/_index.scss
@@ -3,7 +3,6 @@
 @use '@styles/breakpoints' as *;
 @use '@styles/functions' as *;
 
-
 h2.bf-usa-alert__heading {
   @include h5($font-family: 'sans');
 
@@ -31,7 +30,7 @@ h2.bf-usa-alert__heading {
     padding-left: rem(32px);
   }
 
-  ul {
+  .bf-usa-alert ul {
     padding-left: 0;
   }
 

--- a/benefit-finder/src/shared/components/EmailTrigger/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/EmailTrigger/__tests__/__snapshots__/index.spec.jsx.snap
@@ -4,7 +4,8 @@ exports[`Email > renders a match to the previous snapshot 1`] = `
 <DocumentFragment>
   <a
     class="bf-email-trigger bf-usa-link usa-link"
-    href=""
+    role="link"
+    tabindex="0"
   >
     Email
   </a>

--- a/benefit-finder/src/shared/components/EmailTrigger/index.jsx
+++ b/benefit-finder/src/shared/components/EmailTrigger/index.jsx
@@ -38,9 +38,11 @@ const EmailTrigger = ({ ui, data }) => {
 
   return (
     <a
-      href=""
+      tabIndex={0}
+      role="link"
       className="bf-email-trigger bf-usa-link usa-link"
       onClick={e => handleClick(e)}
+      onKeyDown={e => handleClick(e)}
     >
       {ui?.emailTrigger || 'Email'}
     </a>

--- a/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.jsx.snap
@@ -43,7 +43,10 @@ exports[`NoticesList > renders a match to the previous snapshot 1`] = `
                with each agency.
             </p>
             <p>
-              We do not share, save, or submit your information.
+              <strong>
+                We do not share, save, or submit
+              </strong>
+               your information.
             </p>
           </div>
         </div>

--- a/benefit-finder/src/shared/components/ShareTrigger/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/benefit-finder/src/shared/components/ShareTrigger/__tests__/__snapshots__/index.spec.jsx.snap
@@ -5,7 +5,8 @@ exports[`Share > renders a match to the previous snapshot 1`] = `
   <a
     class="bf-share-trigger bf-usa-link usa-link"
     data-testid="bf-share-trigger"
-    href=""
+    role="link"
+    tabindex="0"
   >
     Share
   </a>

--- a/benefit-finder/src/shared/components/ShareTrigger/index.jsx
+++ b/benefit-finder/src/shared/components/ShareTrigger/index.jsx
@@ -40,9 +40,11 @@ const ShareTrigger = ({ ui, data }) => {
 
   return (
     <a
-      href=""
+      tabIndex={0}
+      role="link"
       className="bf-share-trigger bf-usa-link usa-link"
       onClick={e => handleClick(e)}
+      onKeyDown={e => handleClick(e)}
       data-testid="bf-share-trigger"
     >
       {ui?.shareTrigger || 'Share'}

--- a/benefit-finder/src/shared/components/Summary/_index.scss
+++ b/benefit-finder/src/shared/components/Summary/_index.scss
@@ -1,12 +1,17 @@
 @use '@styles/mixins' as *;
 @use '@styles/colors' as color;
 @use '@styles/functions' as *;
+@use '@styles/breakpoints' as *;
 
 .bf-usa-summary-box {
   @include h5($font-family: 'sans');
 
-  margin-bottom: rem(16px);
+  margin: rem(16px) rem(15px);
   border-color: color.$teal;
+
+  @media (width > $desktop) {
+    margin: rem(16px) 0;
+  }
 
   .bf-usa-list {
     li {

--- a/benefit-finder/src/shared/locales/en/en.json
+++ b/benefit-finder/src/shared/locales/en/en.json
@@ -164,7 +164,7 @@
       "shareLinkContent": "Copied",
       "emailTrigger": "Email results",
       "emailSubject": "Results from USAGov’s benefit finder",
-      "description": "Copy or email these results. Your answers will be visible. Only share with those you trust."
+      "description": "Copy or email these results. Your answers will be visible. <strong>Only share with those you trust</<strong>."
     }
   },
   "shareResults": {

--- a/benefit-finder/src/shared/locales/en/en.json
+++ b/benefit-finder/src/shared/locales/en/en.json
@@ -153,7 +153,7 @@
     "notEligibleResults": {
       "heading": "Benefits you did not qualify for",
       "description": "<div>Based on your answers you are not eligible for these benefits. <strong>You may become eligible if you enter additional information or your situation changes.</strong></div>",
-      "cta": "Explore benefits you did not qualify for"
+      "cta": "See benefits you didn't qualify for"
     },
     "resultsRelativeBenefits": {
       "heading": "More benefits"

--- a/benefit-finder/src/shared/locales/en/en.json
+++ b/benefit-finder/src/shared/locales/en/en.json
@@ -20,7 +20,7 @@
       "iconAlt": "Important",
       "list": [
         {
-          "notice": "<div><p><strong>This is not an application. You will need to apply for benefits</strong> with each agency.</p><p>We do not share, save, or submit your information.</p></div>"
+          "notice": "<div><p><strong>This is not an application. You will need to apply for benefits</strong> with each agency.</p><p><strong>We do not share, save, or submit</strong> your information.</p></div>"
         }
       ]
     },

--- a/benefit-finder/src/shared/locales/es/es.json
+++ b/benefit-finder/src/shared/locales/es/es.json
@@ -20,7 +20,7 @@
       "iconAlt": "Importante",
       "list": [
         {
-          "notice": "<div><p><strong>Esto no es una aplicación. Necesita presentar una solicitud</strong> con cada agencia.</p><p>No guardamos ni compartimos sus respuestas con ninguna agencia.</p></div>"
+          "notice": "<div><p><strong>Esto no es una aplicación. Necesita presentar una solicitud</strong> con cada agencia.</p><p><strong>No guardamos ni compartimos sus respuestas</strong> con ninguna agencia.</p></div>"
         }
       ]
     },

--- a/benefit-finder/src/shared/locales/es/es.json
+++ b/benefit-finder/src/shared/locales/es/es.json
@@ -165,7 +165,7 @@
       "emailTrigger": "Envie sus resultados por correo electrónico",
       "shareLinkContent": "Copiado",
       "emailSubject": "Resultados del buscador de beneficios de USAGov",
-      "description": "Copie o envíe sus resultados. Sus respuestas serán visibles. Solo comparta con quienes usted confíe."
+      "description": "Copie o envíe sus resultados. Sus respuestas serán visibles. <strong>Solo comparta con quienes usted confíe</strong>."
     }
   },
   "shareResults": {


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

## Related Github Issue

- Fixes #2016 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] navigate to results view

<!--- If there are steps for user testing list them here -->
Summary box looks slightly wider and bullet list is too close to the edge of the container. The bullet list should be aligned:

Live site
![image](https://github.com/user-attachments/assets/482761a4-b731-4106-8113-79386ec5849f)
Expected:
![image](https://github.com/user-attachments/assets/e2abb8e7-854a-4150-b0cd-259a365b5a07)


The "expand all" button should be removed from the mobile design

previous:
![image](https://github.com/user-attachments/assets/39125b6a-5585-40d5-aed4-8d518177ac9d)
Expected:
![image](https://github.com/user-attachments/assets/790315e2-d7b2-4568-b8c2-fdeda5816825)

Change "Explore benefits you did not qualify for" to "See benefits you didn't qualify for"

previous:
![image](https://github.com/user-attachments/assets/a2b81f66-b3d2-46ba-8b69-3eaa27a49738)
Expected:
![image](https://github.com/user-attachments/assets/058df3c2-dc3f-4903-9aac-19ce908b9050)


"Only share with those you trust" should be bolded

previous:
![image](https://github.com/user-attachments/assets/358ebf08-c249-424b-aac7-55afad6aff5c)
expected:
![image](https://github.com/user-attachments/assets/5b39c20c-c825-47a5-82a0-5add406b5263)

Links note alignment is off, bullets overflow to edge of the container, and color of links look like it has been clicked purple, should be blue)

previous:
![image](https://github.com/user-attachments/assets/0720ec27-e506-45a7-b845-6cb1473a09de)

Expected:
![image](https://github.com/user-attachments/assets/60cff6f6-8291-4d42-8c2a-1147413f443a)
