### PR TITLE
USAGOV-2378: Investigate failing benefit-finder test-firefox

### DIFF
--- a/benefit-finder/cypress/e2e/storybook/dataLayer.cy.js
+++ b/benefit-finder/cypress/e2e/storybook/dataLayer.cy.js
@@ -647,10 +647,18 @@ describe('Calls to Google Analytics Object', function () {
     })
 
     cy.clickButton('Review your selections').then(() => {
-      utils.validateEventInDataLayer(
-        dataLayerValueVerifySelections,
-        'Verify Selections'
-      )
+      cy.wait(500)
+      cy.window().should(win => {
+        const event = win.dataLayer?.find(
+          e => e.event === 'bf_page_change' &&
+               e.bfData?.pageView === 'bf-verify-selections'
+        )
+
+        const cleaned = { ...event }
+        removeID(cleaned)
+
+        expect(cleaned).to.deep.equal(dataLayerValueVerifySelections)
+      })
     })
 
     // Validate zero results view (eligible benefits)
@@ -702,10 +710,18 @@ describe('Calls to Google Analytics Object', function () {
     })
 
     cy.clickButton('Review your selections').then(() => {
-      utils.validateEventInDataLayer(
-        dataLayerValueVerifySelections,
-        'Verify Selections'
-      )
+      cy.wait(500)
+      cy.window().should(win => {
+        const event = win.dataLayer?.find(
+          e => e.event === 'bf_page_change' &&
+               e.bfData?.pageView === 'bf-verify-selections'
+        )
+
+        const cleaned = { ...event }
+        removeID(cleaned)
+
+        expect(cleaned).to.deep.equal(dataLayerValueVerifySelections)
+      })
     })
 
     // Validate zero results view (eligible benefits)
@@ -752,13 +768,19 @@ describe('Calls to Google Analytics Object', function () {
           )
 
           // Clean the data layer by removing unique IDs or any other unnecessary properties
-          const cleanedDataLayer = filteredDataLayer.map(event => {
-            removeID(event) // Assuming `removeID` is defined to clean unique IDs
-            return event
+          const cleanedExpected = dataLayerValues.map(event => {
+            const copy = { ...event }
+            removeID(copy)
+            return copy
           })
 
-          // Assert that the cleaned data layer matches the expected data
-          expect(cleanedDataLayer).to.deep.equal(dataLayerValues)
+          const cleanedActual = filteredDataLayer.map(event => {
+            const copy = { ...event }
+            removeID(copy)
+            return copy
+          })
+
+          expect(cleanedActual).to.deep.equal(cleanedExpected)
         })
       })
   })

--- a/benefit-finder/cypress/support/utils.js
+++ b/benefit-finder/cypress/support/utils.js
@@ -113,9 +113,12 @@ export function validateEventInDataLayer(expectedEvent, validationDescription) {
     )
 
     const normalizedEvent = { ...matchingEvents[matchingEvents.length - 1] }
-    removeID(normalizedEvent)
+    const normalizedExpected = { ...expectedEvent }
 
-    expect(normalizedEvent).to.deep.equal(expectedEvent)
+    removeID(normalizedEvent)
+    removeID(normalizedExpected)
+
+    expect(normalizedEvent).to.deep.equal(normalizedExpected)
   })
 }
 


### PR DESCRIPTION
One of the tests are consistently failing in FIreFox, and in this browser only. I suspect this is due to a race condition as this does not fail on my local when I run it.
So in this PR, I am implementing a static wait for the failing test (to allow the page to load), and also implementing a retry loop (up to 3 retries).

Resolution for JIra ticket:
[- Fixes #(issue)](https://cm-jira.usa.gov/browse/USAGOV-2378)

Dev notes:
* I ran `dataLayer.cy.js` locally in Firefox (v138) and all 13 tests passed
* In CI (GitHub Actions, tests-firefox job), 1 of the 13 tests fails consistently
* Perhaps this appears to be an environment-specific or timing-related issue, not a real break in Firefox functionality? 🤔
* CI may render the page more slowly, so the expected event (like bf_page_change) hasn’t yet appeared in window.dataLayer when the assertion runs

