### PR TITLE
PXBF-2086-fix-nested-date-criteria: check dates for child dependencies

### DIFF
--- a/benefit-finder/src/Routes/LifeEventSection/index.jsx
+++ b/benefit-finder/src/Routes/LifeEventSection/index.jsx
@@ -509,10 +509,66 @@ const LifeEventSection = ({ data, handleData, ui }) => {
                      * @return {boolean} returns true or false
                      */
 
+                    const checkDateDependency = value => {
+                      const dateObj = { month: 0, day: 0, year: 0 }
+                      const dateValues = value?.value
+
+                      if (dateValues === undefined) {
+                        return true
+                      }
+
+                      const dateKeys = Object.keys(dateObj)
+                      const valuesKeys = Object.keys(dateValues)
+
+                      // check to ensure all keys and values for date obj are present
+                      if (dateKeys.length !== valuesKeys.length) {
+                        return true
+                      } else {
+                        for (const key of dateKeys) {
+                          const value = dateValues[key]
+
+                          if (value === undefined || value < 0) {
+                            return true
+                          }
+
+                          if (
+                            dateValues.year !== undefined &&
+                            dateValues.year.length < 4
+                          ) {
+                            return true
+                          }
+                        }
+
+                        return !apiCalls.UTILS.DateEligibility({
+                          selectedValue: selectedParentValue.value,
+                          conditional:
+                            item.fieldset.inputs[0].inputCriteria
+                              .childDependencyOption,
+                        })
+                      }
+                    }
+
+                    const checkFieldDependencies = value => {
+                      return (
+                        value?.value !==
+                        item.fieldset.inputs[0].inputCriteria
+                          .childDependencyOption
+                      )
+                    }
+
                     const hidden =
-                      selectedParentValue?.value !==
-                      item.fieldset.inputs[0].inputCriteria
-                        .childDependencyOption
+                      item.fieldset.inputs[0].inputCriteria.type === 'Date'
+                        ? checkDateDependency(selectedParentValue)
+                        : checkFieldDependencies(selectedParentValue)
+                    // const hidden = checkDateDependency(selectedParentValue)
+                    // const hidden = checkFieldDependencies(selectedParentValue)
+
+                    // const hidden =
+                    //   selectedParentValue?.value !==
+                    //   item.fieldset.inputs[0].inputCriteria
+                    //     .childDependencyOption
+
+                    // console.log('hidden', hidden)
 
                     return hidden
                   }


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
adds functionality to include childDependency checking on Date fieldsets

## Related Github Issue

- Fixes #2086 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] point proxy to dev
- [ ] navigate to first step
- [ ] confirm child fieldsets are _not_ visible
- [ ] input date: >=18years
- [ ] confirm child fieldsets are visible
- [ ] adjust date: <18years
- [ ] confirm child fieldsets are _not_ visible
- [ ] ensure you can complete form
- [ ] ensure you can validate error alerts
- [ ] ensure expected criteria still validates criteria correctly

<!--- If there are steps for user testing list them here -->

expected:

https://github.com/user-attachments/assets/779eabf6-e529-4209-839a-cff69842926b


