### PR TITLE
PXBF-2080-remove-criteria-type-boolean

### DIFF
--- a/usagov_benefit_finder/configuration/field.storage.node.field_b_type.yml
+++ b/usagov_benefit_finder/configuration/field.storage.node.field_b_type.yml
@@ -1,0 +1,30 @@
+uuid: 254f0bcd-acf6-430c-8b21-b212b78dab4d
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_b_type
+field_name: field_b_type
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: Date
+      label: Date
+    -
+      value: Select
+      label: Select
+    -
+      value: Radio
+      label: Radio
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## PR Summary

This work removes type "boolean" of content type "criteria".

## Related Github Issue

- Fixes #2080

## Detailed Testing steps

To test in local development site or in dev site.

- [ ] Pull changes locally
- [ ] Make local development site up at `http://localhost`
- [ ] Navigate to `admin/content?combine=&type=bears_criteria&status=All&langcode=All`
- [ ] Go to criteria "Applicate date of birth" edit page
- [ ] Verify no Boolean in the list of Type field

<img width="500" src="https://github.com/user-attachments/assets/ff6ee609-9949-4394-b078-733720900236">


