### PR TITLE
Refactoring DataLayer Validation Scenarios for Modularity

### DIFF
--- a/benefit-finder/cypress/support/utils.js
+++ b/benefit-finder/cypress/support/utils.js
@@ -1,3 +1,12 @@
+import { pageObjects } from './pageObjects'
+import * as EN_LOCALE_DATA from '../../../benefit-finder/src/shared/locales/en/en.json'
+
+export function filterDataLayerByEvent(eventName) {
+  return cy.window().then(window => {
+    return window.dataLayer.filter(item => item.event === eventName)
+  })
+}
+
 export function getDateByOffset(offset) {
   const date = new Date(Date.now())
   const n = Number(offset)
@@ -25,5 +34,106 @@ export const encodeURIFromObject = obj => {
     .join('&')
 }
 
+export const removeID = event => {
+  if (Array.isArray(event)) {
+    event.forEach(e => delete e['gtm.uniqueEventId'])
+  } else {
+    delete event['gtm.uniqueEventId']
+  }
+}
+
 // can be used by all the test that are visiting in story mode
 export const storybookUri = `/iframe.html?args=&id=app--primary&viewMode=story&`
+
+export function toggleExpandAllAccordions(
+  openAllAccordionsEvent,
+  accordionTitle,
+  accordionOpenEvent
+) {
+  pageObjects
+    .expandAll()
+    .click()
+    .then(() => {
+      validateEventInDataLayer(
+        openAllAccordionsEvent,
+        'Open all accordions event'
+      )
+
+      pageObjects
+        .expandAll()
+        .click()
+        .then(() => {
+          const updatedEvent = {
+            ...openAllAccordionsEvent,
+            bfData: {
+              ...openAllAccordionsEvent.bfData,
+              accordionsOpen: !openAllAccordionsEvent.bfData.accordionsOpen,
+            },
+          }
+
+          validateEventInDataLayer(updatedEvent, 'Toggle open/close accordions')
+
+          pageObjects.accordionByTitle(accordionTitle).click()
+          validateEventInDataLayer(accordionOpenEvent, 'Accordion open event')
+        })
+    })
+}
+
+export function validateDataLayerExists() {
+  cy.window().then(window => {
+    assert.isDefined(window.dataLayer, 'window.dataLayer is defined')
+  })
+}
+
+export function validateEventData(expectedEvent, index = -1) {
+  cy.window().then(window => {
+    const event = { ...window.dataLayer.at(index) }
+    removeID(event) // Normalize the event
+    expect(event).to.deep.equal(expectedEvent)
+  })
+}
+
+export function validateEventExists(eventName) {
+  cy.window().then(window => {
+    cy.wrap(window.dataLayer).should(dataLayer => {
+      const event = dataLayer.find(e => e.event === eventName)
+      assert.isDefined(event, `${eventName} is present`)
+    })
+  })
+}
+
+export function validateEventInDataLayer(expectedEvent, validationDescription) {
+  cy.window().then(window => {
+    const matchingEvents = window.dataLayer.filter(
+      event => event?.event === expectedEvent.event
+    )
+
+    assert.isNotEmpty(
+      matchingEvents,
+      `${validationDescription} event is triggered`
+    )
+
+    const normalizedEvent = { ...matchingEvents[matchingEvents.length - 1] }
+    removeID(normalizedEvent)
+
+    expect(normalizedEvent).to.deep.equal(expectedEvent)
+  })
+}
+
+export function validateFormStep(expectedEvent, index = -1) {
+  cy.window().then(window => {
+    const event = { ...window.dataLayer.at(index) }
+    removeID(event)
+
+    expect(event).to.deep.equal(expectedEvent)
+  })
+}
+
+export function validateGTMIsLoaded() {
+  cy.window().then(window => {
+    assert.isDefined(
+      window.dataLayer.find(event => event.event === 'gtm.js'),
+      'GTM is loaded'
+    )
+  })
+}


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
This PR focuses on refactoring Cypress test scenarios related to dataLayer validation to enhance modularity, maintainability, and readability. The changes encapsulate repetitive logic into reusable utility functions and streamline the structure of the test cases, ensuring consistency and reducing redundancy.
## Related Github Issue

- Fixes #1982

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] pull changes locally
- [ ]  `cd benefit finder`
- [ ] `npm run dev:storybook`
- [ ]  `cy:run:e2e` and verify dataLayer and all other test pass

<!--- If there are steps for user testing list them here -->
