### PR TITLE
PXBF-2088-life-event-form-error-message

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
@@ -385,6 +385,7 @@ class LifeEventController extends ControllerBase {
       "legend" => $criteria->get('field_b_legend')->value ?? "",
       "required" => $criteria->get('field_b_required')->value ? TRUE : FALSE,
       "hint" => $criteria->get('field_b_hint')->value ?? "",
+      "errorMessage" => $criteria->get('field_b_error_message')->value ?? "",
     ];
 
     // Build inputCriteria.


### PR DESCRIPTION
## PR Summary

This work adds error message in life event form.

## Related Github Issue

- Fixes #2088

## Detailed Testing steps

To test in local development site or in dev site.

- [ ] Pull changes locally
- [ ] Make local development site up at http://localhost
- [ ] Navigate to `admin/content?combine=&type=bears_life_event_form&status=All&langcode=All`
- [ ] Go to life event form "Benefit finder: disability" edit page
- [ ] Go to criteria "Applicant date of birth"
- [ ] Input "ERROR MESSAGE for applicant date of birth" in Error Message field
- [ ] Save as published
- [ ] Navigate to `benefit-finder/disability`
- [ ] Click `Next` to "About the applicant" page
- [ ] Click `Next`
- [ ] Verify the error message having the value in Error Message field

<img width=600 src="https://github.com/user-attachments/assets/566e299e-178f-4f5f-881f-71bcc9da556f">


