### PR TITLE
PXBF-1904-polite-a11y-page-titles: update a11y title content

### DIFF
--- a/benefit-finder/src/shared/utils/a11yTitles/index.js
+++ b/benefit-finder/src/shared/utils/a11yTitles/index.js
@@ -8,7 +8,7 @@ const a11yTitles = (location, locale) => {
   const title = pathValue.replace('-', ' ')
 
   // create language specific titles
-  const enTitle = `Entering Benefit Finder: ${title.toLowerCase()} | USAGov`
+  const enTitle = `Benefit Finder: ${title.toLowerCase()} | USAGov`
   const esTitle = `Buscador de beneficios: ${title.toLowerCase()} | USAGov`
   const defaultTitle = `${title} | USAGov`
 


### PR DESCRIPTION
## PR Summary

<!--- Include a summary of the change, relevant motivation, and context. -->
updates content in a11yTitles

## Related Github Issue

- Fixes #1904 

## Detailed Testing steps

<!--- If there are steps for local setup list them here -->
- [ ] ensure test are passing
- [ ] ensure that "Entering..." is not announced with a11y page titles
- [ ] ensure that "Entering..." is not announced with html page title update
