### PR TITLE
2065 fix skip to h1 tab order

### DIFF
--- a/benefit-finder/src/Routes/Intro/index.jsx
+++ b/benefit-finder/src/Routes/Intro/index.jsx
@@ -2,7 +2,7 @@ import { useEffect, useContext } from 'react'
 import { useNavigate, useLocation } from 'react-router'
 import { RouteContext } from '@/App'
 import { dataLayerUtils, politeTitles } from '@utils'
-import { useResetElement } from '@hooks'
+import { useScrollToAnchor } from '@hooks'
 import PropTypes from 'prop-types'
 import {
   Button,
@@ -26,14 +26,13 @@ const Intro = ({ content, ui, hasQueryParams }) => {
   const { timeEstimate, title, summary } = content
   const { heading, timeIndicator, steps, notices, button } = ui
   const { intro } = dataLayerUtils.dataLayerStructure
-  const resetElement = useResetElement()
   const ROUTES = useContext(RouteContext)
   const navigate = useNavigate()
   const location = useLocation()
+  useScrollToAnchor(location)
 
   const handleStep = () => {
     navigate(`/${ROUTES.indexPath}/${ROUTES.formPaths[0]}`)
-    resetElement.current.focus()
   }
 
   // if we have query parameters direct user to the results page

--- a/benefit-finder/src/Routes/LifeEventSection/index.jsx
+++ b/benefit-finder/src/Routes/LifeEventSection/index.jsx
@@ -11,7 +11,7 @@ import {
   handleSurvey,
   politeTitles,
 } from '@utils'
-import { useHandleUnload, useResetElement } from '@hooks'
+import { useHandleUnload, useResetElement, useScrollToAnchor } from '@hooks'
 import * as apiCalls from '@api/apiCalls'
 import {
   Alert,
@@ -55,6 +55,8 @@ const LifeEventSection = ({ data, handleData, ui }) => {
   const locale = apiCalls.GET.Language()
 
   let location = useLocation() // ignore prefer-const
+
+  useScrollToAnchor(location)
 
   /**
    * Finds the index of the current form step in the data array.
@@ -265,14 +267,14 @@ const LifeEventSection = ({ data, handleData, ui }) => {
       },
     })
     politeTitles(location.pathname, locale)
-    resetElement.current?.focus()
-    window.scrollTo(0, 0)
+    !location.hash && resetElement.current?.focus()
+    !location.hash && window.scrollTo(0, 0)
   }, [location])
 
   useEffect(() => {
     errorHandling.getRequiredFieldsets(document, setRequiredFieldsets)
-    resetElement.current?.focus()
-    window.scrollTo(0, 0)
+    !location.hash && resetElement.current?.focus()
+    !location.hash && window.scrollTo(0, 0)
   }, [formStep])
 
   useEffect(() => {

--- a/benefit-finder/src/Routes/ResultsView/index.jsx
+++ b/benefit-finder/src/Routes/ResultsView/index.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useContext } from 'react'
 import { useNavigate, useLocation } from 'react-router'
 import { RouteContext } from '@/App'
-import { useResetElement } from '@hooks'
+import { useResetElement, useScrollToAnchor } from '@hooks'
 import * as apiCalls from '@api/apiCalls'
 import PropTypes from 'prop-types'
 import { Results } from './components/index'
@@ -33,6 +33,7 @@ const ResultsView = ({
   const location = useLocation()
   const ROUTES = useContext(RouteContext)
   const locale = apiCalls.GET.Language()
+  useScrollToAnchor(location)
 
   /**
    * a hook that handles our open state of the accordions in our group
@@ -42,10 +43,6 @@ const ResultsView = ({
   const [isExpandAll, setExpandAll] = useState(false)
 
   const resetElement = useResetElement()
-
-  useEffect(() => {
-    resetElement.current?.focus()
-  }, [resetElement])
 
   // some data-test values
   // how many questions were values provided for
@@ -68,8 +65,8 @@ const ResultsView = ({
 
   // handle location change
   useEffect(() => {
-    resetElement.current?.focus()
-    window.scrollTo(0, 0)
+    !location.hash && resetElement.current?.focus()
+    !location.hash && window.scrollTo(0, 0)
     setExpandAll(false)
   }, [location])
 

--- a/benefit-finder/src/Routes/VerifySelectionsView/index.jsx
+++ b/benefit-finder/src/Routes/VerifySelectionsView/index.jsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation } from 'react-router'
 import PropTypes from 'prop-types'
 import { RouteContext } from '@/App'
 import { parseDate, dataLayerUtils, handleSurvey, politeTitles } from '@utils'
-import { useResetElement } from '@hooks'
+import { useResetElement, useScrollToAnchor } from '@hooks'
 import * as apiCalls from '@api/apiCalls'
 import { Heading, Button } from '@components'
 
@@ -29,6 +29,7 @@ const VerifySelectionsView = ({ ui, data }) => {
   const location = useLocation()
   const ROUTES = useContext(RouteContext)
   const resetElement = useResetElement()
+  useScrollToAnchor(location)
 
   /**
    * a functional component that renders markup when no value has been given
@@ -105,8 +106,8 @@ const VerifySelectionsView = ({ ui, data }) => {
   }
 
   useEffect(() => {
-    resetElement.current?.focus()
-    window.scrollTo(0, 0)
+    !location.hash && resetElement.current?.focus()
+    !location.hash && window.scrollTo(0, 0)
   }, [location])
 
   // handle dataLayer

--- a/benefit-finder/src/shared/hooks/index.js
+++ b/benefit-finder/src/shared/hooks/index.js
@@ -1,5 +1,11 @@
 import useHandleClassName from './useHandleClassName'
 import useHandleUnload from './useHandleUnload'
 import useResetElement from './useResetElement'
+import useScrollToAnchor from './useScrollToAnchor'
 
-export { useHandleClassName, useHandleUnload, useResetElement }
+export {
+  useHandleClassName,
+  useHandleUnload,
+  useResetElement,
+  useScrollToAnchor,
+}

--- a/benefit-finder/src/shared/hooks/useScrollToAnchor/index.jsx
+++ b/benefit-finder/src/shared/hooks/useScrollToAnchor/index.jsx
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react'
+
+function ScrollToAnchor({ location, offset }) {
+  const lastHash = useRef('')
+
+  // listen to location change using useEffect with location as dependency
+  useEffect(() => {
+    if (location?.hash) {
+      lastHash.current = location.hash.slice(1) // safe hash for further use after navigation
+    }
+
+    if (lastHash.current && document.getElementById(lastHash.current)) {
+      setTimeout(() => {
+        document.getElementById(lastHash.current)?.scrollIntoView({
+          block: 'start',
+          inline: 'nearest',
+          top: offset || 0,
+        })
+        lastHash.current = ''
+      }, 100)
+    }
+  }, [location])
+
+  return null
+}
+
+export default ScrollToAnchor


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->

## Related Github Issue

- Fixes #2065 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->

Test reset focus, `skip-to-h1` working
- [ ] navigate to `/death`
- [ ] tab into `skip to main` element
- [ ] CLICK enter
- [ ] Expect h1 to be focused
- [ ] CLICK "Next"
- [ ] tab into `skip to main` element
- [ ] CLICK enter
- [ ] Expect h1 to be focused

Test hash anchor in view

- [ ] navigate to `/death`
- [ ] navigate to first step
- [ ] CLICK "Next"
- [ ] CLICK first error
- [ ] expect hash in url to update
- [ ] expect hash to focus



<!--- If there are steps for user testing list them here -->
